### PR TITLE
talkページをtwitterにシェアする際、ハッシュタグの `#` が重複している問題を修正

### DIFF
--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -17,7 +17,7 @@
                     <div class="talk">
                         <h3>
                           <%= @talk.title %> &nbsp;
-                          <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-hashtags="#CNDT2020">Tweet</a>
+                          <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false" data-hashtags="CNDT2020">Tweet</a>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
                           <span class="fb-share-button" data-href="<%= request.original_url %>" data-layout="button" data-size="small"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">シェア</a></span>


### PR DESCRIPTION
fix: https://github.com/cloudnativedaysjp/dreamkast/issues/227