### PR TITLE
メールアドレスの比較時に大文字・小文字を区別しないようにする

### DIFF
--- a/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
@@ -16,7 +16,7 @@ class SponsorDashboards::SponsorProfilesController < ApplicationController
           redirect_to sponsor_dashboards_path
         end
 
-        unless @sponsor.speaker_emails&.downcase.include?(@current_user[:info][:email])
+        unless @sponsor.speaker_emails && @sponsor.speaker_emails.downcase.include?(@current_user[:info][:email])
           redirect_to "/#{@conference.abbr}/sponsor_dashboards/login", notice: 'ログインが許可されていません'
         end
       end

--- a/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
@@ -16,7 +16,7 @@ class SponsorDashboards::SponsorProfilesController < ApplicationController
           redirect_to sponsor_dashboards_path
         end
 
-        unless @sponsor.speaker_emails&.include?(@current_user[:info][:email])
+        unless @sponsor.speaker_emails&.downcase.include?(@current_user[:info][:email])
           redirect_to "/#{@conference.abbr}/sponsor_dashboards/login", notice: 'ログインが許可されていません'
         end
       end

--- a/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
@@ -16,7 +16,7 @@ class SponsorDashboards::SponsorProfilesController < ApplicationController
           redirect_to sponsor_dashboards_path
         end
 
-        unless @sponsor.speaker_emails && @sponsor.speaker_emails.downcase.include?(@current_user[:info][:email])
+        unless @sponsor.speaker_emails && @sponsor.speaker_emails.downcase.include?(@current_user[:info][:email].downcase)
           redirect_to "/#{@conference.abbr}/sponsor_dashboards/login", notice: 'ログインが許可されていません'
         end
       end


### PR DESCRIPTION
スポンサーのスピーカーリストに記入されたメールアドレスに大文字が混ざっている場合、小文字にして比較しないと異なるアドレスと判定することがある。しかし、一般的には大文字・小文字は区別しないので小文字に変換して比較する。