### PR TITLE
ログインしてプロフィールを入力する前にイベントページ見るとエラーになる問題を修正

### DIFF
--- a/app/views/event/cicd2021_show.html.erb
+++ b/app/views/event/cicd2021_show.html.erb
@@ -58,7 +58,7 @@
                         --row-start: <%= row_start %>;
                         --row-end: <%= row_end  %>;">
                 <div class="content
-                            <%= 'checked' if @current_user && talks_checked?(talk.id) %>"
+                            <%= 'checked' if @current_user && @profile && talks_checked?(talk.id) %>"
                             talk_id="<%= talk.id %>"
                             track_number="<%= talk.track.number %>">
                   <h6>


### PR DESCRIPTION
profileがないとtalks_checked?がエラーになる。

c.f. https://github.com/cloudnativedaysjp/dreamkast/pull/804