### PR TITLE
allow channel_id is null because this column value is null when record is created

### DIFF
--- a/app/models/media_package_channel.rb
+++ b/app/models/media_package_channel.rb
@@ -3,7 +3,7 @@
 # Table name: media_package_channels
 #
 #  id            :bigint           not null, primary key
-#  channel_id    :string(255)      not null
+#  channel_id    :string(255)      default("")
 #  conference_id :bigint           not null
 #  track_id      :bigint           not null
 #

--- a/db/migrate/20220119113029_create_media_package_channels_and_origin_endpoints.rb
+++ b/db/migrate/20220119113029_create_media_package_channels_and_origin_endpoints.rb
@@ -3,7 +3,7 @@ class CreateMediaPackageChannelsAndOriginEndpoints < ActiveRecord::Migration[6.0
     create_table :media_package_channels do |t|
       t.belongs_to :conference, null: false, foreign_key: true
       t.belongs_to :track, null: false, foreign_key: true
-      t.string :channel_id, null: false
+      t.string :channel_id, null: true
       t.index :channel_id, unique: true
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_113029) do
   create_table "media_package_channels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.bigint "track_id", null: false
-    t.string "channel_id", null: false
+    t.string "channel_id", default: ""
     t.index ["channel_id"], name: "index_media_package_channels_on_channel_id", unique: true
     t.index ["conference_id"], name: "index_media_package_channels_on_conference_id"
     t.index ["track_id"], name: "index_media_package_channels_on_track_id"


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/1096 でchannel_idをnull: falseにしていたが、channel_idはレコード作成時には何も値が入らないのでnullを許容する必要があった。