### PR TITLE
チャットの投稿時間がおかしくなる問題を修正

### DIFF
--- a/app/jobs/chat_message_broadcast_job.rb
+++ b/app/jobs/chat_message_broadcast_job.rb
@@ -11,8 +11,9 @@ class ChatMessageBroadcastJob < ApplicationJob
       body: msg.body,
       roomType: msg.room_type,
       roomId: msg.room_id,
-      messageType: msg.message_type,
-      replyTo: msg.parent_id
+      createdAt: msg.created_at.utc,
+      replyTo: msg.parent_id,
+      messageType: msg.message_type
     }
   end
 end


### PR DESCRIPTION
action cableで送っているチャットメッセージにcreated_atが含まれておらず、レンダリング時に投稿時間がおかしくなっていた。
APIのレスポンスには含まれているため( https://github.com/cloudnativedaysjp/dreamkast/blob/main/app/views/api/v1/chat_messages/index.json.jbuilder#L9 )、リロードすると正しく表示される。

fix https://github.com/cloudnativedaysjp/dreamkast-ui/issues/156