### PR TITLE
fix query

### DIFF
--- a/lib/tasks/post_left_idea_issues_to_slack.rake
+++ b/lib/tasks/post_left_idea_issues_to_slack.rake
@@ -19,7 +19,7 @@ namespace :util do
     payload = "作成後 #{5} 日以上アサインが決まっていない idea issueがあります〜〜\n担当チーム、担当者をアサインしたらideaラベルを外してね。"
     attachments = []
 
-    result = client.search_issues("repo:cloudnativedaysjp/cndt2021 is:issue is:open created:>#{created} label:idea")
+    result = client.search_issues("repo:cloudnativedaysjp/cndt2021 is:issue is:open created:<#{created} label:idea no:assignee")
     result.items.each do |issue|
       attachments << {
         title: "#{issue.number} #{issue.title}",


### PR DESCRIPTION
- 作成日が任意の日付より `前` のissueを検索したいので、 `<` を使う必要があった
- AssigneesがいないIssueのみに絞る