### PR TITLE
add test: GET /api/v1/chat_messages

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -215,6 +215,7 @@ paths:
           content:
             application/json:
               schema:
+                type: array
                 items:
                   $ref: '#/components/schemas/ChatMessage'
         '400':
@@ -528,7 +529,7 @@ components:
         - $ref: '#/components/schemas/ChatMessageProperties'
       required:
         - eventAbbr
-        - talkId
+        - roomId
         - body
         - messageType
       example:
@@ -552,6 +553,7 @@ components:
           type: number
         speakerId:
           type: number
+          nullable: true
         eventAbbr:
           type: string
         roomId:
@@ -565,6 +567,9 @@ components:
         messageType:
           type: string
           enum: [chat, qa]
+        replyTo:
+          type: number
+          nullable: true
     Sponsor:
       type: object
       additionalProperties: false

--- a/spec/requests/api/v1/chat_message_index_spec.rb
+++ b/spec/requests/api/v1/chat_message_index_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Api::V1::ChatMessagesController, type: :request do
+  subject(:session) {
+    {
+      userinfo: {
+        info: {
+          email: "alice@example.com",
+          extra: {sub: "alice"}
+        },
+        extra: {
+          raw_info: {
+            sub: "alice",
+            "https://cloudnativedays.jp/roles" => roles
+          }
+        }
+      }
+    }
+  }
+
+  describe 'GET /api/v1/chat_messages' do
+    before do
+      allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(userinfo: {info: {email: alice.email}})
+      create(:talk1)
+      create(:message_from_alice, profile: alice)
+    end
+
+    let!(:cndt2020) { create(:cndt2020) }
+    let!(:alice) { create(:alice, :on_cndt2020, conference: cndt2020)}
+
+    it 'succeed request' do
+      get '/api/v1/chat_messages?eventAbbr=cndt2020&roomId=1&roomType=talk'
+      expect(response).to have_http_status :ok
+      expect(response.status).to eq 200
+    end
+
+    it 'confirm json schema' do
+      get '/api/v1/chat_messages?eventAbbr=cndt2020&roomId=1&roomType=talk'
+      assert_response_schema_confirm
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/issues/1011

- swagger
  - `GET /api/v1/chat_messages` のレスポンスボディはChatMessage Objectの配列なので、swaggerでも配列を明示する必要があった
  - requiedの `talkId` は間違いで `roomId` が正しい
  - `speakerId` と `replyTo` にはnullが入る可能性があるのでnullableにする


api-doc: https://github.com/cloudnativedaysjp/dreamkast/pull/1012