### PR TITLE
新規登録時にTimetableやSpeakersリンクを表示させない

### DIFF
--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -8,8 +8,10 @@
     <div class="collapse navbar-collapse" id="navbarResponsive">
       <ul class="navbar-nav ml-auto my-2 my-lg-0">
         <% unless event_name.nil? %>
-          <li class="nav-item"><%= link_to "Timetable", timetables_path, class: "nav-link js-scroll-trigger" %></li>
-          <li class="nav-item"><%= link_to "Speakers", speakers_path, class: "nav-link js-scroll-trigger" %></li>
+          <% unless controller_name == "profiles" && action_name == "new" %>
+            <li class="nav-item"><%= link_to "Timetable", timetables_path, class: "nav-link js-scroll-trigger" %></li>
+            <li class="nav-item"><%= link_to "Speakers", speakers_path, class: "nav-link js-scroll-trigger" %></li>
+          <% end %>
         <% end %>
         <li class="nav-item dropdown">
           <% if @current_user %>

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe ProfilesController, type: :request do
+  describe "GET /registration" do
+    before do
+      create(:cndt2020)
+    end
+
+    describe 'not logged in' do
+      it "redirect to event top page" do
+        get '/cndt2020/registration'
+        expect(response).to_not be_successful
+        expect(response).to have_http_status '302'
+        expect(response).to redirect_to '/cndt2020'
+      end
+    end
+
+    describe 'logged in and not registerd' do
+      subject(:user_session) { {userinfo: {info: {email: "foo@example.com"}, extra: {raw_info: {sub: "mock", "https://cloudnativedays.jp/roles" => ""}}}}}
+
+      before do
+        allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(user_session)
+      end
+
+      it "doesn't have timetable and speakers links" do
+        get '/cndt2020/registration'
+        expect(response).to be_successful
+        expect(response).to have_http_status '200'
+        expect(response.body).to_not include 'Timetable'
+      end
+    end
+  end
+end


### PR DESCRIPTION
新規登録時にリンクを押すとエラーになる状態だったので、そもそもリンクを表示させないようにした

ついでにテストも追加