### PR TITLE
ログインしているが未登録ユーザーは登録画面にリダイレクト

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,11 @@ class Forbidden < ActionController::ActionControllerError; end
 class ApplicationController < ActionController::Base
   before_action :set_raven_context, :event_exists?
 
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  #rescue_from Exception, with: :render_500
-  rescue_from Forbidden, with: :render_403
+  unless Rails.env.development?
+    rescue_from Exception, with: :render_500
+    rescue_from ActiveRecord::RecordNotFound, with: :render_404
+    rescue_from Forbidden, with: :render_403
+  end
 
   def home_controller?
     controller_name == "home"
@@ -34,18 +36,17 @@ class ApplicationController < ActionController::Base
 
   helper_method :home_controller?, :admin_controller?, :event_name, :talks_checked?, :talk_category, :talk_difficulty
 
-  def render_403(e)
-    @exception = e
+  def render_403
     render template: 'errors/error_403', status: 403, layout: 'application', content_type: 'text/html'
   end
 
-  def render_404(e)
+  def render_404
     render template: 'errors/error_404', status: 404, layout: 'application', content_type: 'text/html'
   end
 
-  def render_500(e)
-    @exception = e
-    render template: 'errors/error_500', status: 404, layout: 'application', content_type: 'text/html'
+  def render_500(e = nil)
+    logger.error "Rendering 500 with exception: #{e.message}" if e
+    render template: 'errors/error_500', status: 500, layout: 'application', content_type: 'text/html'
   end
 
   private

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -15,8 +15,8 @@ module Secured
     end
 
     def new_user?
-      unless ["profiles", "timetable", "speakers", "event", "contents"].include?(controller_name) || controller_path == "talks"
-        unless Profile.find_by(email: @current_user[:info][:email])
+      if session[:userinfo].present? && !Profile.find_by(email: @current_user[:info][:email])
+        unless ["profiles"].include?(controller_name)
           redirect_to "/#{params[:event]}/registration"
         end
       end

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -21,6 +21,20 @@ describe ContentsController, type: :request do
       end
     end
 
+    describe 'logged in and not registerd' do
+      before do
+        create(:cndt2020)
+        allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(userinfo: {info: {email: "foo@example.com"}})
+      end
+
+      it "redirect to /cndt2020/registration" do
+        get '/cndt2020/contents'
+        expect(response).to_not be_successful
+        expect(response).to have_http_status '302'
+        expect(response).to redirect_to '/cndt2020/registration'
+      end
+    end
+
     describe "not logged in" do
       before do
         create(:cndt2020)

--- a/spec/requests/event_spec.rb
+++ b/spec/requests/event_spec.rb
@@ -34,11 +34,11 @@ describe EventController, type: :request do
         allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(userinfo: {info: {email: "foo@example.com"}})
       end
 
-      it "redirect to /:event/dashboard" do
+      it "redirect to /cndt2020/registration" do
         get '/cndt2020'
         expect(response).to_not be_successful
         expect(response).to have_http_status '302'
-        expect(response).to redirect_to dashboard_path
+        expect(response).to redirect_to '/cndt2020/registration'
       end
     end
   end

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -31,6 +31,18 @@ describe TalksController, type: :request do
       end
     end
 
+    describe 'logged in and not registerd' do
+      before do
+        allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(userinfo: {info: {email: "foo@example.com"}})
+      end
+
+      it "redirect to /cndt2020/registration" do
+        get '/cndt2020/talks/1'
+        expect(response).to_not be_successful
+        expect(response).to have_http_status '302'
+        expect(response).to redirect_to '/cndt2020/registration'
+      end
+    end
 
     describe 'logged in' do
       before do

--- a/spec/requests/timetable_spec.rb
+++ b/spec/requests/timetable_spec.rb
@@ -46,6 +46,18 @@ describe TimetableController, type: :request do
       end
     end
 
+    describe 'logged in and not registerd' do
+      before do
+        allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(userinfo: {info: {email: "foo@example.com"}})
+      end
+
+      it "redirect to /cndt2020/registration" do
+        get '/cndt2020/timetables'
+        expect(response).to_not be_successful
+        expect(response).to have_http_status '302'
+        expect(response).to redirect_to '/cndt2020/registration'
+      end
+    end
 
     describe 'logged in' do
       before do


### PR DESCRIPTION
Auth0でログインしたがプロフィール入力をしていないユーザーがtimetableやtalksページを見ると500エラーになっていたので、強制的にリダイレクトするように

Fix #291