### PR TITLE
必須項目を選択しなくてもセッション情報を登録できてしまう不具合の修正

### DIFF
--- a/app/forms/speaker_form.rb
+++ b/app/forms/speaker_form.rb
@@ -117,9 +117,9 @@ class SpeakerForm
       end
       @talks.each do |talk|
         if talk.persisted?
-          talk.save!
+          talk.save!(context: :entry_form)
         else
-          talk.save!
+          talk.save!(context: :entry_form)
           talk_speaker = TalksSpeaker.new(talk_id: talk.id, speaker_id: speaker.id)
           talk_speaker.save!
 

--- a/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
+++ b/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
@@ -66,7 +66,7 @@
         <% @conference.proposal_item_configs.where(item_number: item_number).each do |item|%>
           <% label = first_item.label.pluralize.to_sym %>
           <% checked = existing_items ? existing_items.include?(item.id.to_s) : false%>
-          <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked %>
+          <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, required: true %>
           <%= label label, item.params, {class: 'form-check-label'} %><br>
         <% end %>
       <% else %>


### PR DESCRIPTION
## 現象

CFP 登録時にチェックボックス及びラジオボックスの選択肢が必須のはずが、選択無しでも validation をパスしてしまっている
#1068 

## 原因

以下の validation では `expected_participants` と `execution_phases ` が常に `nil` のため、機能しない
https://github.com/cloudnativedaysjp/dreamkast/blob/6740edf41978fd6743d74544cb5d0609bde43f0f/app/models/talk.rb#L63-L64

https://github.com/cloudnativedaysjp/dreamkast/blob/6740edf41978fd6743d74544cb5d0609bde43f0f/app/models/talk.rb#L303

## 解決方法

validation を `talk.proposal_items` と `conference.proposal_item_configs` のサイズの比較で行うように変更した
現状全て必須項目のため必ず両者のサイズが一致し、もし差ができた場合はその差を不足分としてエラー表示に出している


## 問題点

rspec 実施時、下記の `proposal_items` が実行されると `spec/controllers/talks_controller/display_document_spec.rb` で `true` を期待値とする spec が全滅したため context を設定して factory からの save 時に validation を無効化しました。
https://github.com/cloudnativedaysjp/dreamkast/blob/cf317e308e7f241f73240beee0859667da17074e/app/models/talk.rb#L299

詳細の原因は不明ですが、上記箇所によって下記の `talk.proposal_items` が本来の期待値と異なり空になってしまっているのが表面的な原因のようです。
validation が必ず `true` を返すようにしても発生していました。
https://github.com/cloudnativedaysjp/dreamkast/blob/cf317e308e7f241f73240beee0859667da17074e/app/controllers/talks_controller.rb#L50

現状 talk は SpeakerForm を通してしか作成されないことと、テストでのみ観測可能な問題という認識のため、一旦この対応でも問題は無さそうかと思っていますが根源的な解決にはなっていなさそうなので、その辺りも含めてレビュー頂けると助かります。

### 再現方法

talk.rb#L63 から `context` 以下をコメントアウトしてテストを実行すると再現できます。