### PR TITLE
トーク一覧の表示エラーを修正

### DIFF
--- a/app/views/admin/talks/index.html.erb
+++ b/app/views/admin/talks/index.html.erb
@@ -76,7 +76,7 @@
                   </td>
                   <td>
                     <% if talk.video.present? && talk.video.video_file.present? %>
-                      <%= talk.video.video_url %>
+                      <%= link_to talk.video.video_file.metadata["filename"], talk.video.video_file_url %>
                     <% end %>
                   </td>
                   <td>


### PR DESCRIPTION
- URL生成のメソッド名が間違っていた
- そもそもリンクにすらなっていなかった（ひどい）

https://github.com/cloudnativedaysjp/dreamkast/issues/491