### PR TITLE
html以外のURLが404の時にもhtmlのerrorファイルを表示する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_404
-    render(template: "errors/error_404", status: 404, layout: "application", content_type: "text/html")
+    render(template: "errors/error_404", status: 404, layout: "application", content_type: "text/html", formats: :html)
   end
 
   def render_500(e = nil)

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe("ApplicationController", type: :request) do
+  describe "GET /not/found.html" do
+    it "returns 404 Not Found" do
+      get "/not/found.html"
+      expect(response).to_not(be_successful)
+      expect(response).to(have_http_status("404"))
+    end
+  end
+
+  describe "GET /not/found.txt" do
+    it "returns 404 Not Found" do
+      get "/not/found.txt"
+      expect(response).to_not(be_successful)
+      expect(response).to(have_http_status("404"))
+    end
+  end
+end


### PR DESCRIPTION
`https://event.cloudnativedays.jp/data/admin/allowurl.txt` のような、拡張子がtxtのURLの場合表示するテンプレートもtxtのものを探そうとして存在しないので500エラーとなっている。
拡張子がなんであれ、htmlのテンプレートを使うようにして500エラーにならないようにしたい。