### PR TITLE
Team ページで認証されてないように見える不具合の修正

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,13 @@
 class TeamsController < ApplicationController
-
+  include Secured
   before_action :set_conference
+
+  def logged_in_using_omniauth?
+    if session[:userinfo].present?
+      @current_user = session[:userinfo]
+    end
+  end
+
   def show
     @admin_profiles = @conference.admin_profiles.where(show_on_team_page: true).order(name: 'ASC')
   end


### PR DESCRIPTION
## 現象
ログインした状態で Team ページにアクセスするとユーザアイコンが表示されず、代わりにログインボタンが有効化されている

## 原因
view に `@current_user` が渡されていなかった

## 対応
Controller で Secured を include した  
非ログイン状態でも見れる方が良いと思ったので `logged_in_using_amniauth?` メソッドをリダイレクトしないようにオーバーライドした