### PR TITLE
セッションパーマリンク側もライブが終わるまでは非公開にする

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -140,4 +140,10 @@ class Talk < ApplicationRecord
       ''
     end
   end
+
+  def archived?
+    now = Time.now.in_time_zone('Tokyo')
+    etime =  DateTime.parse("#{date.strftime('%Y-%m-%d')} #{end_time.strftime('%H:%M')} +0900")
+    return (now.to_i - etime.to_i) >= 600
+  end
 end

--- a/app/views/talks/partial_show/_talk_video_block.html.erb
+++ b/app/views/talks/partial_show/_talk_video_block.html.erb
@@ -1,4 +1,4 @@
-<% if talk.video_published && talk.video.present? %>
+<% if talk.video_published && talk.video.present? && talk.archived? %>
   <div class="mb-2">
     <div style="padding:56.25% 0 0 0;position:relative;">
       <iframe src="https://player.vimeo.com/video/<%= talk.video.video_id %>" id="video" frameborder="0" style="position:absolute;top:0;left:0;width:100%;height:100%;" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -48,6 +48,7 @@ describe TalksController, type: :request do
       before do
         Conference.destroy_all
         create(:cndt2020_closed)
+        allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
       end
       it "includes vimeo iframe" do
         get '/cndt2020/talks/1'

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -122,6 +122,7 @@ describe TalksController, type: :request do
         create(:alice)
         create(:alice_cndo2021)
         allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(session)
+        allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
       end
 
       it " includes vimeo iframe if video_published is true" do


### PR DESCRIPTION
fix https://github.com/cloudnativedaysjp/dreamkast/issues/618