### PR TITLE
Implement karte logging to track page

### DIFF
--- a/app/javascript/packs/tracks/track_control.js
+++ b/app/javascript/packs/tracks/track_control.js
@@ -22,8 +22,7 @@ window.update_track = function(track){
             console.log(track)
             tracker.track("watch_video", {
                 track_name: track.track_name,
-                talk_id: track.id,
-                datetime: new Date(),
+                talk_id: track.id
             });
         }, 120 * 1000);
     }

--- a/app/javascript/packs/tracks/track_control.js
+++ b/app/javascript/packs/tracks/track_control.js
@@ -19,7 +19,6 @@ window.update_track = function(track){
         document.getElementById("time").innerHTML = track.start_time + "-" + track.end_time;
         window.selected_talk_id = track.id;
         window.timer = setInterval(function(){
-            console.log(track)
             tracker.track("watch_video", {
                 track_name: track.track_name,
                 talk_id: track.id

--- a/app/javascript/packs/tracks/track_control.js
+++ b/app/javascript/packs/tracks/track_control.js
@@ -1,4 +1,5 @@
 window.update_track = function(track){
+    clearInterval(window.timer);
     if(track === undefined || track === null){
         document.getElementById("video").contentWindow.location.replace("/cndt2020/tracks/blank");
         document.getElementById("chat").contentWindow.location.replace("/cndt2020/tracks/blank");
@@ -17,6 +18,14 @@ window.update_track = function(track){
         document.getElementById("speakers").innerHTML = track.speakers;
         document.getElementById("time").innerHTML = track.start_time + "-" + track.end_time;
         window.selected_talk_id = track.id;
+        window.timer = setInterval(function(){
+            console.log(track)
+            tracker.track("watch_video", {
+                track_name: track.track_name,
+                talk_id: track.id,
+                datetime: new Date(),
+            });
+        }, 120 * 1000);
     }
     document.querySelectorAll(".track_button").forEach(function(a){a.classList.remove('active')});
     document.querySelector('a[track_id="' + selected_track + '"]').classList.toggle('active');


### PR DESCRIPTION
#248 

## 仕様
- ページを開いて動画再生されるのと同じタイミングでタイマー(setInterval)をセット
- 2分後にKarteへのデータ送信。その後も2分おきに送信される(視聴時間を大まかに把握できるようにするため)
- 2分のIntervalがあるので、単純にトラックをザッピングしただけではデータは送信されない

## 動作確認
動作確認するにはKarteの管理者権限が必要(自分と青山さんしかアクセスできない)

以下は実際に確認してみたログ。
![image](https://user-images.githubusercontent.com/79102/90618672-4964f880-e24b-11ea-970d-a58cdaf1a0a9.png)

- 初回送信。データにトラックA,ID1が入っているのが分かる(7番ログ)
- ちょうど2分後に再度送信(6番、5番)
- トラックCに移動。移動してから2分後にログ送信。トラックC、ID3(4番、3番)
- クライアントはそのままに、管理画面から放送を差し替え。トラックCのままID10になっていることが分かる(2番、1番)