### PR TITLE
チャット投稿後に投稿したメッセージが表示されない不具合の修正

### DIFF
--- a/app/jobs/chat_message_broadcast_job.rb
+++ b/app/jobs/chat_message_broadcast_job.rb
@@ -1,5 +1,6 @@
 class ChatMessageBroadcastJob < ApplicationJob
   queue_as :default
+  self.queue_adapter = :async
 
   def perform(*args)
     msg = args[0]


### PR DESCRIPTION
# チャット投稿後に投稿したメッセージが表示されない不具合の修正 #939 

## 不具合

配信中にチャットを送信すると dreamkast 側で500エラーが発生し, UI でチャットが送信できない.
送信が失敗するだけで視聴その他には影響しない.

## 原因

job_adapter がデフォルトの async から sqs に変更されていたが, `ChatMessageBroadcastJob` に対応するdefaultという名前のキューが準備されていなかったためエラーが発生していた.

## 対応

暫定対応として job_adapter を不具合発生前に使用していた `async` に変更.

## 残存問題

* adapter を `async` にしたため非同期に処理されていない
* SQSをエミュレートした状態で adapter を sqs に変更してworkerで Job を処理するようにした際, UI 側で即時反映されない問題が発生.
  * これはリロードすれば反映され, `ChatMessageBroadcastJob` も worker で処理されたことが確認できているため, UI 側とのイベント連携でうまくいっていない可能性がある(この詳細については UI/Job ともに未調査).

どちらにしろ非同期化には Queue や Worker が必要となるため, 別途対応が良さそう

## 動作確認
Admin から CloudNative Days Tokyo 2021 カンファレンスの日時を変更することで配信 UI からチャットを送信できる