### PR TITLE
スピーカー作成と同時にCFPを作成するとメールが送信できない不具合の修正

### DIFF
--- a/app/controllers/speaker_dashboard/speakers_controller.rb
+++ b/app/controllers/speaker_dashboard/speakers_controller.rb
@@ -40,6 +40,7 @@ class SpeakerDashboard::SpeakersController < ApplicationController
 
     respond_to do |format|
       if r = @speaker_form.save
+        @speaker = Speaker.find_by(email: @speaker_form.email)
         r.each do |talk|
           SpeakerMailer.cfp_registered(@conference, @speaker, talk).deliver_later
         end


### PR DESCRIPTION
## 現象

SSIA

## 原因

https://github.com/cloudnativedaysjp/dreamkast/blob/main/app/controllers/speaker_dashboard/speakers_controller.rb#L44　で未初期化のインスタンス変数 `@speaker` を渡しているため worker で `NoMethodError (undefined method `email' for nil:NilClass)` が起こっている.

Update では発生しないのと、#1060 の不具合が先に発生するため顕在化しなかったと考えられる

## 解決方法

save 成功後に `@speaker` に `@speaker_form.email` で照合した Speaker を代入した