### PR TITLE
CFP の新規作成時にメール送信する

### DIFF
--- a/app/controllers/speaker_dashboard/speakers_controller.rb
+++ b/app/controllers/speaker_dashboard/speakers_controller.rb
@@ -42,7 +42,7 @@ class SpeakerDashboard::SpeakersController < ApplicationController
         r.each do |talk|
           begin
             # TODO: 非同期実行
-            SpeakerMailer.cfp_registered(@speaker, talk).deliver_now
+            SpeakerMailer.cfp_registered(@conference, @speaker, talk).deliver_now
           rescue => e
             logger.error "Failed to send mail: #{e.message}"
           end
@@ -74,7 +74,7 @@ class SpeakerDashboard::SpeakersController < ApplicationController
         r.each do |talk|
           begin
             # TODO: 非同期実行
-            SpeakerMailer.cfp_registered(@speaker, talk).deliver_now unless exists_talks.include?(talk.id)
+            SpeakerMailer.cfp_registered(@conference, @speaker, talk).deliver_now unless exists_talks.include?(talk.id)
           rescue => e
             logger.error "Failed to send mail: #{e.message}"
           end

--- a/app/controllers/speaker_dashboard/speakers_controller.rb
+++ b/app/controllers/speaker_dashboard/speakers_controller.rb
@@ -86,7 +86,9 @@ helper_method :speaker_url, :expected_participant_params, :execution_phases_para
 
   def pundit_user
     if @current_user
-      Speaker.find_by(conference: @conference.id, email: @current_user[:info][:email])
+      speaker = Speaker.find_by(conference: @conference.id, email: @current_user[:info][:email])
+      Thread.current[:user] = speaker
+      speaker
     end
   end
 

--- a/app/mailers/speaker_mailer.rb
+++ b/app/mailers/speaker_mailer.rb
@@ -10,10 +10,11 @@ class SpeakerMailer < ApplicationMailer
     mail(to: speaker.email, subject: 'ビデオファイルの提出が完了しました')
   end
 
-  def cfp_registered(speaker, talk)
+  def cfp_registered(conference, speaker, talk)
+    @conference = conference
     @speaker = speaker
     @talk = talk
 
-    mail(to: speaker.email, subject: 'CFP を受け付けました')
+    mail(to: speaker.email, subject: 'プロポーザルを受け付けました')
   end
 end

--- a/app/mailers/speaker_mailer.rb
+++ b/app/mailers/speaker_mailer.rb
@@ -15,6 +15,6 @@ class SpeakerMailer < ApplicationMailer
     @speaker = speaker
     @talk = talk
 
-    mail(to: speaker.email, subject: 'プロポーザルを受け付けました')
+    mail(to: speaker.email, subject: "【#{@conference.name}】プロポーザルを受け付けました")
   end
 end

--- a/app/mailers/speaker_mailer.rb
+++ b/app/mailers/speaker_mailer.rb
@@ -9,4 +9,11 @@ class SpeakerMailer < ApplicationMailer
 
     mail(to: speaker.email, subject: 'ビデオファイルの提出が完了しました')
   end
+
+  def cfp_registered(speaker, talk)
+    @speaker = speaker
+    @talk = talk
+
+    mail(to: speaker.email, subject: 'CFP を受け付けました')
+  end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -1,7 +1,4 @@
 class Talk < ApplicationRecord
-  after_create do
-    SpeakerMailer.cfp_registered(Thread.current[:user], self).deliver_now
-  end
   belongs_to :talk_category, optional: true
   belongs_to :talk_difficulty, optional: true
   belongs_to :conference

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -1,4 +1,7 @@
 class Talk < ApplicationRecord
+  after_create do
+    SpeakerMailer.cfp_registered(Thread.current[:user], self).deliver_now
+  end
   belongs_to :talk_category, optional: true
   belongs_to :talk_difficulty, optional: true
   belongs_to :conference
@@ -158,6 +161,18 @@ class Talk < ApplicationRecord
       start_time.strftime("%H:%M") + "-" + end_time.strftime("%H:%M")
     else
       ''
+    end
+  end
+
+  def expected_participant_params
+    self.expected_participants.filter_map do |e|
+      ProposalItemConfig.find(e).params unless e == 0
+    end
+  end
+
+  def execution_phase_params
+    self.execution_phases.filter_map do |e|
+      ProposalItemConfig.find(e).params unless e == 0
     end
   end
 

--- a/app/views/speaker_mailer/cfp_registered.text.erb
+++ b/app/views/speaker_mailer/cfp_registered.text.erb
@@ -1,5 +1,5 @@
 こんにちは、<%= @speaker.name %> さん。
-CI/CD Conference 2021の CFP を以下の内容で受け付けました。
+<%= @conference.name %> のプロポーザルを以下の内容で受け付けました。
 
 タイトル:     <%= @talk.title %>
 概要:         <%= @talk.abstract %>

--- a/app/views/speaker_mailer/cfp_registered.text.erb
+++ b/app/views/speaker_mailer/cfp_registered.text.erb
@@ -1,0 +1,17 @@
+こんにちは、<%= @speaker.name %> さん。
+CI/CD Conference 2021の CFP を以下の内容で受け付けました。
+
+タイトル:     <%= @talk.title %>
+概要:         <%= @talk.abstract %>
+受講者レベル: <%= @talk.difficulty %>
+資料URL:      <%= @talk.document_url %>
+
+想定受講者:
+   <% @talk.expected_participant_params.each do |e| %>
+   - <%= e %>
+   <% end %>
+
+実行フェーズ:
+   <% @talk.execution_phase_params.each do |e| %>
+   - <%= e %>
+   <% end %>


### PR DESCRIPTION
#701  

- create からは無条件にメール送信
- update の際は talk_id を保存して save の結果と比較することで create を判定

## 特にレビューが欲しいところ

- メール文面
- 本番環境の SES 動きますよねという確認(@takaishi さんのメールが認証されているだけだったので動くのか気になりました)
- エスケープしてないので改行が入ると文面が崩れますけど、対応が必要かどうか

## スクショ
![スクリーンショット 2021-06-11 213959](https://user-images.githubusercontent.com/40717789/121689434-8dd5c380-caff-11eb-9c93-eeb664aed5aa.png)