### PR TITLE
ブーススポンサーのキーイメージとPDFを複数個同時に添付しようとすると失敗する問題を修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,19 +33,19 @@ module ApplicationHelper
 
   def link_to_add_pdf_fields(name, f, association, **args)
     new_object = f.object.to_model.class.reflect_on_association(association).klass.new
-    fields = f.fields_for(association, new_object) do |builder|
+    id = new_object.object_id
+    fields = f.fields_for(association, new_object, :child_index => id) do |builder|
       render(association.to_s.singularize + "_fields", :f => builder)
     end
-    id = new_object.object_id
     link_to(name, '#', class: "add_pdf_fields " + args[:class], data: {id: id, fields: fields.gsub("\n", "")}, style: args[:style])
   end
 
   def link_to_add_key_image_fields(name, f, association, **args)
     new_object = f.object.to_model.class.reflect_on_association(association).klass.new
-    fields = f.fields_for(association, new_object) do |builder|
+    id = new_object.object_id
+    fields = f.fields_for(association, new_object, :child_index => id) do |builder|
       render(association.to_s.singularize + "_fields", :f => builder)
     end
-    id = new_object.object_id
     link_to(name, '#', class: "add_key_image_fields " + args[:class], data: {id: id, fields: fields.gsub("\n", "")}, style: args[:style])
   end
 end


### PR DESCRIPTION
child_indexが未指定のため、複数個ファイルを添付しようとすると同じindex(0)となり片方の添付に失敗していた

fix: https://github.com/cloudnativedaysjp/dreamkast/issues/256