### PR TITLE
カンファレンスのスコープでリソースを取得していない箇所を修正

### DIFF
--- a/app/channels/track_channel.rb
+++ b/app/channels/track_channel.rb
@@ -6,10 +6,4 @@ class TrackChannel < ApplicationCable::Channel
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end
-
-  def update
-    ActionCable.server.broadcast(
-      "track_channel", Video.on_air
-    )
-  end
 end

--- a/app/channels/waiting_channel.rb
+++ b/app/channels/waiting_channel.rb
@@ -6,10 +6,4 @@ class WaitingChannel < ApplicationCable::Channel
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end
-
-  def update
-    ActionCable.server.broadcast(
-      "waiting_channel", Video.on_air
-    )
-  end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -8,7 +8,7 @@ class AdminController < ApplicationController
     def show
         @session = session
         @conference = Conference.find_by(abbr: event_name)
-        @current = Video.on_air
+        @current = Video.on_air(@conference)
     end
 
     def accesslog

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -8,7 +8,7 @@ class TracksController < ApplicationController
     if @conference.abbr == "cndo2021" && @conference.opened?
       redirect_to  '/cndo2021/ui/'
     end
-    @current = Video.on_air
+    @current = Video.on_air(@conference)
     @tracks = Track.all
 
     @talks = Talk.eager_load(:talk_category, :talk_difficulty).all

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -9,25 +9,25 @@ class TracksController < ApplicationController
       redirect_to  '/cndo2021/ui/'
     end
     @current = Video.on_air(@conference)
-    @tracks = Track.all
+    @tracks = @conference.tracks
 
-    @talks = Talk.eager_load(:talk_category, :talk_difficulty).all
-    @talk_categories = TalkCategory.where(conference_id: @conference.id)
-    @talk_difficulties = TalkDifficulty.where(conference_id: @conference.id)
-    @booths = Booth.where(conference_id: @conference.id, published: true)
+    @talks = @conference.talks.eager_load(:talk_category, :talk_difficulty).all
+    @talk_categories = @conference.talk_categories
+    @talk_difficulties = @conference.talk_difficulties
+    @booths = @conference.booths.published
   end
 
   def waiting
-    @conference = Conference.find_by(abbr: event_name)
+    @conference = Conference.includes(:talks).find_by(abbr: event_name)
     if @conference.opened?
       redirect_to tracks_path
     end
 
-    @announcements = @conference.announcements.where(publish: true)
-    @talks = Talk.eager_load(:talk_category, :talk_difficulty).all
-    @talk_categories = TalkCategory.all
-    @talk_difficulties = TalkDifficulty.all
-    @booths = Booth.where(conference_id: @conference.id, published: true)
+    @announcements = @conference.announcements.published
+    @talks = @conference.talks.eager_load(:talk_category, :talk_difficulty).all
+    @talk_categories = @conference.talk_categories
+    @talk_difficulties = @conference.talk_difficulties
+    @booths = @conference.booths.published
   end
 
   def reload

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -17,7 +17,7 @@ module TalksHelper
       video.save
     end
     ActionCable.server.broadcast(
-      "track_channel", Video.on_air
+      "track_channel", Video.on_air(conference)
     )
     ActionCable.server.broadcast(
       "on_air_#{conference.abbr}", Video.on_air_v2

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,3 +1,7 @@
 class Announcement < ApplicationRecord
   belongs_to :conference
+
+  scope :published, -> {
+    where(publish: true)
+  }
 end

--- a/app/models/booth.rb
+++ b/app/models/booth.rb
@@ -25,4 +25,8 @@ class Booth < ApplicationRecord
   def key_image_urls
     sponsor.sponsor_attachment_key_images.present? ? sponsor.sponsor_attachment_key_images.map{|image| image.file_url} : []
   end
+
+  scope :published, -> {
+    where(published: true)
+  }
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -4,7 +4,7 @@ class Video < ApplicationRecord
   belongs_to :talk
 
   def self.on_air(conference)
-    current = conference.talks.accepted.map(&:video).select(&:on_air)
+    current = conference.talks.accepted.map(&:video).compact.select(&:on_air)
     list = {}
     list['current'] = []
     current.each do |video|

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -3,8 +3,8 @@ class Video < ApplicationRecord
 
   belongs_to :talk
 
-  def self.on_air
-    current = Video.where(on_air: true)
+  def self.on_air(conference)
+    current = conference.talks.accepted.map(&:video).select(&:on_air)
     list = {}
     list['current'] = []
     current.each do |video|

--- a/app/views/event/cicd2021_show.html.erb
+++ b/app/views/event/cicd2021_show.html.erb
@@ -58,7 +58,7 @@
                         --row-start: <%= row_start %>;
                         --row-end: <%= row_end  %>;">
                 <div class="content
-                            <%= 'checked' if @current_user && talks_checked?(talk.id) %>"
+                            <%= 'checked' if @current_user && @profile && talks_checked?(talk.id) %>"
                             talk_id="<%= talk.id %>"
                             track_number="<%= talk.track.number %>">
                   <h6>


### PR DESCRIPTION
- Video.on_airが全video見ていたのをカンファレンスを渡してその下のものだけに変更
  - 関連して使っていないであろうActionCableのupdateメソッドを削除
- tracks_controllerで全リソース取得していたのでカンファレンスに関連するものだけ取得するように変更