### PR TITLE
Fix flag

### DIFF
--- a/app/views/event/partial/_speaker_entry_button.html.erb
+++ b/app/views/event/partial/_speaker_entry_button.html.erb
@@ -1,6 +1,8 @@
 <% if display_speaker_dashboard_link? %>
   <p class="text-white display-4">
+    <% if @conference.speaker_entry_enabled? %>
     登壇者募集中!
+    <% end %>
     <% if @conference.abbr == 'cndt2021' %>
     <br/>
     CFP締切 9/8


### PR DESCRIPTION
フラグ読み間違えていて、CFP締め切り後もCFP応募者に「登壇者募集中」の表示が出てしまっていた