### PR TITLE
Add cloudcube add-on

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,7 @@
     "repository": "https://github.com/cloudnativedaysjp/dreamkast/",
     "addons": [
       "cleardb:ignite",
-      "heroku-redis:hobby-dev"
+      "heroku-redis:hobby-dev",
+      "cloudcube:free"
     ]
   }


### PR DESCRIPTION
#86 の実装。
Review appsでfree版をProvisioningするように。freeは5MBしか使えないので、productionでは有料版にする。

この変更により、 `CLOUDCUBE_ACCESS_KEY_ID` `CLOUDCUBE_SECRET_ACCESS_KEY` の環境変数からcredentialをとれるので、コード側でそれを読むようにすればOK