### PR TITLE
Support cfp accepting

### DIFF
--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -18,6 +18,7 @@ class Admin::ConferencesController < ApplicationController
 
   def update
     @conference_form = ConferenceForm.new(conference_params, conference: @conference)
+        referrer_controller = Rails.application.routes.recognize_path(request.referrer)[:controller]
 
     respond_to do |format|
       if @conference_form.save
@@ -25,7 +26,12 @@ class Admin::ConferencesController < ApplicationController
           path = "/#{@conference.abbr}/#{@conference.abbr == 'cndt2020' ? 'tracks' : 'ui/'}"
           ActionCable.server.broadcast("waiting_channel",{msg: "redirect to tracks", redirectTo: path})
         end
-        format.html { redirect_to admin_path, notice: "Conference was successfully updated." }
+        redirect_path = if referrer_controller == 'admin/proposals'
+                          admin_proposals_path
+                        else
+                          admin_path
+                        end
+        format.html { redirect_to redirect_path, notice: "Conference was successfully updated." }
       else
         format.html { render :edit }
       end
@@ -40,6 +46,7 @@ class Admin::ConferencesController < ApplicationController
 
   def conference_params
     params.require(:conference).permit(:status,
+                                       :cfp_result_visible,
                                        :speaker_entry,
                                        :attendee_entry,
                                        :show_timetable,

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -12,6 +12,15 @@ class Admin::ProposalsController < ApplicationController
     end
   end
 
+  def update_proposals
+    params[:proposal].each do |proposal_id, value|
+      proposal = Proposal.find(proposal_id)
+      proposal[:status] = value[:status].to_i
+      proposal.save
+    end
+    redirect_to admin_proposals_url, notice: "配信設定を更新しました"
+  end
+
   private
 
   def is_admin?

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -1,0 +1,20 @@
+class Admin::ProposalsController < ApplicationController
+  include Secured
+  include Logging
+  include LogoutHelper
+
+  before_action :is_admin?, :set_conference
+
+  def index
+    @proposals = @conference.proposals
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  private
+
+  def is_admin?
+    raise Forbidden unless admin?
+  end
+end

--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -20,7 +20,7 @@ class SpeakerDashboardsController < ApplicationController
 
   private
 
-  helper_method :video_registration_url, :video_registration_status
+  helper_method :video_registration_url, :video_registration_status, :proposal_status
 
   def video_registration_url(talk)
     if talk.video_registration.present?
@@ -35,6 +35,19 @@ class SpeakerDashboardsController < ApplicationController
       '提出されたビデオファイルの確認中です。'
     elsif video_registration.confirmed?
       '提出されたビデオファイルの確認が完了しました。'
+    end
+  end
+
+  def proposal_status(proposal)
+    return 'エントリー済み' unless @conference.cfp_result_visible
+
+    case proposal.status
+    when 'registered'
+      'エントリー済み'
+    when 'accepted'
+      '採択'
+    when 'rejected'
+      '不採択'
     end
   end
 end

--- a/app/forms/conference_form.rb
+++ b/app/forms/conference_form.rb
@@ -3,7 +3,7 @@ class ConferenceForm
   include ActiveModel::Attributes
   include ActiveModel::Validations
 
-  attr_accessor :status, :speaker_entry, :attendee_entry, :show_timetable
+  attr_accessor :status, :cfp_result_visible, :speaker_entry, :attendee_entry, :show_timetable
 
   delegate :persisted?, to: :conference
 
@@ -73,7 +73,7 @@ class ConferenceForm
 
   def initialize(attributes = nil, conference: Conference.new)
     @conference = conference
-    attributes ||= default_attributes
+    attributes = default_attributes.merge(attributes||{})
     super(attributes)
   end
 
@@ -85,7 +85,7 @@ class ConferenceForm
     return if invalid?
 
     ActiveRecord::Base.transaction do
-      conference.update!(status: status, speaker_entry: speaker_entry, attendee_entry: attendee_entry, show_timetable: show_timetable)
+      conference.update!(status: status, cfp_result_visible: cfp_result_visible, speaker_entry: speaker_entry, attendee_entry: attendee_entry, show_timetable: show_timetable)
     end
 
   rescue => e
@@ -109,6 +109,7 @@ class ConferenceForm
   def default_attributes
     {
       status: conference.status,
+      cfp_result_visible: conference.cfp_result_visible,
       speaker_entry: conference.speaker_entry,
       attendee_entry: conference.attendee_entry,
       show_timetable: conference.show_timetable,

--- a/app/forms/speaker_form.rb
+++ b/app/forms/speaker_form.rb
@@ -92,8 +92,6 @@ class SpeakerForm
 
           proposal = Proposal.new(conference_id: conference_id, talk_id: talk.id)
           proposal.save!
-          proposal_speaker = ProposalsSpeaker.new(proposal_id: proposal.id, speaker_id: speaker.id)
-          proposal_speaker.save!
         end
       end
     end

--- a/app/forms/speaker_form.rb
+++ b/app/forms/speaker_form.rb
@@ -76,9 +76,11 @@ class SpeakerForm
       puts "conference_id #{conference_id}"
       speaker.update!(name: name, profile: profile, company: company, job_title: job_title, twitter_id: twitter_id, github_id: github_id, avatar: avatar, conference_id: conference_id, sub: sub, email: email, additional_documents: additional_documents)
       @destroy_talks.each do |talk|
+        proposal = Talk.proposal
         talk_speaker = TalksSpeaker.new(talk_id: talk.id, speaker_id: speaker.id)
         talk.destroy!
         talk_speaker.destroy!
+        proposal.destroy! if proposal
       end
       @talks.each do |talk|
         if talk.persisted?

--- a/app/forms/speaker_form.rb
+++ b/app/forms/speaker_form.rb
@@ -87,6 +87,11 @@ class SpeakerForm
           talk.save!
           talk_speaker = TalksSpeaker.new(talk_id: talk.id, speaker_id: speaker.id)
           talk_speaker.save!
+
+          proposal = Proposal.new(conference_id: conference_id, talk_id: talk.id)
+          proposal.save!
+          proposal_speaker = ProposalsSpeaker.new(proposal_id: proposal.id, speaker_id: speaker.id)
+          proposal_speaker.save!
         end
       end
     end

--- a/app/forms/speaker_form.rb
+++ b/app/forms/speaker_form.rb
@@ -98,7 +98,7 @@ class SpeakerForm
       end
     end
   rescue => e
-    puts "faild to save: #{e}"
+    puts "failed to save: #{e}"
     false
   end
 

--- a/app/forms/speaker_form.rb
+++ b/app/forms/speaker_form.rb
@@ -76,7 +76,7 @@ class SpeakerForm
       puts "conference_id #{conference_id}"
       speaker.update!(name: name, profile: profile, company: company, job_title: job_title, twitter_id: twitter_id, github_id: github_id, avatar: avatar, conference_id: conference_id, sub: sub, email: email, additional_documents: additional_documents)
       @destroy_talks.each do |talk|
-        proposal = Talk.proposal
+        proposal = talk.proposal
         talk_speaker = TalksSpeaker.new(talk_id: talk.id, speaker_id: speaker.id)
         talk.destroy!
         talk_speaker.destroy!

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -6,6 +6,7 @@ class Conference < ApplicationRecord
 
   has_many :form_items
   has_many :conference_days
+  has_many :proposals
   has_many :talks
   has_many :tracks
   has_many :sponsors

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,0 +1,7 @@
+class Proposal < ApplicationRecord
+  enum status: { registered: 0, accepted: 1, rejected: 2 }
+
+  belongs_to :talk
+  has_many :proposals_speakers
+  has_many :speakers, through: :proposals_speakers
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -2,6 +2,8 @@ class Proposal < ApplicationRecord
   enum status: { registered: 0, accepted: 1, rejected: 2 }
 
   belongs_to :talk
-  has_many :proposals_speakers
-  has_many :speakers, through: :proposals_speakers
+
+  def speakers
+    talk.speakers
+  end
 end

--- a/app/models/proposals_speaker.rb
+++ b/app/models/proposals_speaker.rb
@@ -1,4 +1,0 @@
-class ProposalsSpeaker < ApplicationRecord
-  belongs_to :proposal, optional: true
-  belongs_to :speaker, optional: true
-end

--- a/app/models/proposals_speaker.rb
+++ b/app/models/proposals_speaker.rb
@@ -1,0 +1,4 @@
+class ProposalsSpeaker < ApplicationRecord
+  belongs_to :proposal, optional: true
+  belongs_to :speaker, optional: true
+end

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -6,6 +6,8 @@ class Speaker < ApplicationRecord
 
   has_many :talks_speakers
   has_many :talks, through: :talks_speakers
+  has_many :proposals_speakers
+  has_many :proposals, through: :proposals_speakers
 
   validates :name, presence: true
   validates :profile, presence: true

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -6,14 +6,16 @@ class Speaker < ApplicationRecord
 
   has_many :talks_speakers
   has_many :talks, through: :talks_speakers
-  has_many :proposals_speakers
-  has_many :proposals, through: :proposals_speakers
 
   validates :name, presence: true
   validates :profile, presence: true
   validates :company, presence: true
   validates :job_title, presence: true
   validates :conference_id, presence: true
+
+  def proposals
+    talks.map(&:proposals)
+  end
 
   def self.import(file)
     message = []

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -4,6 +4,7 @@ class Talk < ApplicationRecord
   belongs_to :conference
   belongs_to :conference_day, optional: true
   belongs_to :track, optional: true
+  has_one :proposal
 
   has_one :video_registration, dependent: :destroy
   has_one :video, dependent: :destroy

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -9,6 +9,7 @@
     <%= render 'admin/nav_item', name: 'AccessLog', path: admin_accesslog_path, active: action_name == 'accesslog' %>
     <%= render 'admin/nav_item', name: 'Users', path: admin_users_path, active: action_name == 'users' %>
     <%= render 'admin/nav_item', name: 'Speakers', path: admin_speakers_path, active:  controller_name == 'speakers' || action_name == 'edit_speaker' %>
+    <%= render 'admin/nav_item', name: 'Proposals', path: admin_proposals_path, active: controller_name == 'proposals' %>
     <%= render 'admin/nav_item', name: 'Talks', path: admin_talks_path, active: controller_name == 'talks' %>
     <%= render 'admin/nav_item', name: 'ビデオファイル提出状況', path: admin_videos_path, active: controller_name == 'videos' %>
     <%= render 'admin/nav_item', name: 'TimeTable', path: admin_timetables_path, active: controller_name == 'timetables' %>

--- a/app/views/admin/conferences/_form.html.erb
+++ b/app/views/admin/conferences/_form.html.erb
@@ -22,6 +22,15 @@
     </div>
   </div>
 
+  <h3>Proposal Result Visible Status</h3>
+
+  <div class="form-row form-group">
+    <div class="col-12 col-md-6">
+      <%= form.check_box :cfp_result_visible %>
+      <%= form.label :cfp_result_visible, 'Visible' %><br>
+    </div>
+  </div>
+
   <h3>Attendee Entry Status</h3>
 
   <div class="form-row form-group">

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -1,0 +1,31 @@
+<%= render 'admin/layout' do %>
+  <div class="row">
+    <h2>Talks</h2>
+    <table class="table table-striped talks_table" >
+      <thead>
+      <tr>
+        <th scope="col">Speakers</th>
+        <th scope="col">Title / Abstract</th>
+        <th scope="col">Status</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @proposals.each do |proposal| %>
+        <tr>
+
+          <td><ul class="p-0"><% proposal.speakers.each do |speaker| %><li class="speaker"><%= speaker.name %></li><% end %></ul></td>
+
+          <td>
+            <h5><%= proposal.talk.title %></h5>
+            <p class="abstract"><%= proposal.talk.abstract[0..30] %></p>
+          </td>
+
+          <td>
+            <%= proposal.status %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -40,4 +40,16 @@
 <% end %>
 <div id="transit_nav" class="p-4">
   <%= submit_tag "保存", form: "proposal_list",class: "btn btn-danger transit_button" %>
+
+  <% if @conference.cfp_result_visible %>
+    <%= form_with(url: admin_conference_path(id: @conference.id), model: @conference, local: true, method: :patch) do |form| %>
+      <%= form.hidden_field :cfp_result_visible, value: false %>
+      <%= form.submit "採択結果を非公開にする", class: "btn btn-danger transit_button", data: { confirm: '本当に非公開にしますか？' } %>
+    <% end %>
+  <% else %>
+    <%= form_with(url: admin_conference_path(id: @conference.id), model: @conference, local: true, method: :patch) do |form| %>
+      <%= form.hidden_field :cfp_result_visible, value: true %>
+      <%= form.submit "採択結果を公開する", class: "btn btn-danger transit_button", data: { confirm: '本当に公開しますか？' }  %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -1,4 +1,10 @@
 <%= render 'admin/layout' do %>
+  <% flash.each do |message_type, message| %>
+    <div class="alert alert-info" role="alert">
+      <%= message %>
+    </div>
+  <% end %>
+
   <div class="row">
     <h2>Talks</h2>
     <table class="table table-striped talks_table" >
@@ -10,22 +16,28 @@
       </tr>
       </thead>
       <tbody>
-      <% @proposals.each do |proposal| %>
-        <tr>
+      <%= form_with(url: admin_proposals_path, local: true, id: "proposal_list", method: "put") do |f| %>
+        <% @proposals.each do |proposal| %>
+          <tr>
 
-          <td><ul class="p-0"><% proposal.speakers.each do |speaker| %><li class="speaker"><%= speaker.name %></li><% end %></ul></td>
+            <td><ul class="p-0"><% proposal.speakers.each do |speaker| %><li class="speaker"><%= speaker.name %></li><% end %></ul></td>
 
-          <td>
-            <h5><%= proposal.talk.title %></h5>
-            <p class="abstract"><%= proposal.talk.abstract[0..30] %></p>
-          </td>
+            <td>
+              <h5><%= proposal.talk.title %></h5>
+              <p class="abstract"><%= proposal.talk.abstract[0..30] %></p>
+            </td>
 
-          <td>
-            <%= proposal.status %>
-          </td>
-        </tr>
+            <td>
+              <%= f.select "proposal[#{proposal.id}][status]", proposal.class.statuses.to_a, {selected: proposal.class.statuses[proposal.status]} %>
+
+            </td>
+          </tr>
+        <% end %>
       <% end %>
       </tbody>
     </table>
   </div>
 <% end %>
+<div id="transit_nav" class="p-4">
+  <%= submit_tag "保存", form: "proposal_list",class: "btn btn-danger transit_button" %>
+</div>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -2,6 +2,7 @@
   <h2><%= @conference.name %></h2>
   <ul>
     <li>カンファレンスステータス: <%= @conference.status %></li>
+    <li>CFPの結果公開: <%= @conference.cfp_result_visible ? '公開' : '非公開' %></li>
     <li>スピーカーのエントリー: <%= @conference.speaker_entry %></li>
     <li>参加者の申し込み: <%= @conference.attendee_entry %></li>
     <li>タイムテーブルを表示: <%= @conference.show_timetable %></li>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,4 +1,10 @@
 <%= render 'layout' do %>
+  <% flash.each do |message_type, message| %>
+    <div class="alert alert-info" role="alert">
+      <%= message %>
+    </div>
+  <% end %>
+
   <h2><%= @conference.name %></h2>
   <ul>
     <li>カンファレンスステータス: <%= @conference.status %></li>

--- a/app/views/speaker_dashboards/show.html.erb
+++ b/app/views/speaker_dashboards/show.html.erb
@@ -17,6 +17,7 @@
                 <%= talk.title %>
                 <%= link_to '(Public Session Page)', talk_path(id: talk.id) %>
               </h5>
+              受付状況: <%= proposal_status(talk.proposal) %>
               <% if talk.talk_category %>
               <h6 class="card-subtitle mb-2 text-muted"><%= talk.talk_category.name %> / <%= talk.talk_time.time_minutes %>分</h6>
               <% end %>

--- a/app/views/speaker_dashboards/show.html.erb
+++ b/app/views/speaker_dashboards/show.html.erb
@@ -17,7 +17,9 @@
                 <%= talk.title %>
                 <%= link_to '(Public Session Page)', talk_path(id: talk.id) %>
               </h5>
-              受付状況: <%= proposal_status(talk.proposal) %>
+              <% if talk.proposal.present? %>
+                受付状況: <%= proposal_status(talk.proposal) %>
+              <% end %>
               <% if talk.talk_category %>
               <h6 class="card-subtitle mb-2 text-muted"><%= talk.talk_category.name %> / <%= talk.talk_time.time_minutes %>分</h6>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       get 'export_speakers' => 'speakers#export_speakers'
       get 'export_profiles' => 'profiles#export_profiles'
       resources :talks, only: [:index]
+      resources :proposals, only: [:index]
       resources :videos, only: [:index]
       resources :timetables, only: [:index]
       resource :timetable, only: [:update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
       post 'close_timetable' => 'timetables#close'
       get 'preview_timetable' => 'timetables#preview'
       put 'talks' => 'talks#update_talks'
+      put 'proposals' => 'proposals#update_proposals'
       post 'bulk_insert_talks' => 'talks#bulk_insert_talks'
       post 'bulk_insert_talks_speaker' => 'talks#bulk_insert_talks_speaker'
       resources :tracks, only: [:index]

--- a/db/migrate/20210216095643_update_columns_to_chat_messages.rb
+++ b/db/migrate/20210216095643_update_columns_to_chat_messages.rb
@@ -1,5 +1,5 @@
 class UpdateColumnsToChatMessages < ActiveRecord::Migration[6.0]
-  def change
+  def up
     remove_foreign_key :chat_messages, :talks
     remove_index :chat_messages, :talk_id
     remove_reference :chat_messages, :talk, index: true
@@ -10,5 +10,12 @@ class UpdateColumnsToChatMessages < ActiveRecord::Migration[6.0]
 
     add_column :chat_messages, :room_type, :string
     add_column :chat_messages, :room_id, :bigint
+  end
+
+  def down
+    remove_column :chat_messages, :room_id
+
+    add_column :chat_messages, :booth_id, :bigint
+    add_column :chat_messages, :talk_id, :bigint
   end
 end

--- a/db/migrate/20210607093009_create_proposals.rb
+++ b/db/migrate/20210607093009_create_proposals.rb
@@ -8,13 +8,6 @@ class CreateProposals < ActiveRecord::Migration[6.0]
       t.timestamps
     end
 
-    create_table :proposals_speakers do |t|
-      t.integer :proposal_id
-      t.integer :speaker_id
-
-      t.timestamps
-    end
-
     add_column :conferences, :cfp_result_visible, :boolean, default: false
   end
 end

--- a/db/migrate/20210607093009_create_proposals.rb
+++ b/db/migrate/20210607093009_create_proposals.rb
@@ -1,0 +1,18 @@
+class CreateProposals < ActiveRecord::Migration[6.0]
+  def change
+    create_table :proposals do |t|
+      t.integer :talk_id, null: false, foreign_key: true
+      t.integer :conference_id, null: false, foreign_key: true
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+
+    create_table :proposals_speakers do |t|
+      t.integer :proposal_id
+      t.integer :speaker_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210607093009_create_proposals.rb
+++ b/db/migrate/20210607093009_create_proposals.rb
@@ -14,5 +14,7 @@ class CreateProposals < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+
+    add_column :conferences, :cfp_result_visible, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2021_06_07_093009) do
     t.integer "speaker_entry"
     t.integer "attendee_entry"
     t.integer "show_timetable"
+    t.boolean "cfp_result_visible", default: false
     t.index ["status"], name: "index_conferences_on_status"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_30_020119) do
+ActiveRecord::Schema.define(version: 2021_06_07_093009) do
 
   create_table "access_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
@@ -157,6 +157,21 @@ ActiveRecord::Schema.define(version: 2021_05_30_020119) do
     t.string "item_name"
     t.json "params"
     t.index ["conference_id"], name: "index_proposal_item_configs_on_conference_id"
+  end
+
+  create_table "proposals", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "talk_id", null: false
+    t.integer "conference_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "proposals_speakers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "proposal_id"
+    t.integer "speaker_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "registered_talks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -168,13 +168,6 @@ ActiveRecord::Schema.define(version: 2021_06_07_093009) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "proposals_speakers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "proposal_id"
-    t.integer "speaker_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "registered_talks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "profile_id"
     t.integer "talk_id"

--- a/lib/tasks/create_proposals_of_cicd2021.rake
+++ b/lib/tasks/create_proposals_of_cicd2021.rake
@@ -1,0 +1,21 @@
+namespace :db do
+  desc "create_proposals_of_cicd2021"
+  task create_proposals_of_cicd2021: :environment do
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    Rails.logger.level = Logger::DEBUG
+
+    ActiveRecord::Base.transaction do
+      begin
+        conference = Conference.find_by(abbr: 'cicd2021')
+        conference.talks.each do |talk|
+          if talk.proposal.nil?
+            proposal = Proposal.new(conference_id: conference.id, talk_id: talk.id, status: 0)
+            proposal.save!
+          end
+        end
+      rescue => e
+        puts e
+      end
+    end
+  end
+end

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -41,6 +41,14 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
       speaker_entry { 0 }
     end
 
+    trait :cfp_result_visible do
+      cfp_result_visible { true }
+    end
+
+    trait :cfp_result_invisible do
+      cfp_result_visible { false }
+    end
+
     after(:build) do |conference|
       create(:day1)
       create(:day2)

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -6,5 +6,4 @@ FactoryBot.define do
     end
   end
 
-  factory :proposals_speakers, class: ProposalsSpeaker
 end

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :proposal, class: Proposal do
+    trait :with_cndt2021 do
+      conference_id { 1 }
+      status { 0 }
+    end
+  end
+
+  factory :proposals_speakers, class: ProposalsSpeaker
+end

--- a/spec/factories/speakers.rb
+++ b/spec/factories/speakers.rb
@@ -9,12 +9,32 @@ FactoryBot.define do
     job_title { 'job_title' }
     conference_id { 1 }
 
-    trait :with_talk1 do
+    trait :with_talk1_registered do
       after(:build) do |speaker|
         talk = FactoryBot.create(:talk1)
         speaker.talks << talk
         FactoryBot.create(:talks_speakers, {talk: talk, speaker: speaker})
-        proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk)
+        proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk, status: 0)
+        FactoryBot.create(:proposals_speakers, speaker: speaker, proposal: proposal)
+      end
+    end
+
+    trait :with_talk1_accepted do
+      after(:build) do |speaker|
+        talk = FactoryBot.create(:talk1)
+        speaker.talks << talk
+        FactoryBot.create(:talks_speakers, {talk: talk, speaker: speaker})
+        proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk, status: 1)
+        FactoryBot.create(:proposals_speakers, speaker: speaker, proposal: proposal)
+      end
+    end
+
+    trait :with_talk1_rejected do
+      after(:build) do |speaker|
+        talk = FactoryBot.create(:talk1)
+        speaker.talks << talk
+        FactoryBot.create(:talks_speakers, {talk: talk, speaker: speaker})
+        proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk, status: 2)
         FactoryBot.create(:proposals_speakers, speaker: speaker, proposal: proposal)
       end
     end

--- a/spec/factories/speakers.rb
+++ b/spec/factories/speakers.rb
@@ -8,7 +8,19 @@ FactoryBot.define do
     company { 'company' }
     job_title { 'job_title' }
     conference_id { 1 }
+
+    trait :with_talk1 do
+      after(:build) do |speaker|
+        talk = FactoryBot.create(:talk1)
+        speaker.talks << talk
+        FactoryBot.create(:talks_speakers, {talk: talk, speaker: speaker})
+        proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk)
+        FactoryBot.create(:proposals_speakers, speaker: speaker, proposal: proposal)
+      end
+    end
   end
+
+  factory :talks_speakers, class: TalksSpeaker
 
   factory :speaker_bob, class: Speaker do
     id { 2 }

--- a/spec/factories/speakers.rb
+++ b/spec/factories/speakers.rb
@@ -15,7 +15,6 @@ FactoryBot.define do
         speaker.talks << talk
         FactoryBot.create(:talks_speakers, {talk: talk, speaker: speaker})
         proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk, status: 0)
-        FactoryBot.create(:proposals_speakers, speaker: speaker, proposal: proposal)
       end
     end
 
@@ -25,7 +24,6 @@ FactoryBot.define do
         speaker.talks << talk
         FactoryBot.create(:talks_speakers, {talk: talk, speaker: speaker})
         proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk, status: 1)
-        FactoryBot.create(:proposals_speakers, speaker: speaker, proposal: proposal)
       end
     end
 
@@ -35,7 +33,6 @@ FactoryBot.define do
         speaker.talks << talk
         FactoryBot.create(:talks_speakers, {talk: talk, speaker: speaker})
         proposal = FactoryBot.create(:proposal, :with_cndt2021, talk: talk, status: 2)
-        FactoryBot.create(:proposals_speakers, speaker: speaker, proposal: proposal)
       end
     end
   end

--- a/spec/requests/speaker_dashboard_spec.rb
+++ b/spec/requests/speaker_dashboard_spec.rb
@@ -3,10 +3,40 @@ require 'rails_helper'
 describe SpeakerDashboardsController, type: :request do
   admin_userinfo = {userinfo: {info: {email: "alice@example.com"}, extra: {raw_info: {sub: "aaaa", "https://cloudnativedays.jp/roles" => ["CNDT2020-Admin"]}}}}
   describe "GET speaker_dashboards#show" do
-    context 'CNDT2020 is registered' do
-      before do
-        create(:cndt2020, :registered)
+
+    shared_examples_for :request_is_successful do
+      it "request is successful" do
+        get '/cndt2020/speaker_dashboard'
+        expect(response).to be_successful
+        expect(response).to have_http_status '200'
       end
+    end
+
+    shared_examples_for :response_includes_proposal_title_and_entry_status do |title, entry_status|
+      it "include information about proposal" do
+        get '/cndt2020/speaker_dashboard'
+        expect(response.body).to include title
+        expect(response.body).to include entry_status
+      end
+    end
+
+    shared_examples_for :response_does_not_include_proposal_title_and_entry_status do |title, entry_status|
+      it "include information about proposal" do
+        get '/cndt2020/speaker_dashboard'
+        expect(response.body).to_not include title
+        expect(response.body).to_not include entry_status
+      end
+    end
+
+    shared_examples_for :response_includes_edit_button do
+      it "include edit button " do
+        get '/cndt2020/speaker_dashboard'
+        expect(response.body).to include 'edit'
+      end
+    end
+
+    context 'CNDT2020 is registered' do
+      let!(:cndt2020) { create(:cndt2020, :registered) }
 
       describe "speaker doesn't logged in" do
         it "returns a success response with speaker dashboard page" do
@@ -37,13 +67,12 @@ describe SpeakerDashboardsController, type: :request do
             create(:speaker_alice)
           end
 
-          it "returns a success response with event top page" do
+          it "response includes header text" do
             get '/cndt2020/speaker_dashboard'
-            expect(response).to be_successful
-            expect(response).to have_http_status '200'
             expect(response.body).to include 'スピーカーダッシュボード'
-            expect(response.body).to include 'edit'
           end
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_includes_edit_button
         end
       end
     end
@@ -51,16 +80,98 @@ describe SpeakerDashboardsController, type: :request do
     context 'CNDT2020 is registered and speaker entry is enabled' do
       before do
         allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(admin_userinfo)
-        create(:cndt2020, :registered, :speaker_entry_enabled)
-        create(:speaker_alice)
       end
 
-      it "doesn't include information about video status" do
-        get '/cndt2020/speaker_dashboard'
-        expect(response).to be_successful
-        expect(response).to have_http_status '200'
-        expect(response.body).to_not include 'ビデオファイル提出状況'
-        expect(response.body).to include 'edit'
+      context 'CFP result is visible' do
+        before do
+          create(:cndt2020, :registered, :speaker_entry_enabled, :cfp_result_visible)
+        end
+
+        context "speaker doesn't have proposal" do
+          before do
+            create(:speaker_alice)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_does_not_include_proposal_title_and_entry_status, 'talk1', '受付状況'
+          it_should_behave_like :response_includes_edit_button
+        end
+
+        context "speaker has proposal and it is registered" do
+          before do
+            create(:speaker_alice, :with_talk1_registered)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_includes_proposal_title_and_entry_status, 'talk1', '受付状況: エントリー済み'
+          it_should_behave_like :response_includes_edit_button
+        end
+
+        context "speaker has proposal and it is accepted" do
+          before do
+            create(:speaker_alice, :with_talk1_accepted)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_includes_proposal_title_and_entry_status, 'talk1', '受付状況: 採択'
+          it_should_behave_like :response_includes_edit_button
+        end
+
+        context "speaker has proposal and it is rejected" do
+          before do
+            create(:speaker_alice, :with_talk1_rejected)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_includes_proposal_title_and_entry_status, 'talk1', '受付状況: 不採択'
+          it_should_behave_like :response_includes_edit_button
+        end
+      end
+
+      context 'CFP result is invisible' do
+        before do
+          create(:cndt2020, :registered, :speaker_entry_enabled, :cfp_result_invisible)
+        end
+
+        context "speaker doesn't have proposal" do
+          before do
+            create(:speaker_alice)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_does_not_include_proposal_title_and_entry_status, 'talk1', '受付状況'
+          it_should_behave_like :response_includes_edit_button
+        end
+
+        context "speaker has proposal and it is registered" do
+          before do
+            create(:speaker_alice, :with_talk1_registered)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_includes_proposal_title_and_entry_status, 'talk1', '受付状況: エントリー済み'
+          it_should_behave_like :response_includes_edit_button
+        end
+
+        context "speaker has proposal and it is accepted" do
+          before do
+            create(:speaker_alice, :with_talk1_accepted)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_includes_proposal_title_and_entry_status, 'talk1', '受付状況: エントリー済み'
+          it_should_behave_like :response_includes_edit_button
+        end
+
+        context "speaker has proposal and it is rejected" do
+          before do
+            create(:speaker_alice, :with_talk1_rejected)
+          end
+
+          it_should_behave_like :request_is_successful
+          it_should_behave_like :response_includes_proposal_title_and_entry_status, 'talk1', '受付状況: エントリー済み'
+          it_should_behave_like :response_includes_edit_button
+        end
       end
     end
   end


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast-kanban/issues/32

* Proposalsテーブルを追加。Statusカラムでプロポーザルの採択・非採択をコントロールする
* Conferenceテーブルにプロポーザルの採択結果を公開するかどうかのフラグを追加。proposalsで採択・非採択しても、こちらで公開しないとスピーカーからは見えない。
* CICD2021の既存の各TalkにProposalを追加するためのRakeタスクを追加。このPRをデプロイ後に手動でタスクを実行する。デプロイ後に追加されるTalkには自動的にProposalは作られる。

![image](https://user-images.githubusercontent.com/107187/121802229-52113a00-cc76-11eb-8af2-c0ea68cdf99d.png)
