### PR TITLE
スポンサーセッションかどうかわかるようにする

### DIFF
--- a/app/views/talks/partial_show/_col_talk_category_block.html.erb
+++ b/app/views/talks/partial_show/_col_talk_category_block.html.erb
@@ -18,5 +18,9 @@
     <% else %>
       <span class="difficulty non_archivable">アーカイブ視聴不可</span>
     <% end %>
+    &nbsp;
+    <% if talk.sponsor.present? %>
+      <span class="difficulty">スポンサーセッション</span>
+    <% end %>
   </div>
 </div>

--- a/app/views/timetable/_talk_category_difficulty.html.erb
+++ b/app/views/timetable/_talk_category_difficulty.html.erb
@@ -1,6 +1,9 @@
 <div class="category_difficulty">
-  <%  if talk.talk_difficulty.present? && talk.talk_difficulty_id != 4 && talk.talk_category_id != 18 %>
+  <% if talk.talk_difficulty.present? && talk.talk_difficulty_id != 4 && talk.talk_category_id != 18 %>
     <%= tag.span(talk_difficulty(talk).name, class: "difficulty difficulty_#{talk_difficulty(talk).id}") %>
   <% end %>
   <span class="difficulty category_<%= talk_category(talk).id %>"><%= talk_category(talk).name %></span>
+  <% if talk.sponsor.present? %>
+    <span class="difficulty">スポンサーセッション</span>
+  <% end %>
 </div>

--- a/app/views/timetable/_talk_category_difficulty.html.erb
+++ b/app/views/timetable/_talk_category_difficulty.html.erb
@@ -2,7 +2,9 @@
   <% if talk.talk_difficulty.present? && talk.talk_difficulty_id != 4 && talk.talk_category_id != 18 %>
     <%= tag.span(talk_difficulty(talk).name, class: "difficulty difficulty_#{talk_difficulty(talk).id}") %>
   <% end %>
-  <span class="difficulty category_<%= talk_category(talk).id %>"><%= talk_category(talk).name %></span>
+  <% if talk.talk_category.present? %>
+    <span class="difficulty category_<%= talk_category(talk).id %>"><%= talk_category(talk).name %></span>
+  <% end %>
   <% if talk.sponsor.present? %>
     <span class="difficulty">スポンサーセッション</span>
   <% end %>


### PR DESCRIPTION
スポンサーセッションの場合、それとわかるようにラベルを表示する。追加するのは以下。

- タイムテーブル
- セッションページ

https://github.com/cloudnativedaysjp/dreamkast/issues/713