### PR TITLE
サイト表示時にスクリプトエラーが発生する事象を修正しました。

### DIFF
--- a/app/javascript/packs/message_box.js
+++ b/app/javascript/packs/message_box.js
@@ -5,13 +5,10 @@ $(function(){
     $(window).scroll(function() {
         $("#message_box").addClass("d-none");
     });
-    if ($(window).touchmove) {
-        $(window).touchmove(function() {
-            $("#message_box").addClass("d-none");
-        });
-    } else {
-        $(window).mousemove(function() {
-            $("#message_box").addClass("d-none");
-        });
-    }
+    $(window).bind('touchmove', function() {
+        $("#message_box").addClass("d-none");
+    });
+    $(window).mousemove(function() {
+        $("#message_box").addClass("d-none");
+    });
 })

--- a/app/javascript/packs/message_box.js
+++ b/app/javascript/packs/message_box.js
@@ -5,7 +5,13 @@ $(function(){
     $(window).scroll(function() {
         $("#message_box").addClass("d-none");
     });
-    $(window).touchmove(function() {
-        $("#message_box").addClass("d-none");
-    });
+    if ($(window).touchmove) {
+        $(window).touchmove(function() {
+            $("#message_box").addClass("d-none");
+        });
+    } else {
+        $(window).mousemove(function() {
+            $("#message_box").addClass("d-none");
+        });
+    }
 })


### PR DESCRIPTION
### 事象

* https://event.cloudnativedays.jp/cndt2020/timetables のURLへアクセスした際に以下のスクリプトエラーが発生します。
* PCのGoogle ChromeブラウザとiPhoneのSafariブラウザにて事象を確認しました。

```
message_box.js:8 Uncaught TypeError: t(...).touchmove is not a function
    at HTMLDocument.<anonymous> (message_box.js:8)
    at c (jquery.js:3235)
    at f (jquery.js:3277)
```

![スクリーンショット 2020-08-05 16 49 24](https://user-images.githubusercontent.com/16251291/89386154-a46ef980-d73b-11ea-8bbb-bf58a0e08e71.png)

### 修正内容

* jQueryオブジェクトにはtouchmoveというメソッドがないため、未定義エラーとなります。そのため、jQueryオブジェクトのbindメソッドを利用してイベントリスナを登録するように修正しました。
* また、PCのブラウザではtouchmoveイベントが動作しないため、代替のmousemoveイベントにて同じ処理のイベントリスナを登録するように修正しました。

### 試験

* https://cndt-dreamka-fix-script-l8it3h.herokuapp.com/cndt2020/registration のURLへアクセスした際に以下の動作となることを確認しました。
  * スクリプトエラーが発生しないこと（PCのGoogle Chromeブラウザ・iPhoneのSafariブラウザ）。
  * ブラウザのウィンドウの任意の場所へマウスオーバした際に「聞きたいセッションを登録しましょう。セッション名をクリックすると詳細が表示されます。」のメッセージが非表示になること（PCのGoogle Chromeブラウザ）。
  * ブラウザのウィンドウの任意の場所をタッチした際に「聞きたいセッションを登録しましょう。セッション名をクリックすると詳細が表示されます。」のメッセージが非表示になること（iPhoneのSafariブラウザ）。
