### PR TITLE
CFP受付中はビデオの投稿や資料URLを非表示に

### DIFF
--- a/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
+++ b/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
@@ -26,10 +26,12 @@
     <%= f.collection_select :talk_difficulty_id, @conference.talk_difficulties, :id, :name, {prompt: ""}, class: "form-control", required: true %>
   </div>
 
+  <% if @conference.speaker_entry_disabled? %>
   <div class="field pb-3">
     <%= f.label :document_url, "資料URL" %>
     <%= f.text_field :document_url, class: "form-control" %>
   </div>
+  <% end %>
 
   <div class="field pb-3">
     <%= f.label :expected_participants, "想定受講者（★★）", {class: 'form-check-label'}%>*

--- a/app/views/speaker_dashboards/show.html.erb
+++ b/app/views/speaker_dashboards/show.html.erb
@@ -25,16 +25,21 @@
               <% if talk.document_url.present? %>
                 <p class="card-text">資料URL: <%= link_to talk.document_url, talk.document_url %></p>
               <% else %>
-                <p class="card-text">資料URLはまだ追加されていません</p>
+                <% if @conference.speaker_entry_disabled? %>
+                  <p class="card-text">資料URLはまだ追加されていません</p>
+                <% end %>
               <% end %>
 
-              <% if talk.video_registration&.url.present? %>
-                <p class="card-text"><%= video_registration_status(talk.video_registration) %> (<%= link_to 'Download', talk.video_registration.url %>)</p>
-              <% else %>
-                <p class="card-text">ビデオファイル提出状況: ダウンロード用URLはまだ登録されていません</p>
-              <% end %>
+              <% if @conference.speaker_entry_disabled? %>
 
-              <a href="<%= video_registration_url(talk) %>" class="btn btn-primary">ビデオファイル登録</a>
+                <% if talk.video_registration&.url.present? %>
+                  <p class="card-text"><%= video_registration_status(talk.video_registration) %> (<%= link_to 'Download', talk.video_registration.url %>)</p>
+                <% else %>
+                  <p class="card-text">ビデオファイル提出状況: ダウンロード用URLはまだ登録されていません</p>
+                <% end %>
+
+                <a href="<%= video_registration_url(talk) %>" class="btn btn-primary">ビデオファイル登録</a>
+              <% end %>
             </div>
           </div>
         <% end %>

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -76,14 +76,31 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
     id { 2 }
     name { 'CloudNative Days Online 2021'}
     abbr { 'cndo2021' }
-    theme { 'これはCloudNativeDaysOnlinee2021のテーマです' }
-    copyright { '© CloudNativeDaysOnline 2021 Committee' }
+    theme { 'これはTestEventAutumn2020のテーマです' }
+    copyright { '© Test Event Autumn 2020 Committee' }
     privacy_policy { 'This is Privacy Policy' }
     privacy_policy_for_speaker { 'This is Privacy Policy for speaker' }
     status { 2 }
     speaker_entry { 1 }
     attendee_entry { 1 }
     show_timetable { 1 }
+    about { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." }
+  end
+  factory :cndt2020_speaker_entry_enabled, class: Conference do
+    id { 3 }
+    name { 'CloudNative Days Tokyo 2020'}
+    abbr { 'cndt2020' }
+    theme { 'これはCICD2021のテーマです' }
+    copyright { '© CloudNativeDaysOnline 2021 Committee' }
+    privacy_policy { 'This is Privacy Policy' }
+    privacy_policy_for_speaker { 'This is Privacy Policy for speaker' }
+    status { 0 }
+    speaker_entry { 1 }
+    attendee_entry { 0 }
+    show_timetable { 0 }
     about { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.

--- a/spec/requests/speaker_dashboard_spec.rb
+++ b/spec/requests/speaker_dashboard_spec.rb
@@ -47,6 +47,22 @@ describe SpeakerDashboardsController, type: :request do
           expect(response.body).to include 'edit'
         end
       end
+
+      describe 'registered and entry enabled' do
+        before do
+          allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(admin_userinfo)
+          create(:cndt2020_speaker_entry_enabled)
+          create(:speaker_alice)
+        end
+
+        it "doesn't include information about video status" do
+          get '/cndt2020/speaker_dashboard'
+          expect(response).to be_successful
+          expect(response).to have_http_status '200'
+          expect(response.body).to_not include 'ビデオファイル提出状況'
+          expect(response.body).to include 'edit'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fix #686 