### PR TITLE
単純にdrop tableするだけだと、db:migrate VERSION=0でリバーとするときにエラーになる

### DIFF
--- a/db/migrate/20200710134030_add_avatar_data_to_speaker.rb
+++ b/db/migrate/20200710134030_add_avatar_data_to_speaker.rb
@@ -1,7 +1,27 @@
 class AddAvatarDataToSpeaker < ActiveRecord::Migration[6.0]
   def change
     add_column :speakers, :avatar_data, :text
-    drop_table :active_storage_attachments
-    drop_table :active_storage_blobs
+    drop_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+    drop_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
   end
 end
+#


### PR DESCRIPTION
元のテーブルと同じ構造が作られるようにきちんと書いた

参考：https://qiita.com/YumaInaura/items/05949d99b42516716685