### PR TITLE
セッション一覧の表示周り修正

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -18,9 +18,9 @@ class TalksController < ApplicationController
   def index
     @conference = Conference.find_by(abbr: event_name)
     @talks = if @conference.cfp_result_visible
-               @conference.talks.joins("INNER JOIN conference_days ON talks.conference_day_id = conference_days.id").includes(:proposal).where(show_on_timetable: true, proposals: { status: :accepted }).order('conference_days.date ASC').order('talks.start_time ASC')
+               @conference.talks.joins("LEFT JOIN conference_days ON talks.conference_day_id = conference_days.id").includes(:proposal).where(show_on_timetable: true, proposals: { status: :accepted }).order('conference_days.date ASC').order('talks.start_time ASC')
              else
-               @conference.talks.joins("INNER JOIN conference_days ON talks.conference_day_id = conference_days.id").includes(:proposal).where(show_on_timetable: true).order('conference_days.date ASC').order('talks.start_time ASC')
+               @conference.talks.joins("LEFT JOIN conference_days ON talks.conference_day_id = conference_days.id").includes(:proposal).where(show_on_timetable: true).order('conference_days.date ASC').order('talks.start_time ASC')
              end
   end
 

--- a/app/views/admin/talks/index.html.erb
+++ b/app/views/admin/talks/index.html.erb
@@ -64,7 +64,7 @@
             </td>
             <td><%= talk.track.present? ? talk.track.name : "" %></td>
             <td>
-              <%= talk.conference_day.date %>
+              <%= talk.conference_day&.date %>
               <% if talk.start_time.present? && talk.start_time.present? %>
                 <%= talk.start_time.strftime("%H:%M") + "-" + talk.end_time.strftime("%H:%M") %>
               <% end %>


### PR DESCRIPTION
- CFPの結果をオープンにした際、Talkがconference_day_idを持っていないと /talks に表示されない問題を修正
- admin/talks を開いた際、 Talkがconference_day_idを持っていないとエラーになる問題を修正

fix https://github.com/cloudnativedaysjp/dreamkast/issues/878