### PR TITLE
Add booth tracking

### DIFF
--- a/app/javascript/packs/booth.js
+++ b/app/javascript/packs/booth.js
@@ -1,0 +1,6 @@
+$(function(){
+    tracker.track("booth", {
+        name: window.booth.name,
+        id: window.booth.id
+    });
+})

--- a/app/views/booths/_booth.html.erb
+++ b/app/views/booths/_booth.html.erb
@@ -68,3 +68,9 @@
     </div>
   </div>
 <% end %>
+<script>
+  window.booth = {};
+  window.booth.name = "<%= sponsor.name %>";
+  window.booth.id = "<%= sponsor.id %>";
+</script>
+<%= javascript_pack_tag 'booth.js' %>


### PR DESCRIPTION
#248 

boothに訪問するとkarteに情報がいくようにした

以下karteでの動作確認ログ
![image](https://user-images.githubusercontent.com/79102/92124575-e8d3df00-ee38-11ea-8839-190a833d26ea.png)