### PR TITLE
アーカイブ動画の表示・非表示まわりの修正

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -27,6 +27,8 @@ class TalksController < ApplicationController
 
   private
 
+  helper_method :display_video?
+
   def talk_params
     params.require(:talk).permit(:title, :abstract, :movie_url, :track, :start_time, :end_time, :talk_difficulty_id, :talk_category_id)
   end
@@ -42,6 +44,12 @@ class TalksController < ApplicationController
       talk.start_time.strftime("%H:%M") + "-" + talk.end_time.strftime("%H:%M")
     else
       ""
+    end
+  end
+
+  def display_video?(conference, talk)
+    if (conference.closed? && @current_user) || (conference.opened? && @current_user) || conference.archived?
+      talk.video_published && talk.video.present? && talk.archived?
     end
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -25,9 +25,18 @@ class TalksController < ApplicationController
              end
   end
 
+  helper_method :display_video?
+
+  def display_video?(conference, talk)
+    if (conference.closed? && logged_in?) || (conference.opened? && logged_in?) || conference.archived?
+      talk.video_published && talk.video.present? && talk.archived?
+    else
+      false
+    end
+  end
+
   private
 
-  helper_method :display_video?
 
   def talk_params
     params.require(:talk).permit(:title, :abstract, :movie_url, :track, :start_time, :end_time, :talk_difficulty_id, :talk_category_id)
@@ -44,12 +53,6 @@ class TalksController < ApplicationController
       talk.start_time.strftime("%H:%M") + "-" + talk.end_time.strftime("%H:%M")
     else
       ""
-    end
-  end
-
-  def display_video?(conference, talk)
-    if (conference.closed? && @current_user) || (conference.opened? && @current_user) || conference.archived?
-      talk.video_published && talk.video.present? && talk.archived?
     end
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -29,7 +29,15 @@ class TalksController < ApplicationController
 
   def display_video?(conference, talk)
     if (conference.closed? && logged_in?) || (conference.opened? && logged_in?) || conference.archived?
-      talk.video_published && talk.video.present? && talk.archived?
+      if talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL).present?
+        if talk.proposal_items.empty?
+          false
+        else
+          talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL)&.proposal_item_configs.map { |config| [VideoAndSlidePublished::ALL_OK, VideoAndSlidePublished::ONLY_VIDEO].include?(config.key.to_i) }.any?
+        end
+      else
+        (talk.video_published && talk.video.present? && talk.archived?)
+      end
     else
       false
     end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -33,7 +33,8 @@ class TalksController < ApplicationController
         if talk.proposal_items.empty?
           false
         else
-          talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL)&.proposal_item_configs.map { |config| [VideoAndSlidePublished::ALL_OK, VideoAndSlidePublished::ONLY_VIDEO].include?(config.key.to_i) }.any?
+          proposal_item = talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL) || []
+          proposal_item.proposal_item_configs.map { |config| [VideoAndSlidePublished::ALL_OK, VideoAndSlidePublished::ONLY_VIDEO].include?(config.key.to_i) }.any?
         end
       else
         (talk.video_published && talk.video.present? && talk.archived?)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -27,8 +27,8 @@ class TalksController < ApplicationController
 
   helper_method :display_video?
 
-  def display_video?(conference, talk)
-    if (conference.closed? && logged_in?) || (conference.opened? && logged_in?) || conference.archived?
+  def display_video?(talk)
+    if (talk.conference.closed? && logged_in?) || (talk.conference.opened? && logged_in?) || talk.conference.archived?
       if talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL).present?
         if talk.proposal_items.empty?
           false

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -46,7 +46,6 @@ class TalksController < ApplicationController
 
   private
 
-
   def talk_params
     params.require(:talk).permit(:title, :abstract, :movie_url, :track, :start_time, :end_time, :talk_difficulty_id, :talk_category_id)
   end

--- a/app/models/proposal_item.rb
+++ b/app/models/proposal_item.rb
@@ -20,4 +20,15 @@
 class ProposalItem < ApplicationRecord
   belongs_to :conference
   belongs_to :talk
+
+  def proposal_item_configs
+    return [] unless params
+
+    case params
+    when String
+      [ProposalItemConfig.find(params.to_i)]
+    when Array
+      params.map { |param| ProposalItemConfig.find(param.to_i) }
+    end
+  end
 end

--- a/app/models/proposal_item_config.rb
+++ b/app/models/proposal_item_config.rb
@@ -6,9 +6,11 @@
 #  description   :text(65535)
 #  item_name     :string(255)
 #  item_number   :integer
+#  key           :string(255)
 #  label         :string(255)
 #  params        :json
 #  type          :string(255)
+#  value         :string(255)
 #  conference_id :bigint           not null
 #
 # Indexes

--- a/app/models/proposal_item_config_check_box.rb
+++ b/app/models/proposal_item_config_check_box.rb
@@ -6,9 +6,11 @@
 #  description   :text(65535)
 #  item_name     :string(255)
 #  item_number   :integer
+#  key           :string(255)
 #  label         :string(255)
 #  params        :json
 #  type          :string(255)
+#  value         :string(255)
 #  conference_id :bigint           not null
 #
 # Indexes

--- a/app/models/proposal_item_config_radio_button.rb
+++ b/app/models/proposal_item_config_radio_button.rb
@@ -6,9 +6,11 @@
 #  description   :text(65535)
 #  item_name     :string(255)
 #  item_number   :integer
+#  key           :string(255)
 #  label         :string(255)
 #  params        :json
 #  type          :string(255)
+#  value         :string(255)
 #  conference_id :bigint           not null
 #
 # Indexes

--- a/app/models/talk_category.rb
+++ b/app/models/talk_category.rb
@@ -10,4 +10,5 @@
 #
 class TalkCategory < ApplicationRecord
   has_one :talk
+  belongs_to :conference
 end

--- a/app/models/talk_difficulty.rb
+++ b/app/models/talk_difficulty.rb
@@ -10,4 +10,5 @@
 #
 class TalkDifficulty < ApplicationRecord
   has_one :talk
+  belongs_to :conference
 end

--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -35,7 +35,7 @@
         <% end %>
       </div>
 
-      <% if display_video?(conference, talk) %>
+      <% if display_video?(talk) %>
         <% if conference.abbr == 'cndt2021' %>
           <%= render 'talks/partial_show/talk_video_block_videojs', talk: talk %>
         <% else %>

--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -35,7 +35,7 @@
         <% end %>
       </div>
 
-      <% if (conference.closed? && @current_user) || (conference.opened? && @current_user) || conference.archived? %>
+      <% if display_video?(conference, talk) %>
         <% if conference.abbr == 'cndt2021' %>
           <%= render 'talks/partial_show/talk_video_block_videojs', talk: talk %>
         <% else %>

--- a/app/views/talks/partial_show/_talk_video_block.html.erb
+++ b/app/views/talks/partial_show/_talk_video_block.html.erb
@@ -1,7 +1,5 @@
-<% if talk.video_published && talk.video.present? && talk.archived? %>
-  <div class="mb-2">
-    <div style="padding:56.25% 0 0 0;position:relative;">
-      <iframe src="https://player.vimeo.com/video/<%= talk.video.video_id %>" id="video" frameborder="0" style="position:absolute;top:0;left:0;width:100%;height:100%;" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-    </div>
+<div class="mb-2">
+  <div style="padding:56.25% 0 0 0;position:relative;">
+    <iframe src="https://player.vimeo.com/video/<%= talk.video.video_id %>" id="video" frameborder="0" style="position:absolute;top:0;left:0;width:100%;height:100%;" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
   </div>
-<% end %>
+</div>

--- a/app/views/talks/partial_show/_talk_video_block_videojs.html.erb
+++ b/app/views/talks/partial_show/_talk_video_block_videojs.html.erb
@@ -1,13 +1,11 @@
-<% if talk.video_published && talk.video.present? && talk.archived? %>
-  <div class="mb-2">
-    <video
-      id="my-player"
-      class="video-js vjs-default-skin"
-      data-setup='{"fluid": true}'
-      controls
-      preload="auto"
-    >
-      <source src="<%= talk.video.video_id %>" type="application/x-mpegURL" />
-    </video>
-  </div>
-<% end %>
+<div class="mb-2">
+  <video
+    id="my-player"
+    class="video-js vjs-default-skin"
+    data-setup='{"fluid": true}'
+    controls
+    preload="auto"
+  >
+    <source src="<%= talk.video.video_id %>" type="application/x-mpegURL" />
+  </video>
+</div>

--- a/config/initializers/constrants.rb
+++ b/config/initializers/constrants.rb
@@ -1,4 +1,6 @@
 class VideoAndSlidePublished
+  LABEL = "whether_it_can_be_published".freeze
+
   ALL_OK = 1
   ONLY_SLIDE = 2
   ONLY_VIDEO = 3

--- a/config/initializers/constrants.rb
+++ b/config/initializers/constrants.rb
@@ -1,0 +1,7 @@
+class VideoAndSlidePublished
+  ALL_OK = 1
+  ONLY_SLIDE = 2
+  ONLY_VIDEO = 3
+  ALL_NG = 4
+  OTHERS = 5
+end

--- a/db/fixtures/development/01_proposal_item_configs.rb
+++ b/db/fixtures/development/01_proposal_item_configs.rb
@@ -182,9 +182,9 @@ ProposalItemConfig.seed(
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
     params: 'All okay - スライド・動画両方ともに公開可',
-    key: 'All okay - スライド・動画両方ともに公開可',
     description: 'イベント終了後に講演資料（スライドはslideshareなどにご自分でアップしてください）とアーカイブ動画を公開します。公開可否は来場者がセッションを選択する際の大きな判断材料となりますので事前に意思を確認させてください。動画はスライドと同期させた映像（例：https://www.youtube.com/watch?v=V21a3WMPC7s）を予定しています - After the event ends, we will publish the lecture materials (please upload yourself to slideshare etc) and archive videos. Please tell us in advance as visitors will be a big material to choose sessions.',
-    value: VideoAndSlidePublished::ALL_OK
+    key: VideoAndSlidePublished::ALL_OK,
+    value: 'All okay - スライド・動画両方ともに公開可'
   },
   {
     id: 21,
@@ -194,8 +194,8 @@ ProposalItemConfig.seed(
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
     params: 'Only Slide - スライドのみ公開可',
-    key: 'Only Slide - スライドのみ公開可',
-    value: VideoAndSlidePublished::ONLY_SLIDE
+    key: VideoAndSlidePublished::ONLY_SLIDE,
+    value: 'Only Slide - スライドのみ公開可'
   },
   {
     id: 22,
@@ -205,8 +205,8 @@ ProposalItemConfig.seed(
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
     params: 'NG - いずれも公開不可（来場者限定のコンテンツ）',
-    key: 'NG - いずれも公開不可（来場者限定のコンテンツ）',
-    value: VideoAndSlidePublished::ALL_NG
+    key: VideoAndSlidePublished::ALL_NG,
+    value: 'NG - いずれも公開不可（来場者限定のコンテンツ）'
   },
   {
     id: 23,
@@ -216,8 +216,8 @@ ProposalItemConfig.seed(
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
     params: 'その他',
-    key: 'その他',
-    value: VideoAndSlidePublished::OTHERS
+    key: VideoAndSlidePublished::OTHERS,
+    value: 'その他'
   },
 
   {

--- a/db/fixtures/development/01_proposal_item_configs.rb
+++ b/db/fixtures/development/01_proposal_item_configs.rb
@@ -182,7 +182,9 @@ ProposalItemConfig.seed(
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
     params: 'All okay - スライド・動画両方ともに公開可',
-    description: 'イベント終了後に講演資料（スライドはslideshareなどにご自分でアップしてください）とアーカイブ動画を公開します。公開可否は来場者がセッションを選択する際の大きな判断材料となりますので事前に意思を確認させてください。動画はスライドと同期させた映像（例：https://www.youtube.com/watch?v=V21a3WMPC7s）を予定しています - After the event ends, we will publish the lecture materials (please upload yourself to slideshare etc) and archive videos. Please tell us in advance as visitors will be a big material to choose sessions.'
+    key: 'All okay - スライド・動画両方ともに公開可',
+    description: 'イベント終了後に講演資料（スライドはslideshareなどにご自分でアップしてください）とアーカイブ動画を公開します。公開可否は来場者がセッションを選択する際の大きな判断材料となりますので事前に意思を確認させてください。動画はスライドと同期させた映像（例：https://www.youtube.com/watch?v=V21a3WMPC7s）を予定しています - After the event ends, we will publish the lecture materials (please upload yourself to slideshare etc) and archive videos. Please tell us in advance as visitors will be a big material to choose sessions.',
+    value: VideoAndSlidePublished::ALL_OK
   },
   {
     id: 21,
@@ -191,7 +193,9 @@ ProposalItemConfig.seed(
     label: 'whether_it_can_be_published',
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
-    params: 'Only Slide - スライドのみ公開可'
+    params: 'Only Slide - スライドのみ公開可',
+    key: 'Only Slide - スライドのみ公開可',
+    value: VideoAndSlidePublished::ONLY_SLIDE
   },
   {
     id: 22,
@@ -200,7 +204,9 @@ ProposalItemConfig.seed(
     label: 'whether_it_can_be_published',
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
-    params: 'NG - いずれも公開不可（来場者限定のコンテンツ）'
+    params: 'NG - いずれも公開不可（来場者限定のコンテンツ）',
+    key: 'NG - いずれも公開不可（来場者限定のコンテンツ）',
+    value: VideoAndSlidePublished::ALL_NG
   },
   {
     id: 23,
@@ -209,7 +215,9 @@ ProposalItemConfig.seed(
     label: 'whether_it_can_be_published',
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
-    params: 'その他'
+    params: 'その他',
+    key: 'その他',
+    value: VideoAndSlidePublished::OTHERS
   },
 
   {

--- a/db/fixtures/production/01_proposal_item_configs.rb
+++ b/db/fixtures/production/01_proposal_item_configs.rb
@@ -182,7 +182,9 @@ ProposalItemConfig.seed(
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
     params: 'All okay - スライド・動画両方ともに公開可',
-    description: 'イベント終了後に講演資料（スライドはslideshareなどにご自分でアップしてください）とアーカイブ動画を公開します。公開可否は来場者がセッションを選択する際の大きな判断材料となりますので事前に意思を確認させてください。動画はスライドと同期させた映像（例：https://www.youtube.com/watch?v=V21a3WMPC7s）を予定しています - After the event ends, we will publish the lecture materials (please upload yourself to slideshare etc) and archive videos. Please tell us in advance as visitors will be a big material to choose sessions.'
+    key: 'All okay - スライド・動画両方ともに公開可',
+    description: 'イベント終了後に講演資料（スライドはslideshareなどにご自分でアップしてください）とアーカイブ動画を公開します。公開可否は来場者がセッションを選択する際の大きな判断材料となりますので事前に意思を確認させてください。動画はスライドと同期させた映像（例：https://www.youtube.com/watch?v=V21a3WMPC7s）を予定しています - After the event ends, we will publish the lecture materials (please upload yourself to slideshare etc) and archive videos. Please tell us in advance as visitors will be a big material to choose sessions.',
+    value: VideoAndSlidePublished::ALL_OK
   },
   {
     id: 21,
@@ -191,7 +193,9 @@ ProposalItemConfig.seed(
     label: 'whether_it_can_be_published',
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
-    params: 'Only Slide - スライドのみ公開可'
+    params: 'Only Slide - スライドのみ公開可',
+    key: 'Only Slide - スライドのみ公開可',
+    value: VideoAndSlidePublished::ONLY_SLIDE
   },
   {
     id: 22,
@@ -200,7 +204,9 @@ ProposalItemConfig.seed(
     label: 'whether_it_can_be_published',
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
-    params: 'NG - いずれも公開不可（来場者限定のコンテンツ）'
+    params: 'NG - いずれも公開不可（来場者限定のコンテンツ）',
+    key: 'NG - いずれも公開不可（来場者限定のコンテンツ）',
+    value: VideoAndSlidePublished::ALL_NG
   },
   {
     id: 23,
@@ -209,7 +215,9 @@ ProposalItemConfig.seed(
     label: 'whether_it_can_be_published',
     item_number: 3,
     item_name: 'スライドと動画の公開可否（★★）',
-    params: 'その他'
+    params: 'その他',
+    key: 'その他',
+    value: VideoAndSlidePublished::OTHERS
   },
 
   {

--- a/db/migrate/20211211104841_add_columns_to_proposal_item_config_and_change_type.rb
+++ b/db/migrate/20211211104841_add_columns_to_proposal_item_config_and_change_type.rb
@@ -1,0 +1,6 @@
+class AddColumnsToProposalItemConfigAndChangeType < ActiveRecord::Migration[6.0]
+  def change
+    add_column :proposal_item_configs, :key, :string
+    add_column :proposal_item_configs, :value, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_30_082839) do
+ActiveRecord::Schema.define(version: 2021_12_11_104841) do
 
   create_table "access_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
@@ -184,6 +184,8 @@ ActiveRecord::Schema.define(version: 2021_10_30_082839) do
     t.string "item_name"
     t.json "params"
     t.text "description"
+    t.string "key"
+    t.string "value"
     t.index ["conference_id"], name: "index_proposal_item_configs_on_conference_id"
   end
 

--- a/spec/controllers/talks_controller_spec.rb
+++ b/spec/controllers/talks_controller_spec.rb
@@ -129,4 +129,78 @@ RSpec.describe(TalksController, type: :controller) do
       expect(response).to(redirect_to(talks_url))
     end
   end
+
+  describe "display_video?" do
+    let!(:category) { create(:talk_category1, conference: conference) }
+    let!(:difficulty) { create(:talk_difficulties1, conference: conference) }
+    let!(:talk1) { create(:talk1, conference: conference) }
+    let!(:talk2) { create(:talk2, conference: conference) }
+    let!(:video) { create(:video) }
+
+    context "user logged in" do
+      before do
+        allow_any_instance_of(TalksController).to(receive(:logged_in?).and_return(true))
+      end
+
+      context "conference is registered" do
+        let!(:conference) { create(:cndt2020, :registered) }
+
+        context "talk is video_published, video is present and talk is archived" do
+          before do
+            allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          end
+
+          it "returns false" do
+            controller = TalksController.new
+            expect(controller.display_video?(conference, talk1)).to(be_falsey)
+          end
+        end
+      end
+
+      context "conference is opened" do
+        let!(:conference) { create(:cndt2020, :opened) }
+
+        context "talk is video_published, video is present and talk is archived" do
+          before do
+            allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          end
+
+          it "returns true" do
+            controller = TalksController.new
+            expect(controller.display_video?(conference, talk1)).to(be_truthy)
+          end
+        end
+      end
+
+      context "conference is closed" do
+        let!(:conference) { create(:cndt2020, :closed) }
+
+        context "talk is video_published, video is present and talk is archived" do
+          before do
+            allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          end
+
+          it "returns true" do
+            controller = TalksController.new
+            expect(controller.display_video?(conference, talk1)).to(be_truthy)
+          end
+        end
+      end
+
+      context "conference is archived" do
+        let!(:conference) { create(:cndt2020, :archived) }
+
+        context "talk is video_published, video is present and talk is archived" do
+          before do
+            allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          end
+
+          it "returns true" do
+            controller = TalksController.new
+            expect(controller.display_video?(conference, talk1)).to(be_truthy)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/talks_controller_spec.rb
+++ b/spec/controllers/talks_controller_spec.rb
@@ -240,14 +240,14 @@ RSpec.describe(TalksController, type: :controller) do
     shared_examples_for :return_true do
       it "returns true" do
         controller = TalksController.new
-        expect(controller.display_video?(conference, talk1)).to(be_truthy)
+        expect(controller.display_video?(talk1)).to(be_truthy)
       end
     end
 
     shared_examples_for :return_false do
       it "returns false" do
         controller = TalksController.new
-        expect(controller.display_video?(conference, talk1)).to(be_falsey)
+        expect(controller.display_video?(talk1)).to(be_falsey)
       end
     end
 

--- a/spec/controllers/talks_controller_spec.rb
+++ b/spec/controllers/talks_controller_spec.rb
@@ -135,6 +135,62 @@ RSpec.describe(TalksController, type: :controller) do
     let!(:difficulty) { create(:talk_difficulties1, conference: conference) }
     let!(:talk1) { create(:talk1, conference: conference) }
 
+    shared_examples_for :return_true_when_proposal_item_whether_it_can_be_published_is_all_ok do
+      context "proposal_item whether_it_can_be_published is all_ok" do
+        before do
+          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          create(:proposal_item_configs_whether_it_can_be_published, :all_ok, conference: conference)
+          create(:proposal_item_whether_it_can_be_published, :all_ok, talk: talk1)
+        end
+        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
+        let!(:video) { create(:video) }
+
+        it_should_behave_like :return_true
+      end
+    end
+
+    shared_examples_for :return_false_when_proposal_item_whether_it_can_be_published_is_only_slide do
+      context "proposal_item whether_it_can_be_published is only_slide" do
+        before do
+          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          create(:proposal_item_configs_whether_it_can_be_published, :only_slide, conference: conference)
+          create(:proposal_item_whether_it_can_be_published, :only_slide, talk: talk1)
+        end
+        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
+        let!(:video) { create(:video) }
+
+        it_should_behave_like :return_false
+      end
+    end
+
+    shared_examples_for :return_true_when_proposal_item_whether_it_can_be_published_is_only_video do
+      context "proposal_item whether_it_can_be_published is only_video" do
+        before do
+          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          create(:proposal_item_configs_whether_it_can_be_published, :only_video, conference: conference)
+          create(:proposal_item_whether_it_can_be_published, :only_video, talk: talk1)
+        end
+        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
+        let!(:video) { create(:video) }
+
+        it_should_behave_like :return_true
+      end
+    end
+
+    shared_examples_for :return_false_when_proposal_item_whether_it_can_be_published_is_all_ng do
+      context "proposal_item whether_it_can_be_published is all_ng" do
+        before do
+          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
+          create(:proposal_item_configs_whether_it_can_be_published, :all_ng, conference: conference)
+          create(:proposal_item_whether_it_can_be_published, :all_ng, talk: talk1)
+        end
+        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
+        let!(:video) { create(:video) }
+
+        it_should_behave_like :return_false
+      end
+    end
+
     shared_examples_for :return_true_when_video_is_published_and_present_and_archived do
       context "talk is video_published, video is present and talk is archived" do
         before do
@@ -213,6 +269,11 @@ RSpec.describe(TalksController, type: :controller) do
         it_should_behave_like :return_false_when_video_is_not_published
         it_should_behave_like :return_false_when_video_is_not_present
         it_should_behave_like :return_false_video_is_not_archived
+
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_all_ok
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_only_slide
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_only_video
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_all_ng
       end
 
       context "conference is closed" do
@@ -222,6 +283,11 @@ RSpec.describe(TalksController, type: :controller) do
         it_should_behave_like :return_false_when_video_is_not_published
         it_should_behave_like :return_false_when_video_is_not_present
         it_should_behave_like :return_false_video_is_not_archived
+
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_all_ok
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_only_slide
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_only_video
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_all_ng
       end
 
       context "conference is archived" do
@@ -231,6 +297,11 @@ RSpec.describe(TalksController, type: :controller) do
         it_should_behave_like :return_false_when_video_is_not_published
         it_should_behave_like :return_false_when_video_is_not_present
         it_should_behave_like :return_false_video_is_not_archived
+
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_all_ok
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_only_slide
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_only_video
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_all_ng
       end
     end
 
@@ -264,6 +335,11 @@ RSpec.describe(TalksController, type: :controller) do
         it_should_behave_like :return_false_when_video_is_not_published
         it_should_behave_like :return_false_when_video_is_not_present
         it_should_behave_like :return_false_video_is_not_archived
+
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_all_ok
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_only_slide
+        it_should_behave_like :return_true_when_proposal_item_whether_it_can_be_published_is_only_video
+        it_should_behave_like :return_false_when_proposal_item_whether_it_can_be_published_is_all_ng
       end
     end
   end

--- a/spec/factories/proposal_item.rb
+++ b/spec/factories/proposal_item.rb
@@ -1,0 +1,46 @@
+# == Schema Information
+#
+# Table name: proposal_item_configs
+#
+#  id            :bigint           not null, primary key
+#  description   :text(65535)
+#  item_name     :string(255)
+#  item_number   :integer
+#  key           :string(255)
+#  label         :string(255)
+#  params        :json
+#  type          :string(255)
+#  value         :string(255)
+#  conference_id :bigint           not null
+#
+# Indexes
+#
+#  index_proposal_item_configs_on_conference_id  (conference_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#
+FactoryBot.define do
+  factory :proposal_item_whether_it_can_be_published, class: ProposalItem do
+    id { 3 }
+    conference_id { 1 }
+    label { "whether_it_can_be_published" }
+
+    trait :all_ok do
+      params { "3" }
+    end
+
+    trait :only_slide do
+      params { "4" }
+    end
+
+    trait :only_video do
+      params { "5" }
+    end
+
+    trait :all_ng do
+      params { "5" }
+    end
+  end
+end

--- a/spec/factories/proposal_item_configs.rb
+++ b/spec/factories/proposal_item_configs.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     item_name { "\u60F3\u5B9A\u53D7\u8B1B\u8005\uFF08\u2605\u2605\uFF09" }
     params { "architect - \u30B7\u30B9\u30C6\u30E0\u8A2D\u8A08" }
   end
+
   factory :proposal_item_configs_execution_phase, class: ProposalItemConfig do
     id { 2 }
     conference_id { 1 }
@@ -39,5 +40,42 @@ FactoryBot.define do
     item_number { 1 }
     item_name { "\u5B9F\u884C\u30D5\u30A7\u30FC\u30BA\uFF08\u2605\u2605\uFF09" }
     params { "Dev/QA\uFF08\u958B\u767A\u74B0\u5883\uFF09" }
+  end
+
+  factory :proposal_item_configs_whether_it_can_be_published, class: ProposalItemConfig do
+    conference_id { 1 }
+    type { "ProposalItemConfigRadioButton" }
+    label { "whether_it_can_be_published" }
+    item_number { 1 }
+    item_name { "スライドと動画の公開可否（★★）" }
+    params { "All okay - スライド・動画両方ともに公開可" }
+
+    trait :all_ok do
+      id { 3 }
+      params { "All okay - スライド・動画両方ともに公開可" }
+      key { 1 }
+      value { "All okay - スライド・動画両方ともに公開可" }
+    end
+
+    trait :only_slide do
+      id { 4 }
+      params { "Only Slide - スライドのみ公開可" }
+      key { 2 }
+      value { "Only Slide - スライドのみ公開可" }
+    end
+
+    trait :only_video do
+      id { 5 }
+      params { "Only Video - 動画のみ公開可" }
+      key { 3 }
+      value { "Only Video - 動画のみ公開可" }
+    end
+
+    trait :all_ng do
+      id { 5 }
+      params { "NG - いずれも公開不可（来場者限定のコンテンツ）" }
+      key { 4 }
+      value { "NG - いずれも公開不可（来場者限定のコンテンツ）" }
+    end
   end
 end

--- a/spec/factories/proposal_item_configs.rb
+++ b/spec/factories/proposal_item_configs.rb
@@ -6,9 +6,11 @@
 #  description   :text(65535)
 #  item_name     :string(255)
 #  item_number   :integer
+#  key           :string(255)
 #  label         :string(255)
 #  params        :json
 #  type          :string(255)
+#  value         :string(255)
 #  conference_id :bigint           not null
 #
 # Indexes

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -43,6 +43,14 @@ FactoryBot.define do
     show_on_timetable { true }
     video_published { true }
     document_url { "http://" }
+
+    trait :video_published do
+      video_published { true }
+    end
+
+    trait :video_not_published do
+      video_published { false }
+    end
   end
 
   factory :talk2, class: Talk do


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/issues/1022

このPRではProposalItemを使ったアーカイブ動画の表示制御とテストの追加を行う。また、そのためにProposlItemConfigの項目を識別するために新しくkeyとvalueのカラムを追加する。keyはプログラムから識別するためのunique idを、valueはユーザーに表示するテキストを保持する。valueとparamsに同じ値が入っているが、これはparamsを今後消すためである(paramsがvaluesに置き換わる)

動画の公開可否は ProposalItemで制御するパターンと video_publlished で制御するパターンの2種類がある。前者はCNDT2021以降で使われる。後者は基本的に今後は使わない。

### 1. カンファレンスのステータスとログイン状況による制御

まず、カンファレンスのステータスとログインしているかどうかで動画を表示するかを制御する。以下のいずれかの条件を満たす場合、2もしくは3の条件チェックに進む。

- カンファレンスがクローズ状態、かつ閲覧者が参加者としてログインしている
- カンファレンスがオープン状態、かつ閲覧者が参加者としてログインしている
- カンファレンスがアーカイブ状態

### 2. 動画の公開可否が ProposalItem で制御されている場合 (label `whether_it_can_be_published` を持つProposalItemがtalkに紐付いている）

ProposalItemに紐付いている(paramsにidが含まれている)ProposalItemConfigのkeyが `ALL_OK`, `ONLY_SLIDE`, `ONLY_VIDEO`, `ALL_NG`, `OTHERS` のうち `ALL_OK` もしくは `ONLY_VIDEO` の場合は表示する

### 3. 動画の公開可否が従来のvideo_publishedで制御されている場合

以下を全て満たしている場合は表示する。

- talk.video_published : talkレコードのvideo_publishedカラムがtrue
- talk.video.present? : talkに紐付くvideoが存在するかどうか。
- talk.archived? : talkのend_timeから600sec経過したかどうか。

