### PR TITLE
カンファレンス開催中、開催後もスピーカーはスピーカーダッシュボードを見られるようにする

### DIFF
--- a/app/views/event/partial/_speaker_entry_button.html.erb
+++ b/app/views/event/partial/_speaker_entry_button.html.erb
@@ -1,9 +1,3 @@
-<% if conference.registered? %>
-    <% if conference.speaker_entry_enabled? %>
-      <%= link_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-primary btn-xl  m-2" } %>
-    <% else %>
-      <% if @speaker.present?  %>
-        <%= link_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-primary btn-xl  m-2" } %>
-      <% end %>
-    <% end %>
+<% if (conference.registered? && conference.speaker_entry_enabled?) || (conference.opened? && @speaker.present?) || (conference.closed? && @speaker.present?) %>
+  <%= link_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-primary btn-xl  m-2" } %>
 <% end %>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -53,7 +53,7 @@
               <% if event_name && @profile.present? && @profile.id %>
                 <%= link_to '登録情報変更', edit_profile_path(id: @profile.id), class: "dropdown-item" %>
               <% end %>
-              <% if !@conference.closed? && @conference.speaker_entry_enabled? %>
+              <% if (@conference.registered? && @conference.speaker_entry_enabled?) || (@conference.opened? && @speaker.present?) || (@conference.closed? && @speaker.present?) %>
                 <div class="dropdown-divider"></div>
                 <%= link_to 'スピーカーダッシュボード', speakers_entry_path, class: "dropdown-item" %>
               <% end %>


### PR DESCRIPTION
fix https://github.com/cloudnativedaysjp/dreamkast/issues/619

以下の場合、スピーカーダッシュボードへのリンクをイベントトップページと右上メニューに表示する
- カンファレンス開催前、かつスピーカーエントリー受付中
- カンファレンス開催中、かつ自身がスピーカーの場合
- カンファレンス開催後、かつ自身がスピーカーの場合（開催後に資料URLを追加することを想定）