### PR TITLE
ブース一覧をダッシュボードとトラックページに表示

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,6 +7,7 @@ class DashboardController < ApplicationController
     @talks = Talk.eager_load(:talk_category, :talk_difficulty).all
     @talk_cagetogies = TalkCategory.all
     @talk_difficulties = TalkDifficulty.all
+    @booths = Booth.where(conference_id: @conference.id)
   end
 
   private

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,7 +7,7 @@ class DashboardController < ApplicationController
     @talks = Talk.eager_load(:talk_category, :talk_difficulty).all
     @talk_cagetogies = TalkCategory.all
     @talk_difficulties = TalkDifficulty.all
-    @booths = Booth.where(conference_id: @conference.id)
+    @booths = Booth.where(conference_id: @conference.id, published: true)
   end
 
   private

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,8 +1,10 @@
 class TracksController < ApplicationController
 
   def index
+    @conference = Conference.includes(:talks).find_by(abbr: event_name)
     @current = Video.on_air
     @tracks = Track.all
+    @booths = Booth.where(conference_id: @conference.id)
   end
 
   def blank

--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -176,3 +176,19 @@ footer ul li {
         object-fit: contain;
     }
 }
+
+.booth-frame {
+    background-color: #FFF;
+    border-radius: 5px;
+    border: solid 1px #CCC;
+    overflow: hidden;
+    padding: 10px;
+}
+
+.booths-header {
+    background-color: #FFF;
+    border-radius: 5px;
+    border: solid 1px #CCC;
+    overflow: hidden;
+    padding: 10px;
+}

--- a/app/views/dashboard/_booth_section.html.erb
+++ b/app/views/dashboard/_booth_section.html.erb
@@ -1,0 +1,16 @@
+<div class="container">
+  <div class="row">
+    <% @booths.shuffle.each do |booth| %>
+      <div class="col-12 col-sm-4 my-3 text-center">
+        <div class="booth-frame">
+          <% if booth.published && booth.sponsor.sponsor_attachment_logo_image.present? %>
+            <%= link_to booth_path(id: booth.id) do %>
+              <%= image_tag booth.sponsor.sponsor_attachment_logo_image.url, class: "sponsor-logo" %>
+              <%= booth.sponsor.name %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -17,7 +17,7 @@
             </ul>
           </div>
         </div>
-        <div class="col-12">
+        <div class="col-12 mb-3">
           <div class="talk">
             <h4>聴講予定セッション一覧</h4>
             <% @profile.talks.each do |talk| %>
@@ -35,6 +35,21 @@
             </div>
           </div>
         </div>
+
+        <% if @conference.opened? %>
+          <div class="col-12">
+            <h4 class="text-center booths-header">↓ ブースにお立ち寄りください ↓</h4>
+          </div>
+
+          <div class="col-12 mb-3">
+            <%= render 'booth_section' %>
+          </div>
+        <% else %>
+          <div class="col-12">
+            <h4 class="text-center booths-header"><%= @conference.name %> is not opened.</h4>
+          </div>
+        <% end %>
+
       </div>
     </div>
     <div class="col-12 col-lg-3 sub-pane mt-3 mt-lg-0">

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -9,12 +9,12 @@
       <ul class="navbar-nav ml-auto my-2 my-lg-0 align-items-center">
         <% unless event_name.nil? %>
           <% unless controller_name == "profiles" && (action_name == "new" || action_name == "create") %>
-            <li class="nav-item"><%= link_to "Timetable", timetables_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false} %></li>
-            <li class="nav-item"><%= link_to "Speakers", speakers_path, class: "nav-link js-scroll-trigger" %></li>
-            <li class="nav-item"><%= link_to "Events", contents_path, class: "nav-link js-scroll-trigger" %></li>
             <% if @conference.present? && @conference.opened? %>
               <li class="nav-item"><%= link_to "Booths", booths_path, class: "nav-link js-scroll-trigger" %></li>
             <% end %>
+            <li class="nav-item"><%= link_to "Timetable", timetables_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false} %></li>
+            <li class="nav-item"><%= link_to "Speakers", speakers_path, class: "nav-link js-scroll-trigger" %></li>
+            <li class="nav-item"><%= link_to "Events", contents_path, class: "nav-link js-scroll-trigger" %></li>
           <% end %>
         <% end %>
         <li class="nav-item dropdown">

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -38,6 +38,23 @@
       </div>
     </div>
   </div>
+
+  <div class="row">
+    <% if @conference.opened? %>
+      <div class="col-12 mb-3 py-1 my-3 text-center booths-header">
+        <h4>↓ ブースにお立ち寄りください ↓</h4>
+      </div>
+
+      <div class="col-12 mb-3">
+        <%= render 'dashboard/booth_section' %>
+      </div>
+    <% else %>
+      <div class="col-12">
+        <h4 class="text-center booths-header"><%= @conference.name %> is not opened.</h4>
+      </div>
+    <% end %>
+  </div>
+
 </div>
 <script>
   window.track_list=<%= @current["current"].to_json.html_safe %>;


### PR DESCRIPTION
- ダッシュボードにブースリストを表示
- トラックページにブースリストを表示
- 上記2つのリストはシャッフルして表示
- ヘッダー上の表示位置を左端に変更

ref: https://github.com/cloudnativedaysjp/dreamkast/issues/262