### PR TITLE
パフォーマンスチューニング

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,5 @@ gem "aws-sdk-s3", "~> 1.14"
 gem 'seed-fu'
 
 gem 'rails_autolink'
+
+gem "rack-timeout"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-timeout (0.6.0)
     rails (6.0.3.1)
       actioncable (= 6.0.3.1)
       actionmailbox (= 6.0.3.1)
@@ -323,6 +324,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 0.1)
   pry-rails
   puma (~> 4.1)
+  rack-timeout
   rails (~> 6.0.3, >= 6.0.3.1)
   rails_autolink
   redis-rails

--- a/README.md
+++ b/README.md
@@ -74,5 +74,3 @@ $ ./bin/webpack-dev-server
 $ bundle exec rails db:migrate
 $ bundle exec rails db:seed
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ $ ./bin/webpack-dev-server
 $ bundle exec rails db:migrate
 $ bundle exec rails db:seed
 ```
+
+

--- a/config/database.yml
+++ b/config/database.yml
@@ -30,3 +30,4 @@ production:
   url: <%= ENV['DATABASE_URL'] || ENV.fetch('CLEARDB_DATABASE_URL', '').sub('mysql://', 'mysql2://') %>
   encoding: utf8mb4
   adapter: mysql2
+  pool: 40

--- a/config/database.yml
+++ b/config/database.yml
@@ -30,4 +30,4 @@ production:
   url: <%= ENV['DATABASE_URL'] || ENV.fetch('CLEARDB_DATABASE_URL', '').sub('mysql://', 'mysql2://') %>
   encoding: utf8mb4
   adapter: mysql2
-  pool: 40
+  pool: 50

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,7 +27,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 #
 # workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
-workers = ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 preload_app!
 
 # Use the `preload_app!` method when specifying a `workers` number.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-workers = ENV.fetch("WEB_CONCURRENCY") { 4 }
+workers = ENV.fetch("WEB_CONCURRENCY") { 2 }
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,6 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-workers = ENV.fetch("WEB_CONCURRENCY") { 2 }
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
@@ -27,6 +26,9 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # processes).
 #
 # workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+workers = ENV.fetch("WEB_CONCURRENCY") { 2 }
+preload_app!
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,6 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
+workers = ENV.fetch("WEB_CONCURRENCY") { 4 }
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count


### PR DESCRIPTION
- rack-timeoutを入れてタイムアウト時間を設定できるように
- pumaのworkersを環境変数で可変に

これにより以下の4環境変数でチューニングを行う
WEB_CONCURRENCY - pumaのworker(プロセス数)を設定
RAILS_MAX_THREADS - pumaの最大スレッド数を設定
RAILS_MIN_THREADS - pumaの最小スレッド数を設定
RACK_TIMEOUT_SERVICE_TIMEOUT - pumaのタイムアウト時間を設定

いずれもHeroku公式に紹介されている設定。
https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server

