### PR TITLE
remove status seed

### DIFF
--- a/db/fixtures/production/seeds.rb
+++ b/db/fixtures/production/seeds.rb
@@ -3,7 +3,6 @@ Conference.seed(
     id: 1,
     name: "CloudNative Days Tokyo 2020",
     abbr: "cndt2020",
-    status: 2, # closed
     speaker_entry: 0, # disabled
     attendee_entry: 0, # disabled
     theme: "+Native 〜ともに創るクラウドネイティブの世界〜",


### PR DESCRIPTION
シード値にStatusを含めていると手動でシード値と異なる値にStatusを変更した後にデプロイが走るとシード値のStatusに上書きされてしまう。