### PR TITLE
add rake task: update profiles that don't have conference_id

### DIFF
--- a/lib/tasks/relate_profile_to_cndt2020_if_conference_id_is_nil.rake
+++ b/lib/tasks/relate_profile_to_cndt2020_if_conference_id_is_nil.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  desc "relate_profile_to_cndt2021_if_conference_id_is_nil"
+  task relate_profile_to_cndt2021_if_conference_id_is_nil: :environment do
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    Rails.logger.level = Logger::DEBUG
+
+    ActiveRecord::Base.transaction do
+      begin
+        p Profile.where(conference_id: nil).update_all(conference_id: 1)
+      rescue => e
+        puts e
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/345 で各モデルにconference_idを追加していて、Profileだけは更新オペレーションが必要なのでRakeタスクを書いた（他のモデルはseedで追加した）。

https://github.com/cloudnativedaysjp/dreamkast/issues/348