### PR TITLE
admin画面細々修正

### DIFF
--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -6,7 +6,7 @@ class Admin::TalksController < ApplicationController
   before_action :is_admin?, :set_conference
 
   def index
-    @talks = @conference.talks.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference.talks.accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
     respond_to do |format|
       format.html
       format.csv do

--- a/app/controllers/admin/timetables_controller.rb
+++ b/app/controllers/admin/timetables_controller.rb
@@ -6,7 +6,7 @@ class Admin::TimetablesController < ApplicationController
   before_action :is_admin?, :set_conference, :set_profile
 
   def index
-    @talks = @conference.talks.where(show_on_timetable: true).order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference.talks.show_on_timetable.order('conference_day_id ASC, start_time ASC, track_id ASC')
     @tracks = Track.where(conference_id: @conference.id)
     @conference_form = ConferenceForm.new(conference: @conference)
     respond_to do |format|

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -39,6 +39,18 @@ class Talk < ApplicationRecord
     includes(:video).where(videos: { on_air: 1 })
   }
 
+  scope :show_on_timetable, -> {
+    includes(:proposal).where(show_on_timetable: true, proposals: { status: :accepted })
+  }
+
+  scope :accepted, -> {
+    includes(:proposal).where(proposals: { status: :accepted })
+  }
+
+  scope :rejected, -> {
+    includes(:proposal).where(proposals: { status: :rejected })
+  }
+
   def self.import(file)
     message = []
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -157,6 +157,10 @@ class Talk < ApplicationRecord
     # CICD2021は全セッション40分固定で、talk_timeを持たせていないため
     return 40 if conference.abbr == 'cicd2021'
 
+    # CNDT2021移行はセッションの時間をProposalItemで管理するので、ProposalItemにsession_timeがあればそこからセッション時間を取得して返す
+    session_time = proposal_items.find_by(label: 'session_time')
+    return ProposalItemConfig.find(session_time.params.to_i).params.split('min')[0].to_i if session_time
+
     talk_time.present? ? talk_time.time_minutes : 0
   end
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -154,6 +154,9 @@ class Talk < ApplicationRecord
   end
 
   def time
+    # CICD2021は全セッション40分固定で、talk_timeを持たせていないため
+    return 40 if conference.abbr == 'cicd2021'
+
     talk_time.present? ? talk_time.time_minutes : 0
   end
 

--- a/app/views/timetable/_timetable.html.erb
+++ b/app/views/timetable/_timetable.html.erb
@@ -37,7 +37,7 @@
               <span class="track_name">Track <%= talk.track.name %>&nbsp;</span><%= talk.start_time.strftime("%H:%M") %>-<%= talk.end_time.strftime("%H:%M") %><%= ' (アーカイブ視聴不可)' unless talk.video_published %></span>
             </h6>
 
-            <%= render 'talk_category_difficulty', talk: talk %>
+            <%= render 'timetable/talk_category_difficulty', talk: talk %>
 
             <h5><%= link_to talk.title, talk_path(id: talk.id), remote: true %></h5>
           </div>


### PR DESCRIPTION
- `/admin/timetables` にはacceptedなセッションのみ表示する
- `/admin/talks` にはacceptedなセッションのみ表示する
- `/admin/timetables` において、セッションの時間の取得方法を更新
  - CICD2021はProposalでセッション時間を取得しておらず、40min固定なのでそれを返すようにする
  - CNDT2021以降はセッション時間はProposalItemを使って管理しているので、ProposalItemに`session_time` のラベルを持つものがあれば使うようにする