### PR TITLE
review_app で使用するキューをDkから作成できるようにする

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,5 +26,9 @@ Naming/MemoizedInstanceVariableName:
 Style/BlockDelimiters:
   Enabled: false
 
+# 必ずしも文字列を破壊的に操作したくない場合があるため
+Style/StringConcatenation:
+  Enabled: false
+
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses

--- a/config/aws_sqs_active_job.yml
+++ b/config/aws_sqs_active_job.yml
@@ -1,2 +1,2 @@
 queues:
-  fifo: <%= ENV["SQS_FIFO_QUEUE_URL"] %>
+  fifo: <%= sqs_queue_url %>

--- a/lib/tasks/aws_sqs.rake
+++ b/lib/tasks/aws_sqs.rake
@@ -6,7 +6,7 @@ namespace :aws_sqs do
     exit unless review_app?
 
     cli = Aws::SQS::Client.new(region: "ap-northeast-1")
-    queue_name = ENV["DREAMKAST_NAMESPACE"] + "_#{review_app_number}"+ ".fifo"
+    queue_name = "review_app_#{review_app_number}" + ".fifo"
     result = cli.create_queue(
       {
         queue_name: queue_name,
@@ -14,6 +14,10 @@ namespace :aws_sqs do
           DelaySeconds: "0",
           FifoQueue: true.to_s,
           ContentBasedDeduplication: false.to_s
+        },
+        tags: {
+          Environment: env_name,
+          ReviewAppNumber: review_app_number.to_s
         }
       }
     )
@@ -26,7 +30,7 @@ namespace :aws_sqs do
     exit unless review_app?
 
     cli = Aws::SQS::Client.new(region: "ap-northeast-1")
-    result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + "_#{review_app_number}"+ ".fifo" })
+    result = cli.get_queue_url({ queue_name: "review_app_#{review_app_number}" + ".fifo" })
     response = cli.delete_queue({ queue_url: result.queue_url })
     raise(response.error) unless response.successful?
   rescue Aws::SQS::Errors::NonExistentQueue
@@ -39,7 +43,7 @@ namespace :aws_sqs do
     def queue_url
       if review_app?
         cli = Aws::SQS::Client.new(region: "ap-northeast-1")
-        result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + "_#{review_app_number}" + ".fifo" })
+        result = cli.get_queue_url({ queue_name: "review_app_#{review_app_number}" + ".fifo" })
         raise(result.error) unless result.successful?
         result.queue_url
       else

--- a/lib/tasks/aws_sqs.rake
+++ b/lib/tasks/aws_sqs.rake
@@ -1,13 +1,12 @@
-namespace :dev_sqs do
+namespace :aws_sqs do
   desc "create review_app linked sqs"
   task create_sqs: :environment do
     include EnvHelper
-    Rails.logger.level = Logger::DEBUG
 
     exit unless review_app?
 
     cli = Aws::SQS::Client.new(region: "ap-northeast-1")
-    queue_name = ENV["DREAMKAST_NAMESPACE"] + ".fifo"
+    queue_name = ENV["DREAMKAST_NAMESPACE"] + "_#{review_app_number}"+ ".fifo"
     result = cli.create_queue(
       {
         queue_name: queue_name,
@@ -23,12 +22,11 @@ namespace :dev_sqs do
 
   task delete_sqs: :environment do
     include(EnvHelper)
-    Rails.logger.level = Logger::DEBUG
 
     exit unless review_app?
 
     cli = Aws::SQS::Client.new(region: "ap-northeast-1")
-    result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + ".fifo" })
+    result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + "_#{review_app_number}"+ ".fifo" })
     response = cli.delete_queue({ queue_url: result.queue_url })
     raise(response.error) unless response.successful?
   rescue Aws::SQS::Errors::NonExistentQueue
@@ -41,7 +39,7 @@ namespace :dev_sqs do
     def queue_url
       if review_app?
         cli = Aws::SQS::Client.new(region: "ap-northeast-1")
-        result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + ".fifo" })
+        result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + "_#{review_app_number}" + ".fifo" })
         raise(result.error) unless result.successful?
         result.queue_url
       else

--- a/lib/tasks/dev_sqs.rake
+++ b/lib/tasks/dev_sqs.rake
@@ -1,0 +1,56 @@
+namespace :dev_sqs do
+  desc "create review_app linked sqs"
+  task create_sqs: :environment do
+    include EnvHelper
+    Rails.logger.level = Logger::DEBUG
+
+    exit unless review_app?
+
+    cli = Aws::SQS::Client.new(region: "ap-northeast-1")
+    queue_name = ENV["DREAMKAST_NAMESPACE"] + ".fifo"
+    result = cli.create_queue(
+      {
+        queue_name: queue_name,
+        attributes: {
+          DelaySeconds: "0",
+          FifoQueue: true.to_s,
+          ContentBasedDeduplication: false.to_s
+        }
+      }
+    )
+    raise result.error unless result.successful?
+  end
+
+  task delete_sqs: :environment do
+    include(EnvHelper)
+    Rails.logger.level = Logger::DEBUG
+
+    exit unless review_app?
+
+    cli = Aws::SQS::Client.new(region: "ap-northeast-1")
+    result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + ".fifo" })
+    response = cli.delete_queue({ queue_url: result.queue_url })
+    raise(response.error) unless response.successful?
+  rescue Aws::SQS::Errors::NonExistentQueue
+    Rails.logger.debug("Queue not exist")
+  end
+
+  task fifo_job: :environment do
+    require "aws/rails/sqs_active_job/poller"
+    include EnvHelper
+    def queue_url
+      if review_app?
+        cli = Aws::SQS::Client.new(region: "ap-northeast-1")
+        result = cli.get_queue_url({ queue_name: ENV["DREAMKAST_NAMESPACE"] + ".fifo" })
+        raise(result.error) unless result.successful?
+        result.queue_url
+      else
+        ENV["SQS_FIFO_QUEUE_URL"]
+      end
+    end
+    ARGV.clear
+    ARGV << "--queue"
+    ARGV << "fifo"
+    Aws::Rails::SqsActiveJob::Poller.new.run
+  end
+end


### PR DESCRIPTION
SQS のメッセージを複数のワーカーで食い合う問題を修正。
`DREAMKAST_NAMESPACE` を使ってSQSにキューを作成/削除する Rake task を作成。
同時に Polling 時にキューのURLを動的に生成する必要があったため worker のコマンドを変更する必要がありました。

P/Rの作成/削除の際の Task トリガーについては別途実装予定です(infra との兼ね合いでタイミングは考えます)。

`queue_url` メソッドが呼ばれるたびに AWS::Client の初期化が走るのがあんまり良くないポイントとして残ってしまったので良い解決法があれば教えて欲しいです。
この実装にしているのは AWS の AccountId とかをハードコーディングしたくないなーというのが背景にあります。