### PR TITLE
オンエアの自動切り替え v2

### DIFF
--- a/app/channels/on_air_channel.rb
+++ b/app/channels/on_air_channel.rb
@@ -1,0 +1,12 @@
+class OnAirChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "on_air_#{params["eventAbbr"]}"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+
+  def update
+  end
+end

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -34,7 +34,7 @@ class Admin::TalksController < ApplicationController
   end
 
   def update_talks
-  TalksHelper.update_talks(params[:video])
+  TalksHelper.update_talks(@conference, params[:video])
 
     redirect_to admin_talks_url, notice: "配信設定を更新しました"
   end

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -1,5 +1,5 @@
 module TalksHelper
-  def self.update_talks(videos)
+  def self.update_talks(conference, videos)
     videos.each do |talk_id, value|
       talk = Talk.find(talk_id)
       if talk.video
@@ -19,6 +19,9 @@ module TalksHelper
     end
     ActionCable.server.broadcast(
       "track_channel", Video.on_air
+    )
+    ActionCable.server.broadcast(
+      "on_air_#{conference.abbr}", Video.on_air_v2
     )
   end
 end

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,5 @@
+// Load all the channels within this directory and all subdirectories.
+// Channel files must be named *_channel.js.
+
+const channels = require.context('.', true, /_channel\.js$/)
+channels.keys().forEach(channels)

--- a/app/javascript/channels/on_air_channel.js
+++ b/app/javascript/channels/on_air_channel.js
@@ -1,0 +1,19 @@
+import consumer from "./consumer"
+
+consumer.subscriptions.create("OnAirChannel", {
+  connected() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received(data) {
+    // Called when there's incoming data on the websocket for this channel
+  },
+
+  update: function() {
+    return this.perform('update');
+  }
+});

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -28,6 +28,10 @@ class Talk < ApplicationRecord
 
   SLOT_MAP = ["1200","1400","1500","1600","1700","1800","1900","2000"]
 
+  scope :on_air, -> {
+    includes(:video).where(videos: { on_air: 1 })
+  }
+
   def self.import(file)
     message = []
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -39,7 +39,7 @@ class Video < ApplicationRecord
           id: talk.id,
           trackId: talk.track_id,
           videoPlatform: track.video_platform,
-          videoId: talk.video_id,
+          videoId: track.video_id,
           title: talk.title,
           abstract: talk.abstract,
           speakers: talk.speaker_names,

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -2,26 +2,28 @@ class Video < ApplicationRecord
   include VideoFileUploader::Attachment(:video_file)
 
   belongs_to :talk
-  
+
   def self.on_air
     current = Video.where(on_air: true)
     list = {}
     list['current'] = []
     current.each do |video|
-      list['current'][video.talk.track_id - 1] = {
-        video_id: video.video_id,
-        site: video.site,
-        slido_id: video.slido_id,
-        id: video.talk.id,
-        title: video.talk.title,
-        start_time: video.talk.start_time.strftime("%H:%M"),
-        end_time: video.talk.end_time.strftime("%H:%M"),
-        abstract: video.talk.abstract,
-        track_name: video.talk.track.present? ? video.talk.track.name : '',
-        track_number: video.talk.track.present? ? video.talk.track.number : '',
-        track_id: video.talk.track_id,
-        speakers: video.talk.speakers.map{|speaker| speaker.name}.join("/")
-      }
+      if video.talk.track.present?
+        list['current'][video.talk.track.number - 1] = {
+          video_id: video.video_id,
+          site: video.site,
+          slido_id: video.slido_id,
+          id: video.talk.id,
+          title: video.talk.title,
+          start_time: video.talk.start_time.strftime("%H:%M"),
+          end_time: video.talk.end_time.strftime("%H:%M"),
+          abstract: video.talk.abstract,
+          track_name: video.talk.track.present? ? video.talk.track.name : '',
+          track_number: video.talk.track.present? ? video.talk.track.number : '',
+          track_id: video.talk.track_id,
+          speakers: video.talk.speakers.map{|speaker| speaker.name}.join("/")
+        }
+      end
     end
     return list
   end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -38,8 +38,8 @@ class Video < ApplicationRecord
         res[track.id] = {
           id: talk.id,
           trackId: talk.track_id,
-          trackId: talk.track_id,
           videoPlatform: track.video_platform,
+          videoId: talk.video_id,
           title: talk.title,
           abstract: talk.abstract,
           speakers: talk.speaker_names,

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -25,4 +25,34 @@ class Video < ApplicationRecord
     end
     return list
   end
+
+  def self.on_air_v2
+    tracks = Track.where(conference_id: 2)
+    res = {}
+    on_air_talks = Talk.on_air.where(conference_id: 2)
+    tracks.each do |track|
+      talk = on_air_talks.find_by(track_id: track.id)
+      if talk
+        res[track.id] = {
+          id: talk.id,
+          trackId: talk.track_id,
+          trackId: talk.track_id,
+          videoPlatform: track.video_platform,
+          title: talk.title,
+          abstract: talk.abstract,
+          speakers: talk.speaker_names,
+          dayId: talk.conference_day.present? ? talk.conference_day.id : 0,
+          showOnTimetable: talk.show_on_timetable,
+          startTime: talk.start_time,
+          endTime: talk.end_time,
+          talkDuration: talk.duration,
+          talkDifficulty: talk.difficulty,
+          talkCategory: talk.category,
+          onAir: talk.on_air?,
+          documentUrl: talk.document_url ? talk.document_url : '',
+        }
+      end
+    end
+    return res
+  end
 end

--- a/spec/channels/on_air_channel_spec.rb
+++ b/spec/channels/on_air_channel_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OnAirChannel, type: :channel do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
admin画面でtalkのオンエアを切り替えた際、`"on_air_#{params["eventAbbr"]}"` チャンネルに通知します。
通知内容は各トラックでオンエアしているトークの一覧（トラックIDとトークのマップ）

https://github.com/cloudnativedaysjp/dreamkast-ui/pull/56