### PR TITLE
use PR number for IVS/MediaLive resource name

### DIFF
--- a/app/helpers/env_helper.rb
+++ b/app/helpers/env_helper.rb
@@ -12,6 +12,6 @@ module EnvHelper
   end
 
   def review_app_number
-    ENV['DREAMKAST_NAMESPACE'].gsub(/dreamkast-dk-/, '').to_i
+    ENV["DREAMKAST_NAMESPACE"].gsub(/dreamkast-dk-/, "").to_i
   end
 end

--- a/app/helpers/env_helper.rb
+++ b/app/helpers/env_helper.rb
@@ -14,4 +14,8 @@ module EnvHelper
   def review_app_number
     ENV["DREAMKAST_NAMESPACE"].gsub(/dreamkast-dk-/, "").to_i
   end
+
+  def review_app?
+    env_name == "review_app"
+  end
 end

--- a/app/helpers/env_helper.rb
+++ b/app/helpers/env_helper.rb
@@ -10,4 +10,8 @@ module EnvHelper
       "others"
     end
   end
+
+  def review_app_number
+    ENV['DREAMKAST_NAMESPACE'].gsub(/dreamkast-dk-/, '').to_i
+  end
 end

--- a/app/models/live_stream_ivs.rb
+++ b/app/models/live_stream_ivs.rb
@@ -25,7 +25,7 @@ class LiveStreamIvs < LiveStream
   belongs_to :track
 
   before_create do
-    tags = {"Environment" => env_name}
+    tags = { "Environment" => env_name }
     tags["ReviewAppNumber"] = review_app_number.to_s
     resp = ivs_client.create_channel(
       name: channel_name,

--- a/app/models/live_stream_ivs.rb
+++ b/app/models/live_stream_ivs.rb
@@ -85,7 +85,7 @@ class LiveStreamIvs < LiveStream
   private
 
   def channel_name
-    name = env_name == "review_app" ? "review_app_#{review_app_number}" : env_name
+    name = review_app? ? "review_app_#{review_app_number}" : env_name
     "#{name}_#{conference.abbr}_track#{track.name}"
   end
 

--- a/app/models/live_stream_ivs.rb
+++ b/app/models/live_stream_ivs.rb
@@ -25,15 +25,15 @@ class LiveStreamIvs < LiveStream
   belongs_to :track
 
   before_create do
+    tags = {"Environment" => env_name}
+    tags["ReviewAppNumber"] = review_app_number.to_s
     resp = ivs_client.create_channel(
-      name: "#{env_name}_#{conference.abbr}_track#{track.name}",
+      name: channel_name,
       latency_mode: "LOW",
       type: "STANDARD",
       authorized: false,
       recording_configuration_arn: recording_configuration_arn,
-      tags: {
-        "Environment" => env_name
-      }
+      tags: tags
     )
 
     self.params = {
@@ -83,6 +83,11 @@ class LiveStreamIvs < LiveStream
   end
 
   private
+
+  def channel_name
+    name = env_name == "review_app" ? "review_app_#{review_app_number}" : env_name
+    "#{name}_#{conference.abbr}_track#{track.name}"
+  end
 
   def ivs_client
     creds = Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])

--- a/app/models/live_stream_ivs.rb
+++ b/app/models/live_stream_ivs.rb
@@ -85,8 +85,11 @@ class LiveStreamIvs < LiveStream
   private
 
   def channel_name
-    name = review_app? ? "review_app_#{review_app_number}" : env_name
-    "#{name}_#{conference.abbr}_track#{track.name}"
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}_track#{track.name}"
+    else
+      "#{env_name}_#{conference.abbr}_track#{track.name}"
+    end
   end
 
   def ivs_client

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -190,8 +190,11 @@ class LiveStreamMediaLive < LiveStream
   end
 
   def resource_name
-    name = review_app? ? "review_app_#{review_app_number}" : env_name
-    "#{name}_#{conference.abbr}_track#{track.name}"
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}_track#{track.name}"
+    else
+      "#{env_name}_#{conference.abbr}_track#{track.name}"
+    end
   end
 
   def create_input_params

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -189,23 +189,34 @@ class LiveStreamMediaLive < LiveStream
     end
   end
 
+  def resource_name
+    name = env_name == "review_app" ? "review_app_#{review_app_number}" : env_name
+    "#{name}_#{conference.abbr}_track#{track.name}"
+  end
+
   def create_input_params
+    tags = {"Environment" => env_name}
+    tags["ReviewAppNumber"] = review_app_number.to_s
     {
-      name: "#{env_name}_#{conference.abbr}_track#{track.name}",
+      name: resource_name,
       type: "RTMP_PULL",
       sources: [
         {
           url: track.live_stream_ivs.playback_url
         }
-      ]
+      ],
+      tags: tags
     }
   end
 
   def create_channel_params(input_id, input_name)
+    tags = {"Environment" => env_name}
+    tags["ReviewAppNumber"] = review_app_number.to_s
     {
-      name: "#{env_name}_#{conference.abbr}_track#{track.name}",
+      name: resource_name,
       role_arn: "arn:aws:iam::607167088920:role/MediaLiveAccessRole",
       channel_class: "SINGLE_PIPELINE",
+      tags: tags,
       destinations: [
         {
           id: "destination1",

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -190,7 +190,7 @@ class LiveStreamMediaLive < LiveStream
   end
 
   def resource_name
-    name = env_name == "review_app" ? "review_app_#{review_app_number}" : env_name
+    name = review_app? ? "review_app_#{review_app_number}" : env_name
     "#{name}_#{conference.abbr}_track#{track.name}"
   end
 
@@ -453,131 +453,55 @@ class LiveStreamMediaLive < LiveStream
           source: "EMBEDDED"
         },
         video_descriptions: [
-          {
-            name: "video_1080p30",
-            height: 1080,
-            width: 1920,
-            codec_settings: {
-              h264_settings: {
-                adaptive_quantization: "HIGH",
-                afd_signaling: "NONE",
-                bitrate: 5000000,
-                color_metadata: "INSERT",
-                entropy_encoding: "CABAC",
-                flicker_aq: "ENABLED",
-                force_field_pictures: "DISABLED",
-                framerate_control: "SPECIFIED",
-                framerate_denominator: 1,
-                framerate_numerator: 30,
-                gop_b_reference: "ENABLED",
-                gop_closed_cadence: 1,
-                gop_num_b_frames: 3,
-                gop_size: 60,
-                gop_size_units: "FRAMES",
-                level: "H264_LEVEL_AUTO",
-                look_ahead_rate_control: "HIGH",
-                num_ref_frames: 3,
-                par_control: "INITIALIZE_FROM_SOURCE",
-                profile: "HIGH",
-                rate_control_mode: "CBR",
-                scan_type: "PROGRESSIVE",
-                scene_change_detect: "ENABLED",
-                slices: 1,
-                spatial_aq: "ENABLED",
-                subgop_length: "FIXED",
-                syntax: "DEFAULT",
-                temporal_aq: "ENABLED",
-                timecode_insertion: "DISABLED"
-              }
-            },
-            respond_to_afd: "NONE",
-            scaling_behavior: "DEFAULT",
-            sharpness: 50
-          },
-          {
-            name: "video_720p30",
-            height: 720,
-            width: 1280,
-            codec_settings: {
-              h264_settings: {
-                adaptive_quantization: "HIGH",
-                afd_signaling: "NONE",
-                bitrate: 3000000,
-                color_metadata: "INSERT",
-                entropy_encoding: "CABAC",
-                flicker_aq: "ENABLED",
-                force_field_pictures: "DISABLED",
-                framerate_control: "SPECIFIED",
-                framerate_denominator: 1,
-                framerate_numerator: 30,
-                gop_b_reference: "ENABLED",
-                gop_closed_cadence: 1,
-                gop_num_b_frames: 3,
-                gop_size: 60,
-                gop_size_units: "FRAMES",
-                level: "H264_LEVEL_AUTO",
-                look_ahead_rate_control: "HIGH",
-                num_ref_frames: 3,
-                par_control: "INITIALIZE_FROM_SOURCE",
-                profile: "HIGH",
-                rate_control_mode: "CBR",
-                scan_type: "PROGRESSIVE",
-                scene_change_detect: "ENABLED",
-                slices: 1,
-                spatial_aq: "ENABLED",
-                subgop_length: "FIXED",
-                syntax: "DEFAULT",
-                temporal_aq: "ENABLED",
-                timecode_insertion: "DISABLED"
-              }
-            },
-            respond_to_afd: "NONE",
-            scaling_behavior: "DEFAULT",
-            sharpness: 100
-          },
-          {
-            name: "video_480p30",
-            height: 480,
-            width: 854,
-            codec_settings: {
-              h264_settings: {
-                adaptive_quantization: "HIGH",
-                afd_signaling: "NONE",
-                bitrate: 1500000,
-                color_metadata: "INSERT",
-                entropy_encoding: "CABAC",
-                flicker_aq: "ENABLED",
-                force_field_pictures: "DISABLED",
-                framerate_control: "SPECIFIED",
-                framerate_denominator: 1,
-                framerate_numerator: 30,
-                gop_b_reference: "ENABLED",
-                gop_closed_cadence: 1,
-                gop_num_b_frames: 3,
-                gop_size: 60,
-                gop_size_units: "FRAMES",
-                level: "H264_LEVEL_AUTO",
-                look_ahead_rate_control: "HIGH",
-                num_ref_frames: 3,
-                par_control: "INITIALIZE_FROM_SOURCE",
-                profile: "MAIN",
-                rate_control_mode: "CBR",
-                scan_type: "PROGRESSIVE",
-                scene_change_detect: "ENABLED",
-                slices: 1,
-                spatial_aq: "ENABLED",
-                subgop_length: "FIXED",
-                syntax: "DEFAULT",
-                temporal_aq: "ENABLED",
-                timecode_insertion: "DISABLED"
-              }
-            },
-            respond_to_afd: "NONE",
-            scaling_behavior: "STRETCH_TO_OUTPUT",
-            sharpness: 100,
-          },
+          video_description("video_1080p30", 1080, 1920, 5000000, 50),
+          video_description("video_720p30", 720, 1280, 3000000, 100),
+          video_description("video_480p30", 480, 854, 1500000, 100)
         ]
       }
+    }
+  end
+
+  def video_description(name, height, width, bitrate, sharpness)
+    {
+      name: name,
+      height: height,
+      width: width,
+      codec_settings: {
+        h264_settings: {
+          adaptive_quantization: "HIGH",
+          afd_signaling: "NONE",
+          bitrate: bitrate,
+          color_metadata: "INSERT",
+          entropy_encoding: "CABAC",
+          flicker_aq: "ENABLED",
+          force_field_pictures: "DISABLED",
+          framerate_control: "SPECIFIED",
+          framerate_denominator: 1,
+          framerate_numerator: 30,
+          gop_b_reference: "ENABLED",
+          gop_closed_cadence: 1,
+          gop_num_b_frames: 3,
+          gop_size: 60,
+          gop_size_units: "FRAMES",
+          level: "H264_LEVEL_AUTO",
+          look_ahead_rate_control: "HIGH",
+          num_ref_frames: 3,
+          par_control: "INITIALIZE_FROM_SOURCE",
+          profile: "HIGH",
+          rate_control_mode: "CBR",
+          scan_type: "PROGRESSIVE",
+          scene_change_detect: "ENABLED",
+          slices: 1,
+          spatial_aq: "ENABLED",
+          subgop_length: "FIXED",
+          syntax: "DEFAULT",
+          temporal_aq: "ENABLED",
+          timecode_insertion: "DISABLED"
+        }
+      },
+      respond_to_afd: "NONE",
+      scaling_behavior: "DEFAULT",
+      sharpness: sharpness
     }
   end
 end

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -195,7 +195,7 @@ class LiveStreamMediaLive < LiveStream
   end
 
   def create_input_params
-    tags = {"Environment" => env_name}
+    tags = { "Environment" => env_name }
     tags["ReviewAppNumber"] = review_app_number.to_s
     {
       name: resource_name,
@@ -210,7 +210,7 @@ class LiveStreamMediaLive < LiveStream
   end
 
   def create_channel_params(input_id, input_name)
-    tags = {"Environment" => env_name}
+    tags = { "Environment" => env_name }
     tags["ReviewAppNumber"] = review_app_number.to_s
     {
       name: resource_name,


### PR DESCRIPTION
IVSとMediaLiveのリソース名にPRの番号をつけ、タグにもPR番号をつけるようにした。PRクローズ時にタグ情報を元にリソースを削除する機能を別途実装予定。

fix https://github.com/cloudnativedaysjp/dreamkast/issues/1034

## IVS 

![image](https://user-images.githubusercontent.com/107187/143730618-4fe9844a-5433-4e04-929b-feb4ae7336d2.png)

![image](https://user-images.githubusercontent.com/107187/143730639-dbc0bf3e-ee6f-419e-a48b-fc4b195f1a06.png)


## MediaLIve

![image](https://user-images.githubusercontent.com/107187/143730623-7f104738-d01e-441b-b89f-f09a33a28d37.png)

![image](https://user-images.githubusercontent.com/107187/143730643-67675237-355f-48e9-91f5-0f7de9c26f0c.png)
