### PR TITLE
dreamkast-infra の資材更新方法変更

### DIFF
--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -47,4 +47,24 @@ jobs:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           repository: cloudnativedaysjp/dreamkast-infra
           directory: dreamkast-infra
-          branch: main
+          branch: gc/dk-${{ github.event.pull_request.number }}
+
+      - name: Create and Merge Pull Request
+        uses: "actions/github-script@v2"
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const pr = await github.pulls.create({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              title: "Automated PR (gc/dk-${{ github.event.pull_request.number }})",
+              body: "**this PR is automatically created & merged**",
+              head: "development/gc-${{ github.event.pull_request.number }}",
+              base: "main"
+            });
+            await github.pulls.merge({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              pull_number: pr.data.number,
+              merge_method: "merge",
+            });

--- a/.github/workflows/gitops-dev.yml
+++ b/.github/workflows/gitops-dev.yml
@@ -116,7 +116,27 @@ jobs:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           repository: cloudnativedaysjp/dreamkast-infra
           directory: dreamkast-infra
-          branch: main
+          branch: development/dk-${{ github.event.pull_request.number }}
+
+      - name: Create and Merge Pull Request
+        uses: "actions/github-script@v2"
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const pr = await github.pulls.create({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              title: "Automated PR (development/dk-${{ github.event.pull_request.number }})",
+              body: "**this PR is automatically created & merged**",
+              head: "development/dk-${{ github.event.pull_request.number }}",
+              base: "main"
+            });
+            await github.pulls.merge({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              pull_number: pr.data.number,
+              merge_method: "merge",
+            });
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/gitops-prd.yml
+++ b/.github/workflows/gitops-prd.yml
@@ -104,4 +104,24 @@ jobs:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           repository: cloudnativedaysjp/dreamkast-infra
           directory: dreamkast-infra
-          branch: main
+          branch: production/dk-main
+
+      - name: Create and Merge Pull Request
+        uses: "actions/github-script@v2"
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const pr = await github.pulls.create({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              title: "Automated PR (production/dk-main)",
+              body: "**this PR is automatically created & merged**",
+              head: "production/dk-main",
+              base: "main"
+            });
+            await github.pulls.merge({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              pull_number: pr.data.number,
+              merge_method: "merge",
+            });

--- a/.github/workflows/gitops-stg.yml
+++ b/.github/workflows/gitops-stg.yml
@@ -104,4 +104,24 @@ jobs:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           repository: cloudnativedaysjp/dreamkast-infra
           directory: dreamkast-infra
-          branch: main
+          branch: staging/dk-main
+
+      - name: Create and Merge Pull Request
+        uses: "actions/github-script@v2"
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          script: |
+            const pr = await github.pulls.create({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              title: "Automated PR (staging/dk-main)",
+              body: "**this PR is automatically created & merged**",
+              head: "staging/dk-main",
+              base: "main"
+            });
+            await github.pulls.merge({
+              owner: "cloudnativedaysjp",
+              repo: "dreamkast-infra",
+              pull_number: pr.data.number,
+              merge_method: "merge",
+            });


### PR DESCRIPTION
* 従来: dreamkast-infra に対して push to main
* これ以降 : push to temporary branch && create PR && merge PR


これにより、複数 GitHub Actions が同時に走ることによる push Error を回避する


### 注意点

* merge 前に https://github.com/cloudnativedaysjp/dreamkast-infra にて[ブランチの自動削除機能](https://docs.github.com/ja/github/administering-a-repository/managing-the-automatic-deletion-of-branches) を有効化してもらいたいです
    * これがないと、 2 回目以降の push 時に GitHub Actions が dreamkast-infra に対して同名 branch を push しようとしてエラーする