### PR TITLE
Fix MissingExactTemplate when CSRF detected

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -16,6 +16,6 @@ class Auth0Controller < ApplicationController
   
     def failure
       # show a failure page or redirect to an error page
-      @error_msg = request.params['message']
+      redirect_to "/"
     end
   end

--- a/app/views/event/show.html.erb
+++ b/app/views/event/show.html.erb
@@ -12,7 +12,7 @@
                 <p class="text-white-75 font-weight-light">参加費無料</p>
             </div>
             <div class="col-12 col-xs-12 col-lg-3 align-self-baseline my-4">
-                <%= button_to '参加申し込み / ログイン', 'auth/auth0', {method: :post, class: "btn btn-primary btn-xl inline" } %>
+                <%= button_to '参加申し込み / ログイン', '/auth/auth0', {method: :post, class: "btn btn-primary btn-xl inline" } %>
             </div>
             <div class="col-12 col-xs-12 col-lg-3 align-self-baseline my-4">
                 <%= button_to 'タイムテーブル', timetables_path, {method: :get, class: "btn btn-secondary btn-xl inline" } %>


### PR DESCRIPTION
結構頻繁に起きてるこのエラー
https://sentry.io/organizations/cloudnative-days/issues/1810758959/?project=5350644&query=is%3Aunresolved#exception

https://github.com/cloudnativedaysjp/dreamkast/blob/master/app/middlewares/rescue_from_invalid_authenticity_token.rb#L9-L11

でInvalidAuthenticityTokenが起きたときはリダイレクトするようにしてるんだけど、エラーの内容を読む限りここに引っかかるのではなく、Auth0 Controllerのfailureが呼ばれているケースがある様子。
https://github.com/cloudnativedaysjp/dreamkast/blob/master/app/controllers/auth0_controller.rb#L17-L20
ただ、このactionに対するテンプレートが無いため上記エラーが発生しているものと推測。

対策としてはfailureにview templateを用意するか、リダイレクトするか。
InvalidAuthenticityTokenでもリダイレクトしているので、今回もそのままリダイレクトする形にした。


### 追記

ログインパスが相対パスになっていて、これが原因でエラーがあるようだった(slack参照)　ので修正した