### PR TITLE
複数のカンファレンスでSpeakerになっている際にForbiddenになることがある問題を修正

### DIFF
--- a/app/controllers/speaker_dashboard/speakers_controller.rb
+++ b/app/controllers/speaker_dashboard/speakers_controller.rb
@@ -86,7 +86,7 @@ class SpeakerDashboard::SpeakersController < ApplicationController
 
   def pundit_user
     if @current_user
-      Speaker.find_by(email: @current_user[:info][:email])
+      Speaker.find_by(conference: @conference.id, email: @current_user[:info][:email])
     end
   end
 


### PR DESCRIPTION
Speaker検索にConference情報が使われていなかったため、複数のカンファレンスでスピーカーになっている場合Forbiddenになることがある。