### PR TITLE
CICD2021向け修正

### DIFF
--- a/app/controllers/sponsor_dashboards/speakers_controller.rb
+++ b/app/controllers/sponsor_dashboards/speakers_controller.rb
@@ -34,7 +34,7 @@ class SponsorDashboards::SpeakersController < ApplicationController
     @conference = Conference.find_by(abbr: params[:event])
     @sponsor = Sponsor.find(params[:sponsor_id])
 
-    @speaker_form = SpeakerForm.new(speaker_params, speaker: Speaker.new())
+    @speaker_form = SpeakerForm.new(speaker_params, speaker: Speaker.new(), conference: @conference)
     @speaker_form.sub = @current_user[:extra][:raw_info][:sub]
     @speaker_form.email = @current_user[:info][:email]
 
@@ -64,7 +64,7 @@ class SponsorDashboards::SpeakersController < ApplicationController
     @speaker = Speaker.find(params[:id])
     authorize @speaker
 
-    @speaker_form = SpeakerForm.new(speaker_params, speaker: @speaker, sponsor: @sponsor)
+    @speaker_form = SpeakerForm.new(speaker_params, speaker: @speaker, sponsor: @sponsor, conference: @conference)
     @speaker_form.sub = @current_user[:extra][:raw_info][:sub]
     @speaker_form.email = @current_user[:info][:email]
     # @speaker_form.load
@@ -117,6 +117,7 @@ class SponsorDashboards::SpeakersController < ApplicationController
   # Only allow a list of trusted parameters through.
   def speaker_params
     params.require(:speaker).permit(:name,
+                                    :name_mother_tongue,
                                     :sub,
                                     :email,
                                     :profile,
@@ -127,6 +128,20 @@ class SponsorDashboards::SpeakersController < ApplicationController
                                     :avatar,
                                     :conference_id,
                                     :additional_documents,
-                                    talks_attributes: [:id, :title, :abstract, :document_url, :conference_id, :_destroy, :talk_difficulty_id, :talk_time_id, :sponsor_session, expected_participants: [], execution_phases: []])
+                                    talks_attributes: talks_attributes)
+  end
+
+  def talks_attributes
+    attr= [:id, :title, :abstract, :document_url, :conference_id, :_destroy, :talk_category_id, :talk_difficulty_id, :talk_time_id, :sponsor_session]
+    h = {}
+    @conference.proposal_item_configs.map(&:label).uniq.each do |label|
+      conf = @conference.proposal_item_configs.find_by(label: label)
+      if conf.class.to_s == 'ProposalItemConfigCheckBox'
+        h[conf.label.pluralize.to_sym] = []
+      elsif conf.class.to_s == 'ProposalItemConfigRadioButton'
+        attr << conf.label.pluralize.to_sym
+      end
+    end
+    attr.append(h)
   end
 end

--- a/lib/tasks/fix_proposal_items_for_cicd2021.rake
+++ b/lib/tasks/fix_proposal_items_for_cicd2021.rake
@@ -1,0 +1,21 @@
+namespace :db do
+  desc "fix_proposal_items_for_cicd2021"
+  task fix_proposal_items_for_cicd2021: :environment do
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    Rails.logger.level = Logger::DEBUG
+
+    ActiveRecord::Base.transaction do
+      begin
+        Talk.where(conference_id: 3).each do |talk|
+          assumed_visitor = talk.proposal_items.find_by(label: 'assumed_visitor').params
+          talk.proposal_items.find_by(label: 'assumed_visitor').update!(params: assumed_visitor.select{|i| !i.to_i.zero?})
+
+          execution_phase= talk.proposal_items.find_by(label: 'execution_phase').params
+          talk.proposal_items.find_by(label: 'execution_phase').update!(params: execution_phase.select{|i| !i.to_i.zero?})
+        end
+      rescue => e
+        puts e
+      end
+    end
+  end
+end


### PR DESCRIPTION
- スポンサーダッシュボードからセッションを登録する際、一部の項目が保存されない問題を修正
  - CNDT2021のCFPオープンのため、ProposalItemを導入してカンファレンス毎にCFPの項目を動的に変更できるようにした。しかし、スポンサーセッションを登録するためのコントローラーを修正できていなかった。
- ProposalItem導入時にtalksテーブルの `expected_participants` と `execution_phases` をProposalItemにマイグレーションした。PropsalItemのparamに入るのはProposalItemConfigのidの配列でなければならないのだが、0が混ざっていてエラーになっていた。マイグレーション時に消さないといけなかったが考慮が漏れていた。