### PR TITLE
Modify CI job name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  build-deploy:
+  run-test:
     runs-on: ubuntu-18.04
     if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
     steps:


### PR DESCRIPTION
CIのジョブの名前が「Build deploy」ってなってるけど実際にはテスト動かしてるだけなのでややこしいと思って直した

![image](https://user-images.githubusercontent.com/20236173/141670206-8cc1152a-faf4-4667-85a0-0948d87c6957.png)
