### PR TITLE
Improving other contents

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,5 +23,6 @@ import './timetable.js'
 import './sponsor_form.js'
 import './message_box.js'
 import './admin.js'
+import './contents.js'
 
 require.context('images', true, /\.(png|jpg|jpeg|svg)$/)

--- a/app/javascript/packs/contents.js
+++ b/app/javascript/packs/contents.js
@@ -1,0 +1,10 @@
+$(function(){
+    $(".collapse-button").on("click", function() {
+        $(this).toggleClass("on-click");
+        if ($(this).hasClass('on-click')) {
+            $(this).html("↑")
+        } else {
+            $(this).html("↓ Read More ↓")
+        }
+    });
+});

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -1,128 +1,161 @@
 <div class="container">
-  <h1 class="my-3 text-center">リアルタイム参加型コンテンツ</h1>
-
-　  <div class="row">
-      <div class="col-12 col-md-12 py-3">
+  <h1 class="text-center">リアルタイム参加型コンテンツ</h1>
+  <div class="row">
+    <div class="col-12 col-md-12 py-3">
       <div class="card h-100">
-      <div class="card-body">
-          <h4 class="card-title">
+        <div class="card-body">
+          <%= link_to '#kontest' do %>
+            <h4 class="card-title" id="kontest" style="color: #2E2F30">
               Kontest（Kubernetes Contest）
-          </h4>
+            </h4>
+          <% end %>
           <h6 class="card-subtitle text-muted mb-3">
-              開催日時：Day1 2020/09/08 (火) 14:00 - Day2 2020/09/09 (水) 23:59
+            開催日時：Day1 2020/09/08 (火) 14:00 - Day2 2020/09/09 (水) 23:59
           </h6>
           <h6 class="card-subtitle mb-3">
-              参加URL：
-              <% if @current_user %>
-                <a href="https://kontest.cloudnativedays.jp">https://kontest.cloudnativedays.jp</a>
-              <% else %>
-                <strong>表示するには CNDT2020 サイトにログインしてください。</strong>
-              <% end %>
+            参加URL：
+            <% if @current_user %>
+              <a href="https://kontest.cloudnativedays.jp">https://kontest.cloudnativedays.jp</a>
+            <% else %>
+              <strong>表示するには CNDT2020 サイトにログインしてください。</strong>
+            <% end %>
           </h6>
 
           <p class="card-text">あなたのKubernetes力を試してみませんか？</p>
-          <p class="card-text">Kontestはアプリケーションの実行に必要なマニフェストを適切に書けるかをクイズ形式でゲーム感覚で学べるコンテンツです。Kontestの問題は全部で19問。初級〜中級の問題を中心に全問正解を目指して挑戦してください！</p>
-          <p class="card-text"><strong>参加時にGitHubアカウントでのログインが必要です。ランキングページにGitHubのユーザ名が表示されます。</strong></p>
+          <p class="card-text">Kontestはアプリケーションの実行に必要なマニフェストを適切に書けるかをクイズ形式でゲーム感覚で学べるコンggテンツです。Kontestの問題は全部で19問。初級〜中級の問題を中心に全問正解を目指して挑戦してください！</p>
 
-          <%= image_tag "contents/kontest.png", :width => '70%', style: 'margin-bottom:30px;' %>
 
-          <h6 class="text-muted mb-3">
+          <div class="collapse" id="kontest-more-body">
+            <p class="card-text"><strong>参加時にGitHubアカウントでのログインが必要です。ランキングページにGitHubのユーザ名が表示されます。</strong></p>
+
+            <%= image_tag "contents/kontest.png", :width => '70%', style: 'margin-bottom:30px;' %>
+
+            <h6 class="text-muted mb-3">
               問題作成：CNDT2020 実行委員会
-          </h6>
-          <h6 class="text-muted mb-3">
+            </h6>
+            <h6 class="text-muted mb-3">
               解説：株式会社カサレアル
-          </h6>
+            </h6>
+          </div>
 
-      </div>
-      </div>
+          <div class="text-center">
+            <button class="collapse-button btn btn-info" data-toggle="collapse" href="#kontest-more-body" role="button" aria-expanded="false" aria-controls="collapseExample">
+              ↓ Read More ↓
+            </button>
+          </div>
+
+        </div>
       </div>
     </div>
+  </div>
 
-　  <div class="row">
-      <div class="col-12 col-md-12 py-3">
+  <div class="row">
+    <div class="col-12 col-md-12 py-3">
       <div class="card h-100">
-      <div class="card-body">
-          <h4 class="card-title">
+        <div class="card-body">
+          <%= link_to '#discussion-board' do %>
+            <h4 class="card-title" id="discussion-board" style="color: #2E2F30">
               CNDT2020 Discussion Board
-          </h4>
+            </h4>
+          <% end %>
           <h6 class="card-subtitle text-muted mb-3">
-              開催日時：Day1 2020/09/08 (火) - Day2 2020/09/09 (水)
+            開催日時：Day1 2020/09/08 (火) - Day2 2020/09/09 (水)
           </h6>
           <h6 class="card-subtitle text-muted mb-3">
-              公開期限：2020/09/27（日）
+            公開期限：2020/09/27（日）
           </h6>
           <h6 class="card-subtitle mb-3">
-              参加URL：
-              <% if @current_user %>
-                <a href="https://miro.com/app/board/o9J_kodoxUo=/">https://miro.com/app/board/o9J_kodoxUo=/</a>
-              <% else %>
-                <strong>表示するには CNDT2020 サイトにログインしてください。</strong>
-              <% end %>
+            参加URL：
+            <% if @current_user %>
+              <a href="https://miro.com/app/board/o9J_kodoxUo=/">https://miro.com/app/board/o9J_kodoxUo=/</a>
+            <% else %>
+              <strong>表示するには CNDT2020 サイトにログインしてください。</strong>
+            <% end %>
           </h6>
 
           <p class="card-text">この CNDT2020 Discussion Board は、ともに悩みを共有し、ともに解決して一歩進んでいくことを目的に作られています。議論の多様性を認めあって、友好的な場にしましょう。オンラインだからこその電子ボード上で、URLや画像を共有しながら気軽に情報交換することができます。</p>
           <p class="card-text"><strong>初級者も歓迎しています！</strong></p>
 
-          <%= image_tag "contents/discussion_board.png", :width => '70%', style: 'margin-bottom:50px;' %>
+          <div class="collapse" id="discussion-board-more-body">
+            <%= image_tag "contents/discussion_board.png", :width => '70%', style: 'margin-bottom:50px;' %>
 
-          <h5 class="card-subtitle mb-1">
-            使い方（Discussion Board 側にも記載してあります）
-          </h5>
-          <%= image_tag "contents/discussion_board_howto.png", :width => '100%', style: 'margin-bottom:30px;' %>
+            <h5 class="card-subtitle mb-1">
+              使い方（Discussion Board 側にも記載してあります）
+            </h5>
+            <%= image_tag "contents/discussion_board_howto.png", :width => '100%', style: 'margin-bottom:30px;' %>
 
-          <h6 class="text-muted mb-3">
+            <h6 class="text-muted mb-3">
               企画・運営：CNDT2020 実行委員会
-          </h6>
+            </h6>
+          </div>
 
-      </div>
-      </div>
+          <div class="text-center">
+            <button class="collapse-button btn btn-info" data-toggle="collapse" href="#discussion-board-more-body" role="button" aria-expanded="false" aria-controls="collapseExample">
+              ↓ Read More ↓
+            </button>
+          </div>
+
+        </div>
       </div>
     </div>
+  </div>
 
-    <h1 class="my-3 text-center">併設イベント</h1>
+  <h1 class="my-3 text-center">併設イベント</h1>
 
-    <div class="row">
-      <div class="col-12 col-md-12 py-3">
+  <div class="row">
+    <div class="col-12 col-md-12 py-3">
       <div class="card h-100">
-      <div class="card-body">
-          <h4 class="card-title">
+        <div class="card-body">
+          <%= link_to '#upstream-training' do %>
+            <h4 class="card-title" id="upstream-training" style="color: #2E2F30">
               Kubernetes Upstream Training
-          </h4>
+            </h4>
+          <% end %>
           <h6 class="card-subtitle text-muted mb-3">
-              開催日時：Day0 2020/09/07 (月) 13:00 - 17:30
+            開催日時：Day0 2020/09/07 (月) 13:00 - 17:30
           </h6>
           <h6 class="card-subtitle text-muted mb-3">
-              募集定員：25人
+            募集定員：25人
           </h6>
           <h6 class="card-subtitle text-muted mb-3">
-              募集期限：8/31（定員に達し次第締め切り）
+            募集期限：8/31（定員に達し次第締め切り）
           </h6>
           <h6 class="card-subtitle mb-3">
-              参加登録フォーム：募集は終了しました。
+            参加登録フォーム：募集は終了しました。
           </h6>
 
           <p class="card-text">KubernetesアップストリームトレーニングはKubernetesの新機能開発・バグ修正・ドキュメント作成などのコミュニティ開発を円滑に行うためのトレーニングプログラムです。参加者はKubernetesコミュニティの概要を把握できることに加えて、Kubernetesコミュニティに対する具体的な貢献方法をハンズオン形式で学ぶことが出来ます。</p>
           <p class="card-text">講師は Kubernetes コミュニティにおいてMember以上の開発者で構成されており、日本語での議論・相談が可能です。技術面だけでなく、オープンなコミュニティにおけるコミュニケーションや議論の進め方など、提案を受け入れてもらうための手法についてもお伝えします。</p>
-          <p class="card-text">トレーニングでは、実際のKubernetesコミュニティのリポジトリやSlackを使用します。オープンな場での行動について、<a href="https://github.com/cncf/foundation/blob/master/code-of-conduct-languages/jp.md">コミュニティ行動規範</a>をご一読いただき、ご理解頂いた上でご参加ください。</p>
-          <p class="card-text">Cloud Native Days Tokyo 2019やその他のイベントでも実施され、毎回大人気なコンテンツとなっています。オンライン開催に伴い、当日は参加者とメンターはZoomに参加して実施します。参加者に限りがあるため、参加希望の方は<strong>8/31までに</strong>上記の「参加登録URL」から登録をお願いします。</p>
 
-          <h6 class="text-muted mb-3">
+          <div class="collapse" id="upstream-training-more-body">
+            <p class="card-text">トレーニングでは、実際のKubernetesコミュニティのリポジトリやSlackを使用します。オープンな場での行動について、<a href="https://github.com/cncf/foundation/blob/master/code-of-conduct-languages/jp.md">コミュニティ行動規範</a>をご一読いただき、ご理解頂いた上でご参加ください。</p>
+            <p class="card-text">Cloud Native Days Tokyo 2019やその他のイベントでも実施され、毎回大人気なコンテンツとなっています。オンライン開催に伴い、当日は参加者とメンターはZoomに参加して実施します。参加者に限りがあるため、参加希望の方は<strong>8/31までに</strong>上記の「参加登録URL」から登録をお願いします。</p>
+
+            <h6 class="text-muted mb-3">
               メンター：稲生章人 NECソリューションイノベータ株式会社
-          </h6>
-          <h6 class="text-muted mb-3">
+            </h6>
+            <h6 class="text-muted mb-3">
               メンター：武藤周 NECソリューションイノベータ株式会社
-          </h6>
-          <h6 class="text-muted mb-3">
+            </h6>
+            <h6 class="text-muted mb-3">
               メンター：豊田康平 NECソリューションイノベータ株式会社
-          </h6>
-          <h6 class="text-muted mb-3">
+            </h6>
+            <h6 class="text-muted mb-3">
               メンター：伊藤慎悟 NECソリューションイノベータ株式会社
-          </h6>
+            </h6>
 
-          <%= image_tag "https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png?raw=true", :size => '90x90'  %>
-      </div>
-      </div>
+            <%= image_tag "https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png?raw=true", :size => '90x90'  %>
+          </div>
+
+          <div class="text-center">
+            <button class="collapse-button btn btn-info" data-toggle="collapse" href="#upstream-training-more-body" role="button" aria-expanded="false" aria-controls="collapseExample">
+              ↓ Read More ↓
+            </button>
+          </div>
+
+        </div>
       </div>
     </div>
+  </div>
 </div>
 <% @message_box = "豊富な併設イベントも開催中！" %>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -14,7 +14,7 @@
             <% end %>
             <li class="nav-item"><%= link_to "Timetable", timetables_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false} %></li>
             <li class="nav-item"><%= link_to "Speakers", speakers_path, class: "nav-link js-scroll-trigger" %></li>
-            <li class="nav-item"><%= link_to "Events", contents_path, class: "nav-link js-scroll-trigger" %></li>
+            <li class="nav-item"><%= link_to "Other Contents", contents_path, class: "nav-link js-scroll-trigger" %></li>
           <% end %>
         <% end %>
         <li class="nav-item dropdown">

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -14,7 +14,7 @@
             <% end %>
             <li class="nav-item"><%= link_to "Timetable", timetables_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false} %></li>
             <li class="nav-item"><%= link_to "Speakers", speakers_path, class: "nav-link js-scroll-trigger" %></li>
-            <li class="nav-item"><%= link_to "Other Contents", contents_path, class: "nav-link js-scroll-trigger" %></li>
+            <li class="nav-item"><%= link_to "Other Contents", contents_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
           <% end %>
         <% end %>
         <li class="nav-item dropdown">


### PR DESCRIPTION
* Kontest / Discussion Board / Kubernetes Upstream Training への導線をわかりやすく
* read moreを追加して、画面上にコンテンツが複数見えやすいようにする（Discussion Boardに気づかないかもしれないので）
* /cndt2020/contents#kontest で飛べるようにした