### PR TITLE
自動で新バージョンの tag を付与する GitHub Actions を追加

### DIFF
--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -9,7 +9,10 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
-
+    if: >-
+      ! contains(github.event.pull_request.labels.*.name, 'release/major') &&
+      ! contains(github.event.pull_request.labels.*.name, 'release/minor') &&
+      ! contains(github.event.pull_request.labels.*.name, 'release/patch')
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/gitops-dev.yml
+++ b/.github/workflows/gitops-dev.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   gitops:
     runs-on: ubuntu-latest
-
+    if: >-
+      ! contains(github.event.pull_request.labels.*.name, 'release/major') &&
+      ! contains(github.event.pull_request.labels.*.name, 'release/minor') &&
+      ! contains(github.event.pull_request.labels.*.name, 'release/patch')
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Push a new tag with Pull Request
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'release/major') ||
+      contains(github.event.pull_request.labels.*.name, 'release/minor') ||
+      contains(github.event.pull_request.labels.*.name, 'release/patch')
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-ecosystem/action-release-label@v1
+        id: release-label
+        if: ${{ github.event.pull_request.merged == true }}
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+        if: ${{ steps.release-label.outputs.level != null }}
+
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: ${{ steps.release-label.outputs.level }}
+
+      - uses: actions-ecosystem/action-push-tag@v1
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          tag: ${{ steps.bump-semver.outputs.new_version }}
+          message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'


### PR DESCRIPTION
### 変更内容

- `release/{major,minor,patch}` label を付けて PR を merge すると、自動で現在の latest tag から {major,minor,patch} をインクリした tag を push する GitHub Action を追加
- `release/{major,minor,patch}` label を付けた際に gitops-dev , gc GitHub Action が動作しないようにした

### 関連 PR

- https://github.com/cloudnativedaysjp/dreamkast-ui/pull/98