### PR TITLE
タイムテーブルでトーク詳細を見た時、スピーカーのプロフィールが改行されていない問題を修正

### DIFF
--- a/app/views/talks/_show_modal.html.erb
+++ b/app/views/talks/_show_modal.html.erb
@@ -50,7 +50,7 @@
             </h6>
               
             <% if speaker.profile != "" %>
-              <p class="card-text"><%= speaker.profile %></p>
+              <p class="card-text"><%= simple_format speaker.profile %></p>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
fix: https://github.com/cloudnativedaysjp/dreamkast/issues/481