### PR TITLE
Add sqs emulator

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,6 +72,11 @@ services:
     image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui:main
     ports:
     - 3001:3001
+  sqs:
+    image: roribio16/alpine-sqs
+    ports:
+    - 9324:9324
+    - 9325:9325
 volumes:
   mysql-data:
   redis-data:


### PR DESCRIPTION
## 概要
SQSの特性上同一キューを使用している場合、意図しない worker にジョブが実行されてしまう場合があるので開発環境上ではSQSをエミュレートしたコンテナにエンドポイントを設定できるようにする

## 使用法
1. `docker-compose up -d redis db sqs` で sqs サービスを起動する
2. `.env-local` の `SQS_MAIL_QUEUE_URL` を `http://localhost:9324/queue/default` に変更する等、環境変数をセットする
3. worker でも同様


9325 のポートを Web UI に使用します

見た感じでは AMI の制限とかは考慮されなさそうですが、今回のケースではそこまで考慮する必要はないかと考えました。

下記 docker-image を使用
https://github.com/roribio/alpine-sqs
https://hub.docker.com/r/roribio16/alpine-sqs/

WebUI
![スクリーンショット 2021-10-07 201346](https://user-images.githubusercontent.com/40717789/136374183-16fc8571-7452-4807-bcae-6f599bc007e1.png)
