### PR TITLE
イベントページをリファイン

### DIFF
--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -6,10 +6,11 @@ class EventController < ApplicationController
 
   def show
     @conference = Conference
-                  .includes(sponsor_types: {sponsors: :sponsor_attachment_logo_image})
-                  .includes(conference_days: :talks)
+                  .includes(sponsor_types: [{sponsors: :sponsor_attachment_logo_image}, :sponsors_sponsor_types])
                   .order("sponsor_types.order ASC")
                   .find_by(abbr: event_name)
+    @talks = @conference.talks.accepted.includes(:talks_speakers, :speakers)
+
     render event_view
   end
 

--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -146,26 +146,23 @@ footer ul li {
 
 #sponsors {
     background-color: #FFF;
-}
-
-.sponsor-col {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.sponsor-logo {
-    width: 100%;
-    max-height: 80px;
-    object-fit: contain;
-}
-
-@media (max-width: 768px) {
+    .sponsor-col {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
     .sponsor-logo {
         width: 100%;
-        max-height: 70px;
-        max-width: 200px;
+        max-height: 80px;
         object-fit: contain;
+    }
+    @media (max-width: 768px) {
+        .sponsor-logo {
+            width: 100%;
+            max-height: 70px;
+            max-width: 200px;
+            object-fit: contain;
+        }
     }
 }
 

--- a/app/javascript/stylesheets/cndt2021/_cndt2021.scss
+++ b/app/javascript/stylesheets/cndt2021/_cndt2021.scss
@@ -2,11 +2,51 @@
     //height: 100vh;
     background: linear-gradient(-45deg, rgba(33, 33, 33, 0.6), rgba(100, 100, 100, 0.6));
     position: relative;
-}
-
-#cndt2021 .contents {
-    position: relative;
-    z-index: 2;
+    #about {
+        background-color: $white
+    }
+    #entry {
+        background-color: $white
+    }
+    .contents {
+        position: relative;
+        z-index: 2;
+    }
+    .btn-entry {
+        background-color: $umemurasaki;
+        color: white;
+        font-size: medium;
+        font-weight: lighter;
+        padding: 1em 2em;
+        @media (min-width: 576px) {
+            font-size: medium;
+        }
+        @media (min-width: 768px) {
+            font-size: large;
+        }
+        @media (min-width: 992px) {
+            font-size: x-large;
+        }
+        &:hover {
+            background-color: $usubeni;
+        }
+    }
+    #speakers {
+        background-color: $white;
+        @media (max-width: 576px) {
+            display: none;
+        }
+        ul {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            gap: 50px;
+        }
+        li {
+            list-style: none;
+            img {}
+        }
+    }
 }
 
 #cndt2021 #masthead {
@@ -15,14 +55,56 @@
     background-repeat: no-repeat;
     background-attachment: fixed;
     background-size: cover;
+    h1 {
+        font-size: 1.5em;
+    }
+    h2 {
+        font-size: 2em;
+    }
     .date {
-        font-size: 4em;
+        font-size: 3em;
         font-weight: lighter;
     }
-}
-
-#cndt2021 #about {
-    background-color: $gunjyo
+    @media (min-width: 576px) {
+        h1 {
+            font-size: 1.2em;
+        }
+        h2 {
+            font-size: 2em;
+        }
+        .date {
+            font-size: 3em;
+            font-weight: lighter;
+        }
+    }
+    @media (min-width: 768px) {
+        h1 {
+            font-size: 1.5em;
+            text-align: left;
+        }
+        h2 {
+            font-size: 3em;
+            text-align: left;
+        }
+        .date {
+            font-size: 4em;
+            font-weight: lighter;
+        }
+    }
+    @media (min-width: 992px) {
+        h1 {
+            font-size: 2.5em;
+            text-align: left;
+        }
+        h2 {
+            font-size: 5em;
+            text-align: left;
+        }
+        .date {
+            font-size: 5em;
+            font-weight: lighter;
+        }
+    }
 }
 
 // Speaker Dashboard

--- a/app/javascript/stylesheets/cndt2021/_variables.scss
+++ b/app/javascript/stylesheets/cndt2021/_variables.scss
@@ -10,13 +10,12 @@ $umemurasaki: #A8497A;
 $usubeni: #C299AE;
 $azurite: #254099;
 $matcha: #D4CDB0;
-
 $text: #444;
 //- Override primary color
 $primary: $gunjyo;
 $secondary: $umemurasaki;
 //- Override font system
-$font-family-sans-serif: "Merriweather Sans",
+$font-family-sans-serif: "din-2014",
 -apple-system,
 BlinkMacSystemFont,
 "Segoe UI",
@@ -29,7 +28,7 @@ sans-serif,
 "Segoe UI Emoji",
 "Segoe UI Symbol",
 "Noto Color Emoji";
-$font-family-serif: "Merriweather",
+$font-family-serif: "din-2014",
 -apple-system,
 BlinkMacSystemFont,
 "Segoe UI",

--- a/app/views/event/cndt2021_show.html.erb
+++ b/app/views/event/cndt2021_show.html.erb
@@ -4,20 +4,39 @@
     <section class="page-section" id="masthead">
       <div class="container">
         <div class="row h-100 align-items-center justify-content-center text-center">
-          <div class="col-lg-12 align-self-end">
+          <div class="col-12 col-sm-8 align-self-end">
+              <h2 class="text-white font-weight-bold">
+                <span class="font-weight-light">+Native</span><br />
+                ともに繋げる<br />
+                クラウド<br />
+                ネイティブの<br />
+                世界<br />
+              </h2>
               <h1 class="text-white font-weight-bold"><%= @conference.name %></h1>
-              <h2 class="text-white font-weight-bold"><%= @conference.theme %></h2>
-              <hr class="divider my-4" />
           </div>
-          <div class="col-lg-12 align-self-center">
-                <p class="text-white date">
-                  <%= @conference.conference_days.where(internal: false).map{|day| day.date.strftime("%m/%d")}.join("-") %>
-                </p>
-                <p class="text-white">オンライン開催 / 参加費無料</p>
-                <% if @conference.closed? || @conference.archived? %>
-                  <p class="text-white-75 font-weight-light">イベントは終了しました。ご参加いただきありがとうございました</p>
-                <% end %>
+          <div class="col-12 col-sm-4 align-self-end">
+              <p class="text-white date">
+                11/03<br/>
+                11/04
+              </p>
+              <p class="text-white">
+              オンライン開催<br/>
+              参加費無料
+              </p>
+              <p class="text-white">
+              #CNDT2021
+              </p>
+              <% if @conference.closed? || @conference.archived? %>
+                <p class="text-white-75 font-weight-light">イベントは終了しました。ご参加いただきありがとうございました</p>
+              <% end %>
           </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="page-section" id="entry">
+      <div class="container">
+        <div class="row h-100 align-items-center justify-content-center text-center">
           <div class="col-12 align-self-center">
             <% if @conference.closed? || @conference.archived?%>
               <%= render 'event/partial/buttons', conference: @conference %>
@@ -31,8 +50,40 @@
     </section>
 
     <!-- About-->
+    <section class="page-section" id="speakers">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-12 text-center">
+            <h2 class="text-black mt-0">Speakers</h2>
+            <hr class="divider  my-4" />
+            <ul class="">
+              <% @conference.talks.each do |talk| %>
+                <% talk.speakers.each do |speaker| %>
+                  <li>
+                    <%= image_tag speaker.avatar_or_dummy_url, :size => '100x100', class: "rounded-circle" %><br/>
+                    <%= speaker&.name %>
+                  </li>
+                <% end %>
+            <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- About-->
     <section class="page-section" id="about">
-      <%= render 'event/partial/about', conference: @conference %>
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-8 text-center">
+            <h2 class="text-black mt-0">About</h2>
+            <hr class="divider  my-4" />
+            <% @conference.about.split("\n").each do |line| %>
+              <p class="text-black-75 mb-4 text-center"><%= line %></p>
+            <% end %>
+          </div>
+        </div>
+      </div>
     </section>
 
     <% if @conference.show_sponsors %>

--- a/app/views/event/cndt2021_show.html.erb
+++ b/app/views/event/cndt2021_show.html.erb
@@ -49,7 +49,8 @@
       </div>
     </section>
 
-    <!-- About-->
+    <!-- Speakers -->
+    <% if (@conference.registered? || @conference.opened?) && @conference.attendee_entry_enabled? %>
     <section class="page-section" id="speakers">
       <div class="container">
         <div class="row justify-content-center">
@@ -57,19 +58,20 @@
             <h2 class="text-black mt-0">Speakers</h2>
             <hr class="divider  my-4" />
             <ul class="">
-              <% @conference.talks.each do |talk| %>
+              <% @talks.each do |talk| %>
                 <% talk.speakers.each do |speaker| %>
                   <li>
                     <%= image_tag speaker.avatar_or_dummy_url, :size => '100x100', class: "rounded-circle" %><br/>
                     <%= speaker&.name %>
                   </li>
                 <% end %>
-            <% end %>
+              <% end %>
             </ul>
           </div>
         </div>
       </div>
     </section>
+    <% end %>
 
     <!-- About-->
     <section class="page-section" id="about">

--- a/app/views/event/partial/_attendee_entry_button.html.erb
+++ b/app/views/event/partial/_attendee_entry_button.html.erb
@@ -1,10 +1,10 @@
 <% if (conference.registered? || conference.opened?) && conference.attendee_entry_enabled? %>
     <% if logged_in? && @profile.present? %>
-      <%= link_to 'ダッシュボード', dashboard_path, {method: :get, class: "btn btn-secondary btn-xl m-2 block" } %>
+      <%= link_to 'ダッシュボード', dashboard_path, {method: :get, class: "btn btn-entry btn-xl m-2 block" } %>
     <% else %>
-      <%= link_to '参加申し込み', registration_path, {method: :get, class: "btn btn-focus btn-xl m-2 block" } %>
+      <%= link_to '参加申し込み', registration_path, {method: :get, class: "btn btn-entry btn-xl m-2 block" } %>
     <% end %>
   <% if @conference.show_timetable_enabled? %>
-      <%= link_to 'タイムテーブル', timetables_path, {method: :get, class: "btn btn-secondary btn-xl m-2 block" } %>
+      <%= link_to 'タイムテーブル', timetables_path, {method: :get, class: "btn btn-entry btn-xl m-2 block" } %>
   <% end %>
 <% end %>

--- a/app/views/event/partial/_speaker_entry_button.html.erb
+++ b/app/views/event/partial/_speaker_entry_button.html.erb
@@ -4,5 +4,5 @@
     登壇者募集中!
     <% end %>
   </p>
-  <%= link_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-secondary btn-xl  m-2" } %>
+  <%= link_to speaker_entry_button_name, speakers_entry_path, {method: :get, class: "btn btn-entry btn-xl  m-2" } %>
 <% end %>

--- a/app/views/event/partial/_sponsors.html.erb
+++ b/app/views/event/partial/_sponsors.html.erb
@@ -7,10 +7,14 @@
       <% conference.sponsor_types.each do |sponsor_type| %>
         <h3 class="text-black mt-0"><%= sponsor_type.name %></h3>
         <hr class="divider primary my-4" />
-        <div class="row justify-content-md-center mb-5">
+        <div class="row justify-content-md-center mb-5  align-items-center">
           <% sponsor_type.sponsors.each do |sponsor| %>
             <% if sponsor.sponsor_attachment_logo_image.present? %>
-              <div class="<%= sponsor_logo_class(sponsor_type) %>"><a href="<%= sponsor.url %>" target="_blank"><%= image_tag sponsor.sponsor_attachment_logo_image.url, class: "sponsor-logo" %></a></div>
+              <div class="<%= sponsor_logo_class(sponsor_type) %>">
+                <a href="<%= sponsor.url %>" target="_blank">
+                  <%= image_tag sponsor.sponsor_attachment_logo_image.url, class: "sponsor-logo" %>
+                </a>
+              </div>
             <% end %>
           <% end %>
         </div>

--- a/db/fixtures/production/00_seeds.rb
+++ b/db/fixtures/production/00_seeds.rb
@@ -332,6 +332,22 @@ if ENV['REVIEW_APP'] == 'true'
       status: ['registered', 'accepted', 'rejected'][line["status"].to_i]
     }
   })
+
+  # Import CNDT2021 Dummy into review app
+  csv = CSV.read(File.join(Rails.root, 'db/csv/cndt2021/talks.csv'), headers: true)
+  Talk.seed(csv.map(&:to_hash))
+
+  csv = CSV.read(File.join(Rails.root, 'db/csv/cndt2021/speakers.csv'), headers: true)
+  Speaker.seed(csv.map(&:to_hash))
+
+  csv = CSV.read(File.join(Rails.root, 'db/csv/cndt2021/talks_speakers.csv'), headers: true)
+  csv.each do |row|
+    TalksSpeaker.seed(:talk_id, :speaker_id) do |t|
+      h = row.to_hash
+      t.talk_id = h["talk_id"]
+      t.speaker_id = h["speaker_id"]
+    end
+  end
     
   Video.seed(
     { id: 1, talk_id: 1, site: "vimeo", video_id: "444387842", on_air: true, slido_id: "styoi2cj"},


### PR DESCRIPTION
- CNDT2021のイベントページの見栄えを変えた。ちょっと暗めの配色だったので背景は白を増やした
- スピーカーの名前とアイコンが出るようにした
- スポンサーロゴが上揃えのためガタガタだったのを中央揃えに変更