### PR TITLE
エントリー受付終了時の挙動変更

### DIFF
--- a/app/views/event/partial/_speaker_entry_button.html.erb
+++ b/app/views/event/partial/_speaker_entry_button.html.erb
@@ -1,5 +1,11 @@
-<% if conference.registered? && conference.speaker_entry_enabled? %>
+<% if conference.registered? %>
   <div class="col-12 col-xs-12 col-lg-3 align-self-baseline my-4">
-    <%= button_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
+    <% if conference.speaker_entry_enabled? %>
+      <%= button_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
+    <% else %>
+      <% if @speaker.present?  %>
+        <%= button_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
+      <% end %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/speaker_dashboard/speakers/_form.html.erb
+++ b/app/views/speaker_dashboard/speakers/_form.html.erb
@@ -53,10 +53,12 @@
           <% end %>
         </div>
 
-        <% if  action_name == "new" || form.object.talks.size < 3 %>
-          <p><%= link_to_add_talk_fields "セッションを追加する", form, :talks, class: 'add-talk btn btn-primary' %></p>
-        <% else %>
-          <p><%= link_to_add_talk_fields "セッションを追加する", form, :talks, class: 'add-talk btn btn-primary', style: "display: none" %></p>
+        <% if @conference.speaker_entry_enabled? %>
+          <% if action_name == "new" || form.object.talks.size < 3 %>
+            <p><%= link_to_add_talk_fields "セッションを追加する", form, :talks, class: 'add-talk btn btn-primary' %></p>
+          <% else %>
+            <p><%= link_to_add_talk_fields "セッションを追加する", form, :talks, class: 'add-talk btn btn-primary', style: "display: none" %></p>
+          <% end %>
         <% end %>
       </section>
 

--- a/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
+++ b/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
@@ -23,6 +23,9 @@
   <%= f.hidden_field :_destroy, class: "destroy_flag_field" %>
   <%= f.hidden_field :conference_id, value: @conference.id %>
 
-  <%= link_to 'Delete', '#', class: 'remove_talk_field' %>
+  <% if @conference.speaker_entry_enabled? %>
+    <%= link_to 'Delete Talk', '#', class: 'remove_talk_field text-right' %>
+  <% end %>
+
   <hr>
 </div>


### PR DESCRIPTION
speaker_entry_disableの時、

- エントリー済みの人にはスピーカーダッシュボードへのリンクを表示
- エントリー済みの人がトークの追加・削除ができないように変更（更新は可能）
- 未エントリーの人にエントリーボタンを表示しないようにする