### PR TITLE
ReviewAppNumberタグをセットするのはDREAMKAST_NAMESPACE環境変数がセットされているときだけ

### DIFF
--- a/app/models/live_stream_ivs.rb
+++ b/app/models/live_stream_ivs.rb
@@ -26,7 +26,7 @@ class LiveStreamIvs < LiveStream
 
   before_create do
     tags = { 'Environment' => env_name }
-    tags['ReviewAppNumber'] = review_app_number.to_s
+    tags['ReviewAppNumber'] = review_app_number.to_s if ENV['DREAMKAST_NAMESPACE']
     resp = ivs_client.create_channel(
       name: channel_name,
       latency_mode: 'LOW',

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -199,7 +199,7 @@ class LiveStreamMediaLive < LiveStream
 
   def create_input_params
     tags = { 'Environment' => env_name }
-    tags['ReviewAppNumber'] = review_app_number.to_s
+    tags['ReviewAppNumber'] = review_app_number.to_s if ENV['DREAMKAST_NAMESPACE']
     {
       name: resource_name,
       type: 'RTMP_PULL',
@@ -214,7 +214,8 @@ class LiveStreamMediaLive < LiveStream
 
   def create_channel_params(input_id, input_name)
     tags = { 'Environment' => env_name }
-    tags['ReviewAppNumber'] = review_app_number.to_s
+    tags['ReviewAppNumber'] = review_app_number.to_s if ENV['DREAMKAST_NAMESPACE']
+
     {
       name: resource_name,
       role_arn: 'arn:aws:iam::607167088920:role/MediaLiveAccessRole',


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/1035 でReviewAppNumberタグをAWSリソースに追加するようにしたが、DREAMKAST_NAMESPACEがないときも追加しようとしてエラーになることがあったので環境値変数をチェックするようにします