### PR TITLE
スピーカーを編集したあと404になる問題を修正

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -57,7 +57,7 @@ class AdminController < ApplicationController
 
         respond_to do |format|
             if @speaker.update(speaker_params)
-                format.html { redirect_to "/admin/speakers", notice: 'Speaker was successfully updated.' }
+                format.html { redirect_to "/admin/speakers", notice: "Speaker #{@speaker.name} (id: #{@speaker.id})was successfully updated." }
                 format.json { render :show, status: :ok, location: @speaker }
             else
                 format.html { render :edit }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -57,7 +57,7 @@ class AdminController < ApplicationController
 
         respond_to do |format|
             if @speaker.update(speaker_params)
-                format.html { redirect_to @speaker, notice: 'Speaker was successfully updated.' }
+                format.html { redirect_to "/admin/speakers", notice: 'Speaker was successfully updated.' }
                 format.json { render :show, status: :ok, location: @speaker }
             else
                 format.html { render :edit }


### PR DESCRIPTION
スピーカーを更新したあとは `/:conference_id/speakers/:speaker_id` にリダイレクトされていたのだが、https://github.com/cloudnativedaysjp/dreamkast/pull/216 でカンファレンスの略称じゃない場合404を返すように変更したので404になっていた。

リダイレクト先を `/admin/speakers` に変更して対応します

fix: https://github.com/cloudnativedaysjp/dreamkast/issues/226