### PR TITLE
Improve csv exporter

### DIFF
--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -6,7 +6,19 @@ class Admin::TracksController < ApplicationController
     @date = params[:date] || @conference.conference_days.first.date.strftime("%Y-%m-%d")
     @track_name = params[:track_name] || @conference.tracks.first.name
     @track = @conference.tracks.find_by(name: @track_name)
-    @talks = @conference.talks.where(conference_day_id: @conference.conference_days.find_by(date: @date).id, track_id: @track.id).order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference
+              .talks
+              .where(conference_day_id: @conference.conference_days.find_by(date: @date).id, track_id: @track.id)
+              .order('conference_day_id ASC, start_time ASC, track_id ASC')
+    respond_to do |format|
+      format.html
+      format.csv do
+        head :no_content
+        filename = Talk.export_csv(@conference, @talks, @track_name, @date)
+        stat = File::stat("./#{filename}.csv")
+        send_file("./#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+      end
+    end
   end
 
   def update_tracks

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -74,8 +74,8 @@ class Talk < ApplicationRecord
     return message
   end
 
-  def self.export_csv(conference, talks)
-    filename = "#{conference.abbr}_talks"
+  def self.export_csv(conference, talks, track_name="all", date="all")
+    filename = "#{conference.abbr}_#{track_name}_#{date}_talks"
     columns = %w[id title abstract speaker session_time difficulty category created_at twitter_id company]
     labels = conference.proposal_item_configs.map(&:label).uniq
     labels.delete('session_time')

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -75,8 +75,8 @@ class Talk < ApplicationRecord
   end
 
   def self.export_csv(conference, talks, track_name="all", date="all")
-    filename = "#{conference.abbr}_#{track_name}_#{date}_talks"
-    columns = %w[id title abstract speaker session_time difficulty category created_at twitter_id company]
+    filename = "#{conference.abbr}_#{date}_#{track_name}"
+    columns = %w[id title abstract speaker session_time difficulty category created_at twitter_id company start_to_end]
     labels = conference.proposal_item_configs.map(&:label).uniq
     labels.delete('session_time')
     columns.concat(labels)
@@ -95,7 +95,8 @@ class Talk < ApplicationRecord
                talk.talk_category.name,
                talk.created_at,
                talk.speaker_twitter_ids.join("/ "),
-               talk.speaker_company_names.join("/ ")]
+               talk.speaker_company_names.join("/ "),
+               talk.start_to_end]
         labels.each do |label|
           v = talk.proposal_item_value(label)
           row << (v.class == Array ? v.join(', ') : v)

--- a/app/views/admin/tracks/_tracks_nav_cndt2021.html.erb
+++ b/app/views/admin/tracks/_tracks_nav_cndt2021.html.erb
@@ -54,3 +54,12 @@
 
 ※ Track video ID は On Air 状態のセッションがUIで表示された時に使われる (ライブ)<br>
 ※ 各セッションの Vimeo ID は Off Air 状態のセッションがUIで表示された時に使われる (アーカイブ)
+
+<div class="row">
+  <div class="col-12 mt-4">
+    <h2>Download talks in this track</h2>
+    <div class="col-12 form-group">
+      <%= link_to 'Download CSV', admin_tracks_path(format: "csv", date: @date, track_name: @track.name), class: "btn btn-primary" %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Fix #952

TracksページにCSV出力機能を実装した。

出力ファイル名: `<イベント名>_<日付>_<トラック名>.csv`  例: `cndt2021_2021-11-04_A.csv`
出力カラム: Talksページで出るものと同一 `id,title,abstract,speaker,session_time,difficulty,category,created_at,twitter_id,company,start_to_end,assumed_visitor,execution_phase,whether_it_can_be_published,language`

注意点:
- セッションのStartとEndの情報が欲しいという要望があったので、 `start_to_end` を増設している。
- Talksと同じメソッドにパラメータを付与する形で実装したため、Talks側で出せるCSVにも↑が反映されている。よってカラムのズレが発生しているので注意
- Talks側で出せるCSVのファイル名が `cndt2021_all_all.csv` に変更になっている