### PR TITLE
dashboardとtracksをスイッチ可能に

### DIFF
--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -5,10 +5,14 @@ class EventController < ApplicationController
   before_action :set_profile
 
   def show
-    if session[:userinfo].present?
-      redirect_to dashboard_path
-    end
     @conference = Conference.first
+    if session[:userinfo].present?
+      if @conference.opened?
+        redirect_to tracks_path
+      else
+        redirect_to dashboard_path
+      end
+    end
     @sponsor_types = @conference.sponsor_types.order(order: "ASC")
   end
   

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,4 +1,6 @@
 class TracksController < ApplicationController
+  include Secured
+  before_action :set_profile
 
   def index
     @conference = Conference.includes(:talks).find_by(abbr: event_name)
@@ -9,5 +11,12 @@ class TracksController < ApplicationController
 
   def blank
     render :layout => false
+  end
+
+  private
+  def set_profile
+    if @current_user
+      @profile = Profile.find_by(email: @current_user[:info][:email])
+    end
   end
 end

--- a/spec/controllers/tracks_controller_spec.rb
+++ b/spec/controllers/tracks_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe TracksController, type: :controller do
-
-end

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -5,4 +5,11 @@ FactoryBot.define do
     abbr { 'cndt2020' }
     status { 0 }
   end
+
+  factory :cndt2020_opened, class: Conference do
+    id { 1 }
+    name { 'CloudNative Days Tokyo 2020'}
+    abbr { 'cndt2020' }
+    status { 1 }
+  end
 end

--- a/spec/requests/tracks_spec.rb
+++ b/spec/requests/tracks_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe DashboardController, type: :request do
+  subject(:session) { {userinfo: {info: {email: "foo@example.com", extra: {sub: "aaa"}}, extra: {raw_info: {sub: "aaa", "https://cloudnativedays.jp/roles" => roles}}} } }
+  let(:roles) { [] }
+
+  describe "GET /:event/tracks" do
+    describe "logged in and registered" do
+      before do
+        create(:cndt2020_opened)
+        create(:alice)
+        allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(session)
+      end
+
+      context "when user access to dashboard" do
+        it "return a success response" do
+          get '/cndt2020/tracks'
+          expect(response).to be_successful
+          expect(response).to have_http_status '200'
+        end
+      end
+
+      context "when user access to root page" do
+        it "redirect to tracks" do
+          get '/cndt2020'
+          expect(response).to_not be_successful
+          expect(response).to have_http_status '302'
+          expect(response).to redirect_to '/cndt2020/tracks'
+        end
+      end
+    end
+
+    describe "not logged in" do
+      before do
+        create(:cndt2020)
+      end
+
+      context 'get exists event\'s dashboard' do
+        it "redirect to top page a success response" do
+          get '/cndt2020/tracks'
+          expect(response).to_not be_successful
+          expect(response).to have_http_status '302'
+          expect(response).to redirect_to '/cndt2020'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
ConferenceがOpenedになったらtracksをデフォルトのリダイレクト先として指定するようにした

また、今回の修正で併せてtracksをログイン要にした

## notes

- tracksページとdashboardページの導線を見直す必要あり
- Navbarも併せて見直しかなぁ