### PR TITLE
Upgrade mimemagic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN --mount=type=cache,uid=1000,target=/app/.cache/node_modules \
 FROM ruby:2.7.2 as fetch-lib
 WORKDIR /app
 COPY Gemfile* ./
+RUN apt-get update && apt-get install shared-mime-info
 RUN bundle install
 
 FROM ruby:2.7.2 as asset-compile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.1)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ the version is controlled by `.node-version` and `.ruby-version` file.
 
 `nodenv` and `rbenv` are recommended to install those.
 
+You need to install shared-mime-info
+
+- macOS: `brew install shared-mime-info`
+- Ubuntu, Debian: `apt-get install shared-mime-info`
+
 ```
 $ yarn install --check-files
 $ bundle install


### PR DESCRIPTION
mimemagicをバージョンアップするか、mimemagicパッケージを削除するかの二つの方法があるが今回は前者を選択する。
dreamkastが現在使っている `rails_autolink` パッケージがmimemagicパッケージをインストールしてしまう (たぶん使ってないんだけど、railsに依存していてインストールされる）ため。

https://hackmd.io/@mametter/mimemagic-info-ja