### PR TITLE
add form for video_id of Track

### DIFF
--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -10,9 +10,13 @@ class Admin::TracksController < ApplicationController
   end
 
   def update_tracks
+    track = Track.find(params[:track][:id])
+    track.video_id = params[:track][:video_id]
+
     respond_to do |format|
-      TalksHelper.update_talks(@conference, params[:video])
-      format.js
+      if track.save && TalksHelper.update_talks(@conference, params[:video])
+        format.js
+      end
     end
   end
   private

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -9,7 +9,6 @@ module TalksHelper
         video.talk_id = talk.id
       end
       video.video_id = value[:video_id]
-      video.slido_id = value[:slido_id]
       if value[:on_air]
         video.on_air = true
       else

--- a/app/views/admin/talks/index.html.erb
+++ b/app/views/admin/talks/index.html.erb
@@ -50,7 +50,6 @@
         <th scope="col">Time</th>
         <th scope="col">Video File</th>
         <th scope="col">Vimeo ID</th>
-        <th scope="col">Sli.do ID</th>
         <th scope="col">On Air</th>
       </tr>
       </thead>
@@ -83,10 +82,6 @@
             <td>
               <% video_id = talk.video ? talk.video.video_id : nil %>
               <%= text_field_tag "video[#{talk.id}][video_id]", video_id,placeholder: "vimeo id", size: "9" %>
-            </td>
-            <td>
-              <% slido_id = talk.video ? talk.video.slido_id : nil %>
-              <%= text_field_tag "video[#{talk.id}][slido_id]", slido_id ,placeholder: "sli.do id", size: "8" %>
             </td>
             <td class="on_air_group btn-group-toggle">
               <% if talk.video %>

--- a/app/views/admin/tracks/_tracks_nav.html.erb
+++ b/app/views/admin/tracks/_tracks_nav.html.erb
@@ -11,7 +11,8 @@
     <% talks = Talk.where(conference_id: conference.id, conference_day_id: conference_day.id, track_id: track.id).order('conference_day_id ASC, start_time ASC, track_id ASC') %>
     <div class="tab-pane fade show <%= index == 0 ? 'active' : '' %>" id="nav-<%= conference_day.date %>-<%= track.number %>" role="tabpanel" aria-labelledby="nav-<%= conference_day.date %>-<%= track.number %>-tab">
       <%= form_with(url: admin_tracks_path, id: "talk_list_#{conference_day.date}_#{track.number}", method: "put", class: "talk_list_form") do |f| %>
-        Track Video ID: <%= text_field_tag "track[video_id]", track.video_id, placeholder: "vimeo id", size: "9" %>
+        Track Video ID: <%= text_field_tag "track[video_id]", track.video_id, placeholder: "vimeo id", size: "9" %> <% if track.video_id != '' %>( <%= link_to "link", "https://player.vimeo.com/video/#{track.video_id}" %>  ) <% end %>
+
         <%= hidden_field_tag "track[id]", track.id %>
 
         <table class="table table-striped talks_table" >
@@ -33,7 +34,11 @@
               <td><h5><%= talk.title %></h5></td>
               <td>
                 <% video_id = talk.video ? talk.video.video_id : nil %>
-                <%= text_field_tag "video[#{talk.id}][video_id]", video_id,placeholder: "vimeo id", size: "9" %>
+                <%= text_field_tag "video[#{talk.id}][video_id]", video_id, placeholder: "vimeo id", size: "9" %>
+                <br>
+                <% if video_id != '' %>
+                  <%=link_to "link", "https://player.vimeo.com/video/#{video_id}" %>
+                <% end %>
               </td>
               <td>
                 <% slido_id = talk.video ? talk.video.slido_id : nil %>

--- a/app/views/admin/tracks/_tracks_nav.html.erb
+++ b/app/views/admin/tracks/_tracks_nav.html.erb
@@ -22,7 +22,6 @@
           <th scope="col">Speakers</th>
           <th scope="col">Title</th>
           <th scope="col">Vimeo ID</th>
-          <th scope="col">Sli.do ID</th>
           <th scope="col">On Air</th>
         </tr>
         </thead>
@@ -39,10 +38,6 @@
                 <% if video_id != '' %>
                   <%=link_to "link", "https://player.vimeo.com/video/#{video_id}" %>
                 <% end %>
-              </td>
-              <td>
-                <% slido_id = talk.video ? talk.video.slido_id : nil %>
-                <%= text_field_tag "video[#{talk.id}][slido_id]", slido_id ,placeholder: "sli.do id", size: "8" %>
               </td>
               <td class="on_air_group btn-group-toggle">
                 <% if talk.video %>

--- a/app/views/admin/tracks/_tracks_nav.html.erb
+++ b/app/views/admin/tracks/_tracks_nav.html.erb
@@ -11,6 +11,9 @@
     <% talks = Talk.where(conference_id: conference.id, conference_day_id: conference_day.id, track_id: track.id).order('conference_day_id ASC, start_time ASC, track_id ASC') %>
     <div class="tab-pane fade show <%= index == 0 ? 'active' : '' %>" id="nav-<%= conference_day.date %>-<%= track.number %>" role="tabpanel" aria-labelledby="nav-<%= conference_day.date %>-<%= track.number %>-tab">
       <%= form_with(url: admin_tracks_path, id: "talk_list_#{conference_day.date}_#{track.number}", method: "put", class: "talk_list_form") do |f| %>
+        Track Video ID: <%= text_field_tag "track[video_id]", track.video_id, placeholder: "vimeo id", size: "9" %>
+        <%= hidden_field_tag "track[id]", track.id %>
+
         <table class="table table-striped talks_table" >
         <thead>
         <tr>

--- a/app/views/admin/tracks/_tracks_nav.html.erb
+++ b/app/views/admin/tracks/_tracks_nav.html.erb
@@ -11,7 +11,7 @@
     <% talks = Talk.where(conference_id: conference.id, conference_day_id: conference_day.id, track_id: track.id).order('conference_day_id ASC, start_time ASC, track_id ASC') %>
     <div class="tab-pane fade show <%= index == 0 ? 'active' : '' %>" id="nav-<%= conference_day.date %>-<%= track.number %>" role="tabpanel" aria-labelledby="nav-<%= conference_day.date %>-<%= track.number %>-tab">
       <%= form_with(url: admin_tracks_path, id: "talk_list_#{conference_day.date}_#{track.number}", method: "put", class: "talk_list_form") do |f| %>
-        Track Video ID: <%= text_field_tag "track[video_id]", track.video_id, placeholder: "vimeo id", size: "9" %> <% if track.video_id != '' %>( <%= link_to "link", "https://player.vimeo.com/video/#{track.video_id}" %>  ) <% end %>
+        Track Video ID: <%= text_field_tag "track[video_id]", track.video_id, placeholder: "vimeo id", size: "9" %> <% if track.video_id != '' %>( <%= link_to "link", "https://player.vimeo.com/video/#{track.video_id}" %>  ) <% end %> <br>
 
         <%= hidden_field_tag "track[id]", track.id %>
 
@@ -56,11 +56,14 @@
           </tbody>
         </table>
 
+        ※ Track video ID は On Air 状態のセッションがUIで表示された時に使われる (ライブ)<br>
+        ※ 各セッションの Vimeo ID は Off Air 状態のセッションがUIで表示された時に使われる (アーカイブ)
         <div class="p-4 text-center">
           <%= f.submit('保存', class: "btn btn-danger transit_button" ) %>
           <br/><span> ※視聴者にも設定が配信されます</span>
         </div>
       <% end %>
+
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
fix https://github.com/cloudnativedaysjp/dreamkast/issues/798

- admin/tracksからtrackのvideo_idを設定可能にした
- video_idが設定されているとき、admin/tracksにvimeoへのリンクを表示するようにした
- sli.doはもう使っていないのでadmin/tracksとadmin/talksのフォームから削除した（過去イベントにはsli.doの情報が残っているのでDBからはまだ消さない）