### PR TITLE
Add context

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,5 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
 end
+
+Sentry.set_tags("dreamkast_namespace": ENV["DREAMKAST_NAMESPACE"])

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
   config.environment = ENV["DREAMKAST_NAMESPACE"]
-  # config.environments = ['staging', 'production']
+  config.environments = ['dreamkast', 'dreamkast-staging'] # Only staging and production send error logs to sentry
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
   config.environment = ENV["DREAMKAST_NAMESPACE"]
-  config.environments = ['dreamkast', 'dreamkast-staging'] # Only staging and production send error logs to sentry
+  config.environments = ["dreamkast", "dreamkast-staging"] # Only staging and production send error logs to sentry
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
   config.environment = ENV["DREAMKAST_NAMESPACE"]
-  config.environments = ["dreamkast", "dreamkast-staging"] # Only staging and production send error logs to sentry
+  config.enabled_environments = ["dreamkast", "dreamkast-staging"] # Only staging and production send error logs to sentry
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
+  config.environment = ENV["DREAMKAST_NAMESPACE"]
+  # config.environments = ['staging', 'production']
 end
-
-Sentry.set_tags(dreamkast_namespace: ENV["DREAMKAST_NAMESPACE"])

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,4 +2,4 @@ Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
 end
 
-Sentry.set_tags("dreamkast_namespace": ENV["DREAMKAST_NAMESPACE"])
+Sentry.set_tags(dreamkast_namespace: ENV["DREAMKAST_NAMESPACE"])


### PR DESCRIPTION
SentryのエラーにNamespaceの情報を付与する
メールでもSlack通知でもどこの環境で発生してるのかすぐわかるので便利になる