### PR TITLE
Add mail-worker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,34 @@ services:
       - "3000:3000"
     depends_on:
       - db
+  mail-worker:
+    build: .
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue mail"
+    environment:
+      RAILS_ENV: production
+      NODE_ENV: production
+      SENTRY_DSN: ${SENTRY_DSN}
+      S3_REGION: ap-northeast-1
+      S3_BUCKET: ${S3_BUCKET}
+      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
+      AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_REGION: ap-northeast-1
+      MYSQL_HOST: db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: dreamkast
+      REDIS_URL: redis://redis:6379
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      SQS_MAIL_QUEUE_URL: ${SQS_MAIL_QUEUE_URL}
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /app/tmp
+    depends_on:
+      - db
   db:
     image: mysql:8
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,35 +3,7 @@ services:
   app:
     build: .
     entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed_fu && ./entrypoint.sh"
-    environment:
-      RAILS_ENV: production
-      NODE_ENV: production
-      SENTRY_DSN: ${SENTRY_DSN}
-      S3_REGION: ap-northeast-1
-      S3_BUCKET: ${S3_BUCKET}
-      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
-      AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET}
-      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      MYSQL_HOST: db
-      MYSQL_USER: user
-      MYSQL_PASSWORD: password
-      MYSQL_DATABASE: dreamkast
-      REDIS_URL: redis://redis:6379
-      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
-    tty: true
-    stdin_open: true
-    tmpfs:
-      - /app/tmp
-    ports:
-      - "3000:3000"
-    depends_on:
-      - db
-  mail-worker:
-    build: .
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue mail"
-    environment:
+    environment: &dkenv
       RAILS_ENV: production
       NODE_ENV: production
       SENTRY_DSN: ${SENTRY_DSN}
@@ -50,6 +22,19 @@ services:
       REDIS_URL: redis://redis:6379
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
       SQS_MAIL_QUEUE_URL: ${SQS_MAIL_QUEUE_URL}
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /app/tmp
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+  mail-worker:
+    build: .
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue mail"
+    environment:
+      <<: *dkenv
     tty: true
     stdin_open: true
     tmpfs:


### PR DESCRIPTION
Docker composeでmail-workerを立ち上げられるように。

利用する際には.envに `SQS_MAIL_QUEUE_URL=https://sqs.ap-northeast-1.amazonaws.com/607167088920/devMailQueue.fifo` (あるいは利用したSQS URL)を追記して利用する