### PR TITLE
conference_dayでtalk一覧を検索するためのパラメータを追加

### DIFF
--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -4,6 +4,9 @@ class Api::V1::TalksController < ApplicationController
     query = {conference_id: conference.id}
     query[:track_id] = params[:trackId] if params[:trackId]
     @talks = Talk.where(query)
+    if params[:conferenceDayIds]
+      @talks = @talks.where(params[:conferenceDayIds].split(",").map{|id| "conference_day_id = #{id}"}.join(" OR "))
+    end
     render 'api/v1/talks/index.json.jbuilder'
   end
 

--- a/app/views/api/v1/talks/index.json.jbuilder
+++ b/app/views/api/v1/talks/index.json.jbuilder
@@ -15,4 +15,6 @@ json.array! @talks do |talk|
   json.talkCategory talk.category
   json.onAir talk.on_air?
   json.documentUrl talk.document_url ? talk.document_url : ''
+  json.conferenceDayId talk.conference_day.id
+  json.conferenceDayDate talk.conference_day.date
 end

--- a/app/views/api/v1/talks/show.json.jbuilder
+++ b/app/views/api/v1/talks/show.json.jbuilder
@@ -14,3 +14,5 @@ json.talkDifficulty @talk.difficulty
 json.talkCategory @talk.category
 json.onAir @talk.on_air?
 json.documentUrl @talk.document_url ? @talk.document_url : ''
+json.conferenceDayId @talk.conference_day.id
+json.conferenceDayDate @talk.conference_day.date

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -97,6 +97,11 @@ paths:
           required: false
           schema:
             type: string
+        - name: conferenceDayIds
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: OK
@@ -317,6 +322,11 @@ components:
           type: boolean
         documentUrl:
           type: string
+        conferenceDayId:
+          type: number
+        conferenceDayDate:
+          type: string
+          format: date
       example:
         - id: 1
           trackId: 2
@@ -370,9 +380,9 @@ components:
       properties:
         id:
           type: number
-        profile_id:
+        profileId:
           type: number
-        speaker_id:
+        speakerId:
           type: number
         eventAbbr:
           type: string


### PR DESCRIPTION
後でAPI定義とそろえる

- 1,2のように複数指定できるようにしている

API: https://github.com/cloudnativedaysjp/dreamkast-api-docs/pull/19