### PR TITLE
Update sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,8 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "mysql2", "~> 0.5.3"
 
-gem "sentry-raven"
+gem "sentry-ruby"
+gem "sentry-rails"
 
 gem "redis-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,9 +256,9 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.6)
     rb-fsevent (0.11.0)
-    rainbow (3.0.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
@@ -341,8 +341,16 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.0.0)
+    sentry-rails (4.8.0)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.8.0)
+    sentry-ruby (4.8.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.8.0)
+    sentry-ruby-core (4.8.0)
+      concurrent-ruby
+      faraday
     shrine (3.3.0)
       content_disposition (~> 1.0)
       down (~> 5.1)
@@ -440,7 +448,8 @@ DEPENDENCIES
   sass-rails (>= 6)
   seed-fu
   selenium-webdriver
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   shrine (~> 3.3)
   simplecov
   slack-incoming-webhooks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class Forbidden < ActionController::ActionControllerError; end
 class ApplicationController < ActionController::Base
   include Pundit
 
-  before_action :set_raven_context, :event_exists?
+  before_action :set_sentry_context, :event_exists?
 
   unless Rails.env.development?
     rescue_from Exception, with: :render_500
@@ -73,9 +73,11 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def set_raven_context
-    Raven.user_context(id: session[:current_user_id]) # or anything else in session
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  def set_sentry_context
+    Sentry.with_scope do |scope|
+      scope.set_user(id: session[:current_user_id])
+      scope.set_extras(params: params.to_unsafe_h, url: request.url)
+    end
   end
 
   def event_exists?

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,3 @@ module Cndtattend
     config.action_cable.mount_path = "/cable"
   end
 end
-
-Sentry.init do |config|
-  config.dsn = ENV["SENTRY_DSN"]
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,6 @@ module Cndtattend
   end
 end
 
-Raven.configure do |config|
+Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Sentry.init do |config|
+  config.dsn = ENV["SENTRY_DSN"]
+end


### PR DESCRIPTION
sentry-ravenはdeprecatedみたいなのでsentry-rubyとsentry-railsに移行する

Ref. https://docs.sentry.io/platforms/ruby/guides/rails/migration/

