### PR TITLE
Add index on talks table

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -25,6 +25,7 @@
 #
 # Indexes
 #
+#  index_talks_on_conference_id       (conference_id)
 #  index_talks_on_talk_category_id    (talk_category_id)
 #  index_talks_on_talk_difficulty_id  (talk_difficulty_id)
 #

--- a/db/migrate/20220118092940_add_index_talks_conference_id.rb
+++ b/db/migrate/20220118092940_add_index_talks_conference_id.rb
@@ -1,5 +1,5 @@
 class AddIndexTalksConferenceId < ActiveRecord::Migration[6.0]
   def change
-    add_index :talks, conference_id
+    add_index :talks, :conference_id
   end
 end

--- a/db/migrate/20220118092940_add_index_talks_conference_id.rb
+++ b/db/migrate/20220118092940_add_index_talks_conference_id.rb
@@ -1,0 +1,5 @@
+class AddIndexTalksConferenceId < ActiveRecord::Migration[6.0]
+  def change
+    add_index :talks, conference_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_01_082455) do
+ActiveRecord::Schema.define(version: 2022_01_18_092940) do
 
   create_table "access_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
@@ -353,6 +353,7 @@ ActiveRecord::Schema.define(version: 2022_01_01_082455) do
     t.json "expected_participants"
     t.json "execution_phases"
     t.integer "sponsor_id"
+    t.index ["conference_id"], name: "index_talks_on_conference_id"
     t.index ["talk_category_id"], name: "index_talks_on_talk_category_id"
     t.index ["talk_difficulty_id"], name: "index_talks_on_talk_difficulty_id"
   end

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -25,6 +25,7 @@
 #
 # Indexes
 #
+#  index_talks_on_conference_id       (conference_id)
 #  index_talks_on_talk_category_id    (talk_category_id)
 #  index_talks_on_talk_difficulty_id  (talk_difficulty_id)
 #


### PR DESCRIPTION
スロークエリのログ
```sql
# Query 2: 0.01 QPS, 0.00x concurrency, ID 0x222A1AF4B5B58DD4DBE9AF086B7DF92C at byte 2673
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2022-01-18T07:37:00 to 2022-01-18T07:47:00
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         50       3
# Exec time     34   865ms   282ms   295ms   288ms   293ms     6ms   279ms
# Lock time      0   192us    41us    76us    64us    73us    15us    73us
# Rows sent     20      57      19      19      19      19       0      19
# Rows examine  75   1.39k     476     476     476     476       0     476
# Query size    35     444     148     148     148     148       0     148
# String:
# Databases    dreamkast
# Hosts        10.0.189.206
# Users        admin
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms
# 100ms  ################################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `dreamkast` LIKE 'talks'\G
#    SHOW CREATE TABLE `dreamkast`.`talks`\G
#    SHOW TABLE STATUS FROM `dreamkast` LIKE 'talk_difficulties'\G
#    SHOW CREATE TABLE `dreamkast`.`talk_difficulties`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT t.id,t.title,td.name AS talk_difficulty FROM talks t LEFT JOIN talk_difficulties td ON t.talk_difficulty_id = td.id WHERE t.conference_id='5'\G
```

Before:
```
mysql> EXPLAIN SELECT t.id,t.title,td.name AS talk_difficulty FROM talks t LEFT JOIN talk_difficulties td ON t.talk_difficulty_id = td.id WHERE t.conference_id='5';
+----+-------------+-------+------------+--------+---------------+---------+---------+--------------------------------+------+----------+-------------+
| id | select_type | table | partitions | type   | possible_keys | key     | key_len | ref                            | rows | filtered | Extra       |
+----+-------------+-------+------------+--------+---------------+---------+---------+--------------------------------+------+----------+-------------+
|  1 | SIMPLE      | t     | NULL       | ALL    | NULL          | NULL    | NULL    | NULL                           |  269 |    10.00 | Using where |
|  1 | SIMPLE      | td    | NULL       | eq_ref | PRIMARY       | PRIMARY | 8       | dreamkast.t.talk_difficulty_id |    1 |   100.00 | NULL        |
+----+-------------+-------+------------+--------+---------------+---------+---------+--------------------------------+------+----------+-------------+
2 rows in set, 1 warning (0.00 sec)
```

After:
```
mysql> EXPLAIN SELECT t.id,t.title,td.name AS talk_difficulty FROM talks t LEFT JOIN talk_difficulties td ON t.talk_difficulty_id = td.id WHERE t.conference_id='5';
+----+-------------+-------+------------+--------+------------------------------+------------------------------+---------+--------------------------------+------+----------+-------+
| id | select_type | table | partitions | type   | possible_keys                | key                          | key_len | ref                            | rows | filtered | Extra |
+----+-------------+-------+------------+--------+------------------------------+------------------------------+---------+--------------------------------+------+----------+-------+
|  1 | SIMPLE      | t     | NULL       | ref    | index_talks_on_conference_id | index_talks_on_conference_id | 5       | const                          |    1 |   100.00 | NULL  |
|  1 | SIMPLE      | td    | NULL       | eq_ref | PRIMARY                      | PRIMARY                      | 8       | dreamkast.t.talk_difficulty_id |    1 |   100.00 | NULL  |
+----+-------------+-------+------------+--------+------------------------------+------------------------------+---------+--------------------------------+------+----------+-------+
```

rows がだいぶ削減されているので改善はできてそう。