### PR TITLE
セッション一覧ページで、セッション時間で検索する際に曖昧な検索がされている問題を修正

### DIFF
--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -10,7 +10,7 @@
         <th data-field="track" data-filter-control="select" scope="col">Track</th>
         <th data-field="data" data-filter-control="select" scope="col">Date</th>
         <th data-field="time" data-filter-control="select" scope="col">Time</th>
-        <th data-field="talk_time" data-filter-control="select" scope="col">TalkTime</th>
+        <th data-field="talk_time" data-filter-control="select" data-filter-strict-search="true" scope="col">TalkTime</th>
         <th data-field="video" data-filter-control="select" data-filter-data-collector="tableFilterStripHtml" scope="col">アーカイブ視聴</th>
         <th data-field="document" data-filter-control="select" data-filter-data-collector="tableFilterStripHtml" scope="col">資料</th>
       </tr>


### PR DESCRIPTION
`5` を選択すると `15` なども表示される。厳密な検索にすることで解決します

fix: https://github.com/cloudnativedaysjp/dreamkast/issues/440