### PR TITLE
セッション登録後のリダイレクト先を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class Forbidden < ActionController::ActionControllerError; end
 class ApplicationController < ActionController::Base
   before_action :set_raven_context
 
-  rescue_from Exception, with: :render_500
+  #rescue_from Exception, with: :render_500
   rescue_from Forbidden, with: :render_403
 
   def home_controller?
@@ -38,8 +38,13 @@ class ApplicationController < ActionController::Base
     render template: 'errors/error_403', status: 403, layout: 'application', content_type: 'text/html'
   end
 
-  def render_404
+  def render_404(e)
     render template: 'errors/error_404', status: 404, layout: 'application', content_type: 'text/html'
+  end
+
+  def render_500(e)
+    @exception = e
+    render template: 'errors/error_500', status: 404, layout: 'application', content_type: 'text/html'
   end
 
   private
@@ -48,6 +53,5 @@ class ApplicationController < ActionController::Base
     Raven.user_context(id: session[:current_user_id]) # or anything else in session
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
-  # rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
 end

--- a/app/controllers/profiles/talks_controller.rb
+++ b/app/controllers/profiles/talks_controller.rb
@@ -26,7 +26,7 @@ class Profiles::TalksController < ApplicationController
         end
       end
     end
-      redirect_to profiles_talks_path
+      redirect_to dashboard_path
     rescue => e
       redirect_to timetables_path, notice: 'セッション登録に失敗しました'
   end

--- a/spec/requests/event_spec.rb
+++ b/spec/requests/event_spec.rb
@@ -34,7 +34,7 @@ describe EventController, type: :request do
         allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(userinfo: {info: {email: "foo@example.com"}})
       end
 
-      it "redirect to /:event/profiles/talks" do
+      it "redirect to /:event/dashboard" do
         get '/cndt2020'
         expect(response).to_not be_successful
         expect(response).to have_http_status '302'


### PR DESCRIPTION
Fix #205 

あと500エラーを別ページに飛ばす実装によってエラーの内容が確認できなくなっていたので一旦無効化