### PR TITLE
admin用ページでブースやスポンサーが見えない問題を修正

### DIFF
--- a/app/views/admin/booths/index.html.erb
+++ b/app/views/admin/booths/index.html.erb
@@ -15,7 +15,7 @@
       <tbody>
       <% @booths.each do |booth| %>
         <tr>
-          <td><%= link_to booth.sponsor.name, "/admin/sponsors/#{booth.sponsor.id}" %></td>
+          <td><%= link_to booth.sponsor.name, admin_sponsor_path(id: booth.sponsor.id) %></td>
           <td><%=  booth.published %></td>
         </tr>
       <% end %>

--- a/app/views/admin/sponsors/index.html.erb
+++ b/app/views/admin/sponsors/index.html.erb
@@ -16,7 +16,7 @@
         <tbody>
         <% sponsor_type.sponsors.each do |sponsor| %>
           <tr>
-            <td><%= link_to sponsor.name, "/admin/sponsors/#{sponsor.id}" %></td>
+            <td><%= link_to sponsor.name, admin_sponsor_path(id: sponsor.id) %></td>
           </tr>
         <% end %>
         </tbody>


### PR DESCRIPTION
adminページは各イベントの配下に移動してURLが変わったのだった。