### PR TITLE
プロポーザルでセッション時間の項目がない場合、タイムテーブル作成画面のセッション時間が0になる問題を修正

### DIFF
--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -36,7 +36,7 @@ class Speaker < ApplicationRecord
   validates :conference_id, presence: true
 
   def proposals
-    talks.map(&:proposals)
+    talks.map(&:proposal)
   end
 
   def sponsor_talks

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -233,7 +233,8 @@ class Talk < ApplicationRecord
     session_time = proposal_items.find_by(label: 'session_time')
     return ProposalItemConfig.find(session_time.params.to_i).params.split('min')[0].to_i if session_time
 
-    talk_time.present? ? talk_time.time_minutes : 0
+    # プロポーザルでセッションの時間を選択するカンファレンスと選択しないカンファレンスがあり、選択しない場合はデフォルト値として40分とする
+    talk_time.present? ? talk_time.time_minutes : 40
   end
 
   def start_to_end

--- a/spec/factories/proposal_item_configs.rb
+++ b/spec/factories/proposal_item_configs.rb
@@ -70,6 +70,30 @@ FactoryBot.define do
     params { 'Dev/QA（開発環境）' }
   end
 
+  factory :proposal_item_configs_assumed_visitor, class: ProposalItemConfig do
+    type { 'ProposalItemConfigCheckBox' }
+    label { 'assumed_visitor' }
+    item_number { 1 }
+    item_name { '想定受講者（★★）' }
+    params { 'architect - システム設計' }
+  end
+
+  factory :proposal_item_configs_presentation_method, class: ProposalItemConfig do
+    type { 'ProposalItemConfigRadioButton' }
+    label { 'presentation_method' }
+    item_number { 1 }
+    item_name { '登壇方法の希望' }
+    params { '現地登壇' }
+  end
+
+  factory :proposal_item_configs_session_time, class: ProposalItemConfig do
+    type { 'ProposalItemConfigRadioButton' }
+    label { 'session_time' }
+    item_number { 1 }
+    item_name { '必要とする講演時間 - Session time you need（★）' }
+    params { '40min (full session)' }
+  end
+
   factory :proposal_item_configs_whether_it_can_be_published, class: ProposalItemConfig do
     conference_id { 1 }
     type { 'ProposalItemConfigRadioButton' }

--- a/spec/requests/speaker_dashboard/speaker_create_spec.rb
+++ b/spec/requests/speaker_dashboard/speaker_create_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe(SpeakerDashboard::SpeakersController, type: :request) do
+  admin_userinfo = { userinfo: { info: { email: 'alice@example.com' }, extra: { raw_info: { sub: 'aaaa', 'https://cloudnativedays.jp/roles' => ['CNDT2020-Admin'] } } } }
+  context 'user already logged in' do
+    context "user doesn't registered" do
+      before do
+        allow_any_instance_of(ActionDispatch::Request).to(receive(:session).and_return(admin_userinfo))
+      end
+
+      describe 'register speaker and proposal without session time selection' do
+        let(:conference) { create(:cndt2020, :registered, :speaker_entry_enabled) }
+        let(:execution_phase) { create(:proposal_item_configs_execution_phase, conference: conference) }
+        let(:assumed_visitor) { create(:proposal_item_configs_assumed_visitor, conference: conference) }
+        let(:whether_it_can_be_published) { create(:proposal_item_configs_whether_it_can_be_published, :all_ok, conference: conference) }
+        let(:presentation_method) { create(:proposal_item_configs_presentation_method, conference: conference) }
+
+        it 'talk\'s session time should be 40 minutes (default value)' do
+          params = {
+            'name' => 'Takaishi Ryo',
+            'name_mother_tongue' => '髙石 諒',
+            'profile' => 'Hello',
+            'company' => 'クラウドネイティブデイズ株式会社',
+            'job_title' => '凄腕エンジニア',
+            'additional_documents' => '',
+            'twitter_id' => '',
+            'github_id' => '',
+            'avatar' => '',
+            'conference_id' => conference.id,
+            'talks_attributes' => {
+              '1644323265675' =>
+                {
+                  'title' => 'すごいセッション',
+                  'abstract' => 'すごいぞ！',
+                  'talk_difficulty_id' => '41',
+                  'assumed_visitors' => [assumed_visitor.id],
+                  'execution_phases' => [execution_phase.id],
+                  'presentation_methods' => presentation_method.id,
+                  'whether_it_can_be_publisheds' => whether_it_can_be_published.id,
+                  '_destroy' => 'false',
+                  'conference_id' => conference.id
+                }
+            }
+          }
+          post('/cndt2020/speaker_dashboard/speakers', params: { speaker: params })
+
+          expect(response).to_not(be_successful)
+          expect(response).to(have_http_status('302'))
+          expect(response).to(redirect_to('/cndt2020/speaker_dashboard'))
+
+          speaker = Speaker.find_by(name: 'Takaishi Ryo')
+          expect(speaker).to_not(be_nil)
+          expect(speaker.proposals.size).to(eq(1))
+
+          talk = speaker.talks.first
+          expect(talk.time).to(eq(40))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
fix: https://github.com/cloudnativedaysjp/dreamkast/issues/1125