### PR TITLE
/:event へ遷移するときだけturbolinkを使わないことでmetaタグの更新がされずにInvalidAuthenticityTokenになる問題を解消する

### DIFF
--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -1,7 +1,7 @@
 <!-- Navigation-->
 <nav class="navbar navbar-expand-lg navbar-light navbar-scrolled" id="mainNav">
   <div class="container">
-    <%= link_to "#{root_url}#{event_name}", class: "navbar-brand js-scroll-trigger" do %>
+    <%= link_to "#{root_url}#{event_name}", class: "navbar-brand js-scroll-trigger", data: {"turbolinks" => false} do %>
       <%= image_tag 'header_logo.png', class: "img-fluid header_logo" %>
     <% end %>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>


### PR DESCRIPTION
fix: https://github.com/cloudnativedaysjp/dreamkast/issues/115

https://railsguides.jp/working_with_javascript_in_rails.html#turbolinks

> Turbolinksを特定のリンクでのみ無効にしたい場合は、タグにdata-turbolinks="false"属性を追加します。