### PR TITLE
sort archives by conference id

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -56,7 +56,7 @@ class Conference < ApplicationRecord
   }
 
   scope :previous, -> {
-    merge(where(status: 2).or(where(status: 3)).joins(:conference_days)).order("conference_days.date desc").to_a.uniq
+    merge(where(status: 2).or(where(status: 3))).order(id: :desc)
   }
 
   scope :unarchived, -> {

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -56,7 +56,7 @@ class Conference < ApplicationRecord
   }
 
   scope :previous, -> {
-    merge(where(status: 2).or(where(status: 3)).joins(:conference_days)).order('conference_days.date desc').to_a.uniq
+    merge(where(status: 2).or(where(status: 3)).joins(:conference_days)).order("conference_days.date desc").to_a.uniq
   }
 
   scope :unarchived, -> {

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -56,7 +56,7 @@ class Conference < ApplicationRecord
   }
 
   scope :previous, -> {
-    merge(where(status: 2).or(where(status: 3)))
+    merge(where(status: 2).or(where(status: 3)).joins(:conference_days)).order('conference_days.date desc').to_a.uniq
   }
 
   scope :unarchived, -> {


### PR DESCRIPTION
closes #1010

期待する挙動は実現できましたが、scopeで`ActiveRecord::Relation`ではなく`Array`を返すようにする是非が気になっています。

> 4-1. ActiveRecord::Relation を返すように義務付ける
個人的には scope って ActiveRecord::Relation を返す目的で使うものだと思っていたのですが、
以下のように Array など別のクラスを返す scope がよくあります。
> 
> scope :latest_users, -> { order(created_at: :desc).first(5) }
これだと scope メソッド同士での連結ができませんし、
一度 Array になってしまうと使い道にも制限が出てしまうので、あまり良くないと思います。

https://nekonenene.hatenablog.com/entry/do-not-use-rails-scope

今のところ1箇所でしか使われていませんが、どうなんでしょう。
```
git grep previous 
app/controllers/home_controller.rb:    @previous = Conference.previous
app/javascript/packs/bootstrap-table.js:              var previousLastIndex = rx.lastIndex;
app/javascript/packs/bootstrap-table.js:              if (!sameValue(previousLastIndex, 0)) rx.lastIndex = 0;
app/javascript/packs/bootstrap-table.js:              if (!sameValue(rx.lastIndex, previousLastIndex)) rx.lastIndex = previousLastIndex;
app/javascript/packs/bootstrap-table.js:            return 'previous page';
app/models/conference.rb:  scope :previous, -> {
app/views/home/show.html.erb:    <% @previous.each do |event| %>
```