### PR TITLE
improve notifying number of registrants

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -29,4 +29,8 @@ class Conference < ApplicationRecord
   scope :previous, -> {
     merge(where(status: 2).or(where(status: 3)))
   }
+
+  scope :unarchived, -> {
+    merge(where(status: 0).or(where(status: 1)).or(where(status: 2)))
+  }
 end

--- a/lib/tasks/post_number_of_registrants_to_slack.rake
+++ b/lib/tasks/post_number_of_registrants_to_slack.rake
@@ -7,7 +7,7 @@ namespace :util do
     Rails.logger.level = Logger::DEBUG
 
     url = ENV['SLACK_WEBHOOK_URL']
-    conferences = Conference.where(status: 0).or(Conference.where(status: 1)).or(Conference.where(status: 2))
+    conferences = Conference.unarchived
 
     conferences.each do |conference|
       slack = Slack::Incoming::Webhooks.new(url)


### PR DESCRIPTION
- registered, open, closedのカンファレンスについて全て通知する用に変更
- 前日のstatsを取得する際にカンファレンスIDを含めて取得するように変更