### PR TITLE
ReviewApp用に作成されたAWSのリソースを削除するためのRakeタスクを追加

### DIFF
--- a/app/helpers/media_live_helper.rb
+++ b/app/helpers/media_live_helper.rb
@@ -40,4 +40,55 @@ module MediaLiveHelper
       w.delay = 5
     end
   end
+
+  def delete_media_live_channels_of_review_app(review_app_num)
+    client = media_live_client
+
+    channels = []
+    next_token = ""
+    loop do
+      resp = client.list_channels(next_token: next_token)
+      channels.concat(resp.channels)
+      break unless resp.next_token
+      next_token = resp.next_token
+    end
+
+    r = channels.select do |channel|
+      channel.tags["Environment"] == "review_app" && channel.tags["ReviewAppNumber"] == review_app_num.to_s
+    end
+
+    r.each do |channel|
+      puts("#{ENV['DRY_RUN'] == 'false' ? '' : '[DRY_RUN] '}Delete MediaLive Channel: #{channel.id} (#{channel.name})")
+      if ENV["DRY_RUN"] == "false"
+        client.delete_channel(channel_id: channel.id)
+      end
+    end
+  end
+
+  def delete_media_live_inputs_of_review_app(review_app_num)
+    client = media_live_client
+
+    inputs = []
+    next_token = ""
+    while true
+      resp = client.list_inputs(next_token: next_token)
+      inputs.concat(resp.inputs)
+      break unless resp.next_token
+      next_token = resp.next_token
+    end
+
+    r = inputs.select do |input|
+      input.tags["Environment"] == "review_app" && input.tags["ReviewAppNumber"] == review_app_num.to_s
+    end
+
+    r.each do |input|
+      puts("#{ENV['DRY_RUN'] == 'false' ? '' : '[DRY_RUN] '}Delete MediaLive Input: #{input.id} (#{input.name})")
+      next unless ENV["DRY_RUN"] == "false"
+      client.wait_until(:input_detached, input_id: input.id) do |w|
+        w.max_attempts = 30
+        w.delay = 5
+      end
+      client.delete_input(input_id: input.id)
+    end
+  end
 end

--- a/lib/tasks/aws.rake
+++ b/lib/tasks/aws.rake
@@ -2,7 +2,6 @@ namespace :aws do
   task delete_review_app_resources: :environment do
     include(MediaLiveHelper)
     include(EnvHelper)
-    Rails.logger.level = Logger::DEBUG
 
     exit unless review_app?
 

--- a/lib/tasks/aws.rake
+++ b/lib/tasks/aws.rake
@@ -1,0 +1,46 @@
+namespace :aws do
+  task delete_review_app_resources: :environment do
+    include(MediaLiveHelper)
+    include(EnvHelper)
+    Rails.logger.level = Logger::DEBUG
+
+    exit unless review_app?
+
+    delete_media_live_channels_of_review_app(review_app_number)
+    delete_media_live_inputs_of_review_app(review_app_number)
+    delete_ivs_channels_of_review_app(review_app_number)
+  end
+
+  def ivs_client
+    creds = Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])
+    if creds.set?
+      Aws::IVS::Client.new(region: "us-east-1", credentials: creds)
+    else
+      Aws::IVS::Client.new(region: "us-east-1")
+    end
+  end
+
+  def delete_ivs_channels_of_review_app(review_app_num)
+    client = ivs_client
+
+    channels = []
+    next_token = ""
+    loop do
+      resp = client.list_channels(next_token: next_token)
+      channels.concat(resp.channels)
+      break unless resp.next_token
+      next_token = resp.next_token
+    end
+
+    r = channels.select do |channel|
+      channel.tags["Environment"] == "review_app" && channel.tags["ReviewAppNumber"] == review_app_num.to_s
+    end
+
+    r.each do |channel|
+      puts("#{ENV['DRY_RUN'] == 'false' ? '' : '[DRY_RUN] '}Delete IVS Channel: #{channel.arn} (#{channel.name})")
+      if ENV["DRY_RUN"] == "false"
+        client.delete_channel(arn: channel.arn)
+      end
+    end
+  end
+end


### PR DESCRIPTION
以下のリソースについて、`Environment` タグの値が `review_app` のもの、かつ `ReviewAppNumber` タグの値が `DREAMKAST_NAMESPACE` 環境変数で指定されたPR番号のものを消す

- IVS Channel
- MediaLive Input
- MediaLive Channel
