### PR TITLE
Add team page

### DIFF
--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -1,0 +1,24 @@
+class Admin::TeamsController < ApplicationController
+  include SecuredAdmin
+  include LogoutHelper
+
+  def show
+    @admin_profiles = @conference.admin_profiles.where(show_on_team_page: true).order(name: 'ASC')
+  end
+
+  def update
+    ActiveRecord::Base.transaction do
+      params['team'].each do |k, v|
+        admin_profile = AdminProfile.find(k)
+        if admin_profile.present?
+          admin_profile.show_on_team_page = v
+          admin_profile.save!
+        end
+      end
+    end
+
+    redirect_to admin_team_path
+  rescue => e
+    redirect_to admin_team_path, notice: "更新に失敗しました: #{e}"
+  end
+end

--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -3,7 +3,7 @@ class Admin::TeamsController < ApplicationController
   include LogoutHelper
 
   def show
-    @admin_profiles = @conference.admin_profiles.where(show_on_team_page: true).order(name: 'ASC')
+    @admin_profiles = @conference.admin_profiles.order(name: 'ASC')
   end
 
   def update

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -2,6 +2,6 @@ class TeamsController < ApplicationController
 
   before_action :set_conference
   def show
-    @admin_profiles = @conference.admin_profiles.order(name: 'ASC')
+    @admin_profiles = @conference.admin_profiles.where(show_on_team_page: true).order(name: 'ASC')
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,7 @@
+class TeamsController < ApplicationController
+
+  before_action :set_conference
+  def show
+    @admin_profiles = @conference.admin_profiles.order(name: 'ASC')
+  end
+end

--- a/app/javascript/stylesheets/_team.scss
+++ b/app/javascript/stylesheets/_team.scss
@@ -1,0 +1,5 @@
+div#team-members {
+  width: 70%;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -13,5 +13,6 @@
 @import "./_booth.scss";
 @import "./_links.scss";
 @import "./_talks.scss";
+@import "./_team.scss";
 // Import custom utilities
 @import "./_utilities.scss";

--- a/app/javascript/stylesheets/cndt2021.scss
+++ b/app/javascript/stylesheets/cndt2021.scss
@@ -13,6 +13,7 @@
 @import "./_booth.scss";
 @import "./_links.scss";
 @import "./_talks.scss";
+@import "./_team.scss";
 @import "./cndt2021/_cndt2021.scss";
 // Import custom utilities
 @import "./cndt2021/_utilities.scss";

--- a/app/models/admin_profile.rb
+++ b/app/models/admin_profile.rb
@@ -1,5 +1,26 @@
 class AdminProfile < ApplicationRecord
+  include ActionView::Helpers::UrlHelper
   include AvatarUploader::Attachment(:avatar)
 
   belongs_to :conference
+
+  def has_avatar?
+    ! self.avatar_url.nil?
+  end
+
+  def avatar_or_dummy_url
+    if has_avatar?
+      return avatar_url
+    else
+      return 'dummy.png'
+    end
+  end
+
+  def twitter_link
+    link_to ActionController::Base.helpers.image_tag("Twitter_Social_Icon_Circle_Color.png", width: 20), "https://twitter.com/#{twitter_id}" if twitter_id.present?
+  end
+
+  def github_link
+    link_to ActionController::Base.helpers.image_tag("GitHub-Mark-64px.png", width: 20), "https://github.com/#{github_id}" if github_id.present?
+  end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -21,6 +21,7 @@ class Conference < ApplicationRecord
   has_many :proposal_item_configs
   has_many :profiles
   has_many :stats_of_registrants
+  has_many :admin_profiles
 
   scope :upcoming, -> {
     merge(where(status: 0).or(where(status: 1)))

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -19,5 +19,6 @@
     <%= render 'admin/nav_item', name: 'Booths', path: admin_booths_path, active: controller_name == 'booths' || action_name == 'show_booth' %>
     <%= render 'admin/nav_item', name: 'Debug', path: admin_debug_path, active: action_name == 'debug' %>
     <%= render 'admin/nav_item', name: 'Edit Admin Profile', path: edit_admin_admin_profile_path(id: @admin_profile), active: action_name == 'administrators' %>
+    <%= render 'admin/nav_item', name: 'Edit Team Page', path: admin_team_path, active: controller_name == 'teams' %>
   </ul>
 </nav>

--- a/app/views/admin/teams/show.html.erb
+++ b/app/views/admin/teams/show.html.erb
@@ -1,0 +1,17 @@
+<%= render 'admin/layout' do %>
+  <%= form_with(url: admin_team_path, local: true, id: "team", method: "put") do |f| %>
+    <% @admin_profiles.each do |admin_profile| %>
+      <div class="form-row form-group">
+        <div class="col-12 col-md-6">
+          <%= hidden_field_tag "team[#{admin_profile.id}]", false %>
+          <%= check_box_tag "team[#{admin_profile.id}]", true, admin_profile.show_on_team_page %>
+          <%= f.label "team[#{admin_profile.id}]", "#{admin_profile.name} (#{admin_profile.email})" %><br>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>
+
+<div id="transit_nav" class="p-4">
+  <%= submit_tag "保存", form: "team",class: "btn btn-danger transit_button" %>
+</div>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -35,16 +35,19 @@
               </div>
             </li>
 
-            <% if event_name == 'cndt2020' %>
+            <% case event_name %>
+            <% when 'cndt2020' %>
               <li class="nav-item"><%= link_to "Speakers", speakers_path, class: "nav-link js-scroll-trigger" %></li>
               <li class="nav-item"><%= link_to "Discussion Board", discussion_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
               <li class="nav-item"><%= link_to "Kontest", kontest_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
               <li class="nav-item"><%= link_to "Links", links_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false} %></li>
-            <% end %>
-            <% if event_name == 'cicd2021' %>
+            <% when 'cicd2021' %>
               <li class="nav-item"><%= link_to "Discussion Board", discussion_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
               <li class="nav-item"><%= link_to "Hands-on (Co-located)", hands_on_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
+            <% when 'cndt2021' %>
+              <li class="nav-item"><%= link_to "Team", team_path, class: "nav-link js-scroll-trigger" %></li>
             <% end %>
+
           <% end %>
         <% end %>
         <li class="nav-item dropdown">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,0 +1,19 @@
+<div class="container white_background">
+  <h1 class="my-3 text-center">Team</h1>
+
+  <div id="team-members" class="row row-cols-1 row-cols-sm-3">
+
+    <% @admin_profiles.each do |admin_profile| %>
+      <div class="col mb-4">
+        <div class="card">
+          <%= image_tag admin_profile.avatar_or_dummy_url, class: 'card-img-top' %>
+          <div class="card-body">
+            <h5 class="card-title"><%= admin_profile.name %></h5>
+            <p class="card-text"><%= admin_profile.twitter_link %> <%= admin_profile.github_link %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,8 @@ Rails.application.routes.draw do
       put 'video_registrations' => 'video_registrations#bulk_update'
     end
 
+    get '/team' => 'teams#show'
+
     get '/speakers/entry' => 'speaker_dashboard/speakers#new'
     resources :speakers, only: [:index, :show]
     get '/speaker_dashboard' => 'speaker_dashboards#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
       put 'tracks' => 'tracks#update_tracks'
       resources :attachments, only: [:show]
       put 'video_registrations' => 'video_registrations#bulk_update'
+      get 'team' => 'teams#show'
+      put 'team' => 'teams#update'
     end
 
     get '/team' => 'teams#show'

--- a/db/migrate/20210923023142_add_show_on_teams_page_columns_to_admin_profile.rb
+++ b/db/migrate/20210923023142_add_show_on_teams_page_columns_to_admin_profile.rb
@@ -1,0 +1,5 @@
+class AddShowOnTeamsPageColumnsToAdminProfile < ActiveRecord::Migration[6.0]
+  def change
+    add_column :admin_profiles, :show_on_team_page, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_21_044345) do
+ActiveRecord::Schema.define(version: 2021_09_23_023142) do
 
   create_table "access_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2021_09_21_044345) do
     t.text "avatar_data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "show_on_team_page"
     t.index ["conference_id"], name: "index_admin_profiles_on_conference_id"
   end
 


### PR DESCRIPTION
- `cndt2021/team` にメンバー情報を表示できるようにする
  - 今回はメンバーのロールは考慮せず、名前順で表示
- 表示するのは AdminProfileの `name` と `twitter_id` 、 `github_id` 、 `avator`
  - adminとして管理者ページにログインして `cndt2021/admin/admin_profiles/1/edit` から管理者プロフィールを登録するする必要がある
- 表示するかどうかを AdminProfile の `show_on_team_page` で制御する ( `cndt2021/admin/team` から編集 )

fix https://github.com/cloudnativedaysjp/dreamkast/issues/745

![image](https://user-images.githubusercontent.com/107187/134448661-f91a0d8f-c4ac-4d32-b7d0-cd4cffe960b8.png)
