### PR TITLE
エントリーフォームの「セッション概要」は空欄のまま申し込んでもよい

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -14,7 +14,10 @@ class Talk < ApplicationRecord
 
   validates :conference_id, presence: true
   validates :title, presence: true
-  validates :abstract, presence: true
+
+  # エントリー時、セッション概要は空白でもいいのでバリデーションしなくていい
+  # validates :abstract, presence: true
+
   # エントリーフォームから入力する時、以下のフィールドには入力しないのでバリデーションを削っている
   # validates :track_id, presence: true
   # validates :talk_category_id, presence: true


### PR DESCRIPTION
フロントサイドではrequiredがついていないのだけど、Rails側でバリデーションしていて空欄のままだとうまく登録できなくなっていた。

ref: https://github.com/cloudnativedaysjp/dreamkast/issues/385