### PR TITLE
アーカイブ動画作成の改善

### DIFF
--- a/app/controllers/admin/harvest_jobs_controller.rb
+++ b/app/controllers/admin/harvest_jobs_controller.rb
@@ -1,0 +1,41 @@
+class Admin::HarvestJobsController < ApplicationController
+  include SecuredAdmin
+  include LogoutHelper
+
+  def index
+    @harvest_jobs = @conference.media_package_harvest_jobs
+  end
+
+  def new
+    @harvest_job = MediaPackageHarvestJob.new
+    @talk = Talk.find(params[:talk_id])
+
+    @initial_start_time = "#{initial_date}T#{@talk.start_time.strftime('%H:%M')}:00+09:00"
+    @initial_end_time = "#{initial_date}T#{@talk.end_time.strftime('%H:%M')}:00+09:00"
+    @base_url = @talk.track.media_package_channel.media_package_origin_endpoints.first.origin_endpoint.url
+    @preview_url = "#{@base_url}?start=#{@initial_start_time}&end=#{@initial_end_time}"
+  end
+
+  def create
+    @job = MediaPackageHarvestJob.new(harvest_job_params.merge(conference_id: @conference.id))
+
+    respond_to do |format|
+      if @job.save
+        @job.create_media_package_resources
+        format.html { redirect_to(admin_tracks_path, notice: 'HarvestJob was successfully updated.') }
+        format.json { render(:show, status: :ok, location: @job) }
+      else
+        format.html { redirect_to(admin_tracks_path, flash: { error: @job.errors.messages }) }
+        format.json { render(json: @job.errors, status: :unprocessable_entity) }
+      end
+    end
+  end
+
+  def initial_date
+    @talk.conference_day.date.strftime('%Y-%m-%d')
+  end
+
+  def harvest_job_params
+    params.require(:media_package_harvest_job).permit(:conference_id, :media_package_channel_id, :talk_id, :start_time, :end_time)
+  end
+end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -52,6 +52,7 @@ class Conference < ApplicationRecord
   has_many :stats_of_registrants
   has_many :admin_profiles
   has_many :live_stream_media_live
+  has_many :media_package_harvest_jobs
 
   scope :upcoming, -> {
     merge(where(status: 0).or(where(status: 1)))

--- a/app/models/media_package_harvest_job.rb
+++ b/app/models/media_package_harvest_job.rb
@@ -1,0 +1,78 @@
+# == Schema Information
+#
+# Table name: media_package_harvest_jobs
+#
+#  id                       :bigint           not null, primary key
+#  end_time                 :datetime
+#  start_time               :datetime
+#  status                   :string(255)
+#  conference_id            :bigint           not null
+#  job_id                   :string(255)
+#  media_package_channel_id :bigint           not null
+#  talk_id                  :bigint           not null
+#
+# Indexes
+#
+#  index_media_package_harvest_jobs_on_conference_id             (conference_id)
+#  index_media_package_harvest_jobs_on_media_package_channel_id  (media_package_channel_id)
+#  index_media_package_harvest_jobs_on_talk_id                   (talk_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#  fk_rails_...  (media_package_channel_id => media_package_channels.id)
+#  fk_rails_...  (talk_id => talks.id)
+#
+class MediaPackageHarvestJob < ApplicationRecord
+  include MediaPackageHelper
+  include EnvHelper
+
+  belongs_to :conference
+  belongs_to :media_package_channel
+  belongs_to :talk
+
+  def job
+    @job ||= media_package_client.describe_harvest_job(id: job_id)
+  end
+
+  def create_media_package_resources
+    resp = media_package_client.create_harvest_job(create_params)
+    resp = media_package_client.describe_harvest_job(id: resp.id)
+    update!(job_id: resp.id, status: resp.status)
+  rescue => e
+    logger.error(e.message)
+  end
+
+  private
+
+  def create_params
+    {
+      id: "#{resource_name}_#{id}",
+      start_time: start_time.strftime('%Y-%m-%dT%H:%M:%S%:z'),
+      end_time: end_time.strftime('%Y-%m-%dT%H:%M:%S%:z'),
+      origin_endpoint_id: origin_endpoint,
+      s3_destination: {
+        bucket_name: bucket_name,
+        manifest_key: manifest_key,
+        role_arn: 'arn:aws:iam::607167088920:role/MediaPackageLivetoVOD-Policy'
+      }
+    }
+  end
+
+  def origin_endpoint
+    "#{env_name}_#{@job.conference.abbr}_track#{@job.talk.track.name}"
+  end
+
+  def manifest_key
+    "mediapackage/#{conference.abbr}/talks/#{talk_id}/playlist.m3u8"
+  end
+
+  def resource_name
+    track = media_package_channel.track
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}_track#{track.name}"
+    else
+      "#{env_name}_#{conference.abbr}_track#{track.name}"
+    end
+  end
+end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -45,6 +45,7 @@ class Talk < ApplicationRecord
   has_many :registered_talks
   has_many :speakers, through: :talks_speakers
   has_many :profiles, through: :registered_talks
+  has_many :media_package_harvest_jobs
 
   has_many :proposal_items, autosave: true, dependent: :destroy
 

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -16,6 +16,7 @@
     <%= render 'admin/nav_item', name: 'TimeTable', path: admin_timetables_path, active: controller_name == 'timetables' %>
     <%= render 'admin/nav_item', name: 'Tracks', path: admin_tracks_path, active: controller_name == 'tracks'%>
     <%= render 'admin/nav_item', name: 'IVS', path: admin_live_stream_ivs_path, active: action_name == 'live_stream_ivs' %>
+    <%= render 'admin/nav_item', name: 'HarvestJobs', path: admin_harvest_jobs_path, active: action_name == 'media_package_harvest_job' %>
     <%= render 'admin/nav_item', name: 'Statistics', path: admin_statistics_path, active: action_name == 'statistics' %>
     <%= render 'admin/nav_item', name: 'Sponsors', path: admin_sponsors_path, active: controller_name == 'sponsors' || action_name == 'show_sponsor' %>
     <%= render 'admin/nav_item', name: 'Booths', path: admin_booths_path, active: controller_name == 'booths' || action_name == 'show_booth' %>

--- a/app/views/admin/harvest_jobs/_form.html.erb
+++ b/app/views/admin/harvest_jobs/_form.html.erb
@@ -1,0 +1,71 @@
+<div class="modal-dialog modal-lg" role="document">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="card-title">アーカイブ動画を作成する</h5>
+
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+
+    <div class="modal-body">
+      <div id="preview_url"><%= @preview_url %></div>
+
+      <video
+        id="my-player"
+        class="video-js vjs-default-skin"
+        data-setup='{"fluid": true}'
+        controls
+        preload="auto"
+      >
+        <source src="<%= @preview_url %>" type="application/x-mpegURL" />
+      </video>
+
+      <%= form_with(url: admin_harvest_jobs_path, model: @harvest_job, method: :post) do |form| %>
+        <section class="speaker-information py-3">
+          <%= form.hidden_field :media_package_channel_id, value: 11 %>
+          <%= form.hidden_field :talk_id, value: @talk.id %>
+
+          <div class="field">
+            <%= form.label :start_time,'切り出し開始時刻' %>*<br/>
+            <%= form.text_field :start_time, value: @initial_start_time, id: 'start-time-field', class: 'form-control' %>
+          </div>
+
+          <div class="field">
+            <%= form.label :end_time, '切り出し終了時刻' %>*<br/>
+            <%= form.text_field :end_time, value: @initial_end_time, id: 'end-time-field', class: 'form-control' %>
+          </div>
+
+          <div class="field">
+            <button type="button" id="update-start-and-end" class="btn btn-secondary">Update</button>
+          </div>
+
+          <div class="actions justify-content-center py-3">
+            <%= form.submit class: "btn btn-primary btn-lg btn-block" %>
+          </div>
+        </section>
+      <% end %>
+
+
+    </div>
+
+    <div class="modal-footer">
+      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  const player = videojs('my-player');
+  function inputChange(){
+    const s = document.getElementById('start-time-field').value;
+    const e = document.getElementById('end-time-field').value
+    const preview_url = `<%= @base_url %>?start=${s}&end=${e}`
+    document.getElementById('preview_url').innerHTML = preview_url
+    player.src(preview_url)
+  }
+  s = document.getElementById('update-start-and-end')
+  s.addEventListener( "click", inputChange ) ;
+
+  player.play();
+</script>

--- a/app/views/admin/harvest_jobs/index.html.erb
+++ b/app/views/admin/harvest_jobs/index.html.erb
@@ -1,0 +1,26 @@
+<%= render 'admin/layout' do %>
+  <h1>HarvestJobs</h1>
+
+  <table class="table table-striped talks_table" >
+    <thead>
+    <tr>
+      <th scope="col">ID</th>
+      <th scope="col">Harvest Job ID</th>
+      <th scope="col">Harvest Job Status</th>
+      <th scope="col">StartTime</th>
+      <th scope="col">EndTime</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @harvest_jobs.each do |harvest_job| %>
+      <tr>
+        <td><%= harvest_job.id %></td>
+        <td><%= harvest_job.job_id %></td>
+        <td><%= harvest_job.job.status %></td>
+        <td><%= harvest_job.start_time %></td>
+        <td><%= harvest_job.end_time %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/admin/harvest_jobs/new.html.erb
+++ b/app/views/admin/harvest_jobs/new.html.erb
@@ -1,0 +1,9 @@
+<%= render 'admin/layout' do %>
+  <h1>New HarvestJob</h1>
+
+  <div class="row speaker-dashboard-form justify-content-center">
+    <div class="col-12 col-lg-8">
+      <%= render 'admin/harvest_jobs/form' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/tracks/_tracks_nav_cndt2021.html.erb
+++ b/app/views/admin/tracks/_tracks_nav_cndt2021.html.erb
@@ -23,6 +23,7 @@
     <th scope="col">Title</th>
     <th scope="col">On Air</th>
     <th scope="col">Recording</th>
+    <th scope="col">Recording Status</th>
   </tr>
   </thead>
 

--- a/app/views/admin/tracks/partial/_talks_table.erb
+++ b/app/views/admin/tracks/partial/_talks_table.erb
@@ -24,35 +24,17 @@
       <% end %>
     </td>
     <td>
+      <%= link_to "録画する", new_admin_harvest_job_path(talk_id: talk.id) %>
+    </td>
+    <td>
       <% if talk.video && talk.speakers.size > 0 %>
         <% if !waiting_to_stop?(talk) && already_recorded?(talk) %>
           <div class="btn btn-primary">録画済み</div>
         <% else %>
-          <%= form_with(url: recording_url(talk), id: "talk_list_#{conference_day.date}_#{track.number}", method: "post", class: "talk_list_form") do |f| %>
-            <%= f.hidden_field "talk[id]", value: talk.id %>
-            <%= f.hidden_field "talk[date]", value: conference_day.date %>
-            <%= f.hidden_field "talk[track_name]", value: talk.track.name %>
-            <div class="on_air_group btn-group-toggle">
-              <% if waiting_to_start?(talk) || waiting_to_stop?(talk) %>
-                <div class="spinner-border" role="status">
-                  <span class="sr-only">Loading...</span>
-                </div>
-                <div class="btn btn-primary"><%= recording_control_button_label(talk) %></div>
-              <% else %>
-
-                <%= f.submit recording_control_button_label(talk),
-                             id: "recording_button_#{talk.id}",
-                             class: "btn btn-#{recording?(talk) ? 'danger' : 'secondary'} on_air_button #{recording?(talk) ? 'active' : ''}",
-                             autocomplete: "off",
-                             track_name: talk.track.name,
-                             talk_id: talk.id,
-                             data: { confirm: confirm_recording_message(track, talk), disable_with: "送信中..."}
-                %>
-              <% end %>
-            </div>
-          <% end %>
+        未録画
         <% end %>
       <% end %>
     </td>
   </tr>
 <% end %>
+<div class="modal fade" id="talk-modal" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
       post 'bulk_delete_media_live' => 'live_stream_media_live#bulk_delete'
       post 'bulk_create_media_package' => 'live_stream_media_package#bulk_create'
       post 'bulk_delete_media_package' => 'live_stream_media_package#bulk_delete'
+      resources :harvest_jobs
     end
 
     get '/team' => 'teams#show'

--- a/db/migrate/20220123073409_create_media_package_harvest_jobs_table.rb
+++ b/db/migrate/20220123073409_create_media_package_harvest_jobs_table.rb
@@ -1,0 +1,13 @@
+class CreateMediaPackageHarvestJobsTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :media_package_harvest_jobs do |t|
+      t.belongs_to :conference, null: false, foreign_key: true
+      t.belongs_to :media_package_channel, null: false, foreign_key: true
+      t.belongs_to :talk, null: false, foreign_key: true
+      t.string :job_id
+      t.string :status
+      t.datetime :start_time
+      t.datetime :end_time
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_113029) do
+ActiveRecord::Schema.define(version: 2022_01_23_073409) do
 
   create_table "access_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
@@ -157,6 +157,19 @@ ActiveRecord::Schema.define(version: 2022_01_19_113029) do
     t.index ["channel_id"], name: "index_media_package_channels_on_channel_id", unique: true
     t.index ["conference_id"], name: "index_media_package_channels_on_conference_id"
     t.index ["track_id"], name: "index_media_package_channels_on_track_id"
+  end
+
+  create_table "media_package_harvest_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.bigint "media_package_channel_id", null: false
+    t.bigint "talk_id", null: false
+    t.string "job_id"
+    t.string "status"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.index ["conference_id"], name: "index_media_package_harvest_jobs_on_conference_id"
+    t.index ["media_package_channel_id"], name: "index_media_package_harvest_jobs_on_media_package_channel_id"
+    t.index ["talk_id"], name: "index_media_package_harvest_jobs_on_talk_id"
   end
 
   create_table "media_package_origin_endpoints", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
@@ -436,6 +449,9 @@ ActiveRecord::Schema.define(version: 2022_01_19_113029) do
   add_foreign_key "live_streams", "tracks"
   add_foreign_key "media_package_channels", "conferences"
   add_foreign_key "media_package_channels", "tracks"
+  add_foreign_key "media_package_harvest_jobs", "conferences"
+  add_foreign_key "media_package_harvest_jobs", "media_package_channels"
+  add_foreign_key "media_package_harvest_jobs", "talks"
   add_foreign_key "media_package_origin_endpoints", "conferences"
   add_foreign_key "media_package_origin_endpoints", "media_package_channels"
   add_foreign_key "proposal_item_configs", "conferences"

--- a/lib/tasks/polling_harvest_job_and_update_video.rake
+++ b/lib/tasks/polling_harvest_job_and_update_video.rake
@@ -1,0 +1,29 @@
+namespace :util do
+  desc 'polling harvest job and update video'
+  task polling_harvest_job_and_update_video: :environment do
+    include EnvHelper
+    include MediaPackageHelper
+
+    client = media_package_client
+    MediaPackageHarvestJob.where(status: 'IN_PROGRESS').each do |harvest_job|
+      r = client.describe_harvest_job(id: harvest_job.job_id)
+      harvest_job.update!(status: r.status)
+
+      url = "https://#{cloudfront_domain_name(r.s3_destination.bucket_name)}/#{r.s3_destination.manifest_key}"
+      if r.status == 'SUCCEEDED' && harvest_job.talk.video_id == ''
+        harvest_job.talk.video.update!(video_id: url)
+      end
+    end
+  end
+
+  def cloudfront_domain_name(bucket_name)
+    case bucket_name
+    when 'dreamkast-ivs-stream-archive-prd'
+      'd3pun3ptcv21q4.cloudfront.net'
+    when 'dreamkast-ivs-stream-archive-stg'
+      'd3i2o0iduabu0p.cloudfront.net'
+    else
+      'd1jzp6sbtx9by.cloudfront.net'
+    end
+  end
+end

--- a/lib/tasks/polling_harvest_job_and_update_video.rake
+++ b/lib/tasks/polling_harvest_job_and_update_video.rake
@@ -6,11 +6,11 @@ namespace :util do
 
     client = media_package_client
     MediaPackageHarvestJob.where(status: 'IN_PROGRESS').each do |harvest_job|
-      r = client.describe_harvest_job(id: harvest_job.job_id)
-      harvest_job.update!(status: r.status)
+      resp = client.describe_harvest_job(id: harvest_job.job_id)
+      harvest_job.update!(status: resp.status)
 
-      url = "https://#{cloudfront_domain_name(r.s3_destination.bucket_name)}/#{r.s3_destination.manifest_key}"
-      if r.status == 'SUCCEEDED' && harvest_job.talk.video_id == ''
+      url = "https://#{cloudfront_domain_name(resp.s3_destination.bucket_name)}/#{resp.s3_destination.manifest_key}"
+      if resp.status == 'SUCCEEDED' && harvest_job.talk.video_id == ''
         harvest_job.talk.video.update!(video_id: url)
       end
     end

--- a/lib/tasks/polling_harvest_job_and_update_video.rake
+++ b/lib/tasks/polling_harvest_job_and_update_video.rake
@@ -4,9 +4,8 @@ namespace :util do
     include EnvHelper
     include MediaPackageHelper
 
-    client = media_package_client
     MediaPackageHarvestJob.where(status: 'IN_PROGRESS').each do |harvest_job|
-      resp = client.describe_harvest_job(id: harvest_job.job_id)
+      resp = harvest_job.job
       harvest_job.update!(status: resp.status)
 
       url = "https://#{cloudfront_domain_name(resp.s3_destination.bucket_name)}/#{resp.s3_destination.manifest_key}"


### PR DESCRIPTION
- このPRは配信・録画アーキテクチャ変更の一環で、録画アーキテクチャ部分を変更します。
- 全体の変更プランは https://github.com/cloudnativedaysjp/dreamkast/issues/989 のDescriptionを参照
- harvest_jobsテーブルを追加
  - MediaLive HarvestJobを管理するためのテーブル
- admin/tracksに `録画する` ボタンを追加
  - クリックするとそのHarvestJobの作成画面に遷移する
  - HarvestJobの作成画面には録画開始時刻と終了時刻の入力フォームがある
  - 開始時刻と終了時刻のデフォルト値はそのセッションの開始時刻と終了時刻
  - 当日の進行状況によっては開始時刻・終了時刻が変わる可能性があるので変更可能になっている
  - MediaPackageのタイムシフト再生と開始時刻・終了時刻を使ってプレビューできるようになっている
  - HarvestJobを作成するとAWS側でアーカイブ動画の作成が行われる
  - RakeタスクでHarvestJobの状態をポーリングし、アーカイブ動画の作成が完了したらHarvestJobレコードとセッションの動画URLを更新する
    - RakeタスクはCronJobで定期実行することを想定