### PR TITLE
redisに保存するセッションの有効期間が短い

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
 Rails.application.config.session_store :redis_store, **{
     servers: ENV['REDIS_URL'],
-    expire_after: 30.minutes
+    expire_after: 1.weeks
 }


### PR DESCRIPTION
1 weeksに