### PR TITLE
希望セッション時間を見えるようにする

### DIFF
--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -7,10 +7,34 @@ class Admin::TalksController < ApplicationController
 
   def index
     @talks = @conference.talks.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    respond_to do |format|
+      format.html
+      format.csv do
+        head :no_content
+
+        filename = "#{@conference.abbr}_talks"
+        columns = %w[title abstract speaker talk_time]
+
+        csv = CSV.generate do |csv|
+          #カラム名を1行目として入れる
+          csv << columns
+
+          @talks.each do |talk|
+            csv << [talk.title, talk.abstract, talk.speakers.map(&:name).join(", "), talk.time]
+          end
+        end
+
+        File.open("./#{filename}.csv", "w", encoding: "SJIS") do |file|
+          file.write(csv)
+        end
+        stat = File::stat("./#{filename}.csv")
+        send_file("./#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+      end
+    end
   end
 
   def update_talks
-    TalksHelper.update_talks(params[:video])
+  TalksHelper.update_talks(params[:video])
 
     redirect_to admin_talks_url, notice: "配信設定を更新しました"
   end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -121,4 +121,7 @@ class Talk < ApplicationRecord
     video.present? ? video.id : ''
   end
 
+  def time
+    talk_time.present? ? talk_time.time_minutes : 0
+  end
 end

--- a/app/views/admin/talks/index.html.erb
+++ b/app/views/admin/talks/index.html.erb
@@ -5,6 +5,14 @@
         <%= message %>
         </div>
     <% end %>
+
+  <div class="row">
+    <h2>Download TALKS to CSV</h2>
+    <div class="col-12 form-group">
+      <%= link_to 'download', admin_talks_path(format: :csv) %>
+    </div>
+  </div>
+
     <div class="row">
         <h2>Bulk insert TALKS from CSV</h2>
         <div class="col-12 form-group">

--- a/app/views/admin/talks/index.html.erb
+++ b/app/views/admin/talks/index.html.erb
@@ -36,6 +36,7 @@
                     <th scope="col">Title / Abstract</th>
                     <th scope="col">Track</th>
                     <th scope="col">DateTime</th>
+                    <th scope="col">Time</th>
                     <th scope="col">Vimeo ID</th>
                     <th scope="col">Sli.do ID</th>
                     <th scope="col">On Air</th>
@@ -56,6 +57,9 @@
                     <% if talk.start_time.present? && talk.start_time.present? %>
                       <%= talk.start_time.strftime("%H:%M") + "-" + talk.end_time.strftime("%H:%M") %>
                     <% end %>
+                  </td>
+                  <td>
+                    <%= talk.time %>
                   </td>
                   <td>
                     <% video_id = talk.video ? talk.video.video_id : nil %>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -10,6 +10,7 @@
         <th data-field="track" data-filter-control="select" scope="col">Track</th>
         <th data-field="data" data-filter-control="select" scope="col">Date</th>
         <th data-field="time" data-filter-control="select" scope="col">Time</th>
+        <th data-field="talk_time" data-filter-control="select" scope="col">TalkTime</th>
         <th data-field="video" data-filter-control="select" data-filter-data-collector="tableFilterStripHtml" scope="col">アーカイブ視聴</th>
         <th data-field="document" data-filter-control="select" data-filter-data-collector="tableFilterStripHtml" scope="col">資料</th>
       </tr>
@@ -47,6 +48,10 @@
           </td>
 
           <td id="td-id-<%= (index * 7) + 7 %>" class="td-class-<%= index + 1 %> text-center">
+            <%= talk.time %>
+          </td>
+
+          <td id="td-id-<%= (index * 7) + 8 %>" class="td-class-<%= index + 1 %> text-center">
             <% if @conference.closed? || (@conference.opened? && @current_user) %>
               <% if talk.video_published && talk.video.present? %>
                 <%= link_to 'あり', talk_path(id: talk.id), data: {"turbolinks" => false} %>
@@ -54,7 +59,7 @@
             <% end %>
           </td>
 
-          <td id="td-id-<%= (index * 7) + 8 %>" class="td-class-<%= index + 1 %> text-center">
+          <td id="td-id-<%= (index * 7) + 9 %>" class="td-class-<%= index + 1 %> text-center">
             <% if talk.document_url.present? %>
               <%= link_to 'あり', talk.document_url, data: {"turbolinks" => false} %>
             <% end %>


### PR DESCRIPTION
- トーク一覧画面に希望セッション時間を追加
- admin画面からCSVでトーク一覧をダウンロードできるようにした

https://github.com/cloudnativedaysjp/dreamkast/issues/415