### PR TITLE
Add exporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'jbuilder', '~> 2.7'
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+# Use Prometheus client
+gem 'prometheus-client', '~> 3.0.0'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,6 +387,7 @@ GEM
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
+    prometheus-client (3.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -620,6 +621,7 @@ DEPENDENCIES
   opentelemetry-exporter-jaeger
   opentelemetry-instrumentation-all
   opentelemetry-sdk
+  prometheus-client (~> 3.0.0)
   pry-rails
   puma (~> 4.3)
   pundit
@@ -659,4 +661,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.22
+   2.2.32

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'
-
+require 'prometheus/middleware/exporter'
+use Prometheus::Middleware::CustomExporter
 run Rails.application

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -35,7 +35,6 @@ module Prometheus
       def calculate_viewer_count
         accepted_talks = Talk.accepted.pluck(:id)
 
-
         vcs = ViewerCount.select(
           [
             :conference_id, :track_id, :talk_id, ViewerCount.arel_table[:count].maximum.as('count')

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -37,7 +37,7 @@ module Prometheus
 
         max_ids = ViewerCount.where(talk_id: accepted_talks).group(:talk_id).maximum(:id)
 
-        max_id_array=[]
+        max_id_array = []
         max_ids.each do |max_id|
           max_id_array.append(max_id.last)
         end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -6,8 +6,17 @@ module Prometheus
   module Controller
     metrics_prefix = 'dreamkast'
     prometheus = Prometheus::Client.registry
-    VIEWER_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_viewer_count".to_sym, docstring: "Count #{metrics_prefix} viewer number", labels: [:track_id])
-    CHAT_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_chat_count".to_sym, docstring: "Count #{metrics_prefix} chat number", labels: [:room_id])
+    VIEWER_COUNT = Prometheus::Client::Gauge.new(
+      "#{metrics_prefix}_viewer_count".to_sym,
+      docstring: "Count #{metrics_prefix} viewer number",
+      labels: [:talk_id, :track_id, :conference_id]
+    )
+
+    CHAT_COUNT = Prometheus::Client::Gauge.new(
+      "#{metrics_prefix}_chat_count".to_sym,
+      docstring: "Count #{metrics_prefix} chat number",
+      labels: [:conference_id, :talk_id]
+    )
 
     prometheus.register(VIEWER_COUNT)
     prometheus.register(CHAT_COUNT)
@@ -16,25 +25,37 @@ module Prometheus
   module Middleware
     class CustomExporter < Prometheus::Middleware::Exporter
       def respond_with(format)
-        conferences = Conference.all
-        puts(conferences)
-        conferences.each do |conference|
-          tracks = Track.where(conference_id: conference.id)
-          tracks.each do |track|
-            vc = ViewerCount.where(track_id: track.id).order(created_at: :desc).limit(1)[0]
-            puts(vc.to_s)
-            unless vc.nil?
-              Prometheus::Controller::VIEWER_COUNT.set(vc.count, labels: { track_id: track.id })
-            end
-          end
-          chat_counts = ChatMessage.where(conference_id: conference.id).group('room_id').count
-
-          chat_counts.each do |chat_count|
-            Prometheus::Controller::CHAT_COUNT.set(chat_count.count_all, labels: { room_id: chat_count.chat_messages_room_id })
-          end
-        end
-
+        calculate_viewer_count
+        calculate_chat_count
         super
+      end
+
+      private
+
+      def calculate_viewer_count
+        vcs = ViewerCount.all
+        vcs.each do |vc|
+          Prometheus::Controller::VIEWER_COUNT.set(
+            vc.count,
+            labels: { talk_id: vc.talk_id, track_id: vc.track_id, conference_id: vc.conference_id }
+          )
+        end
+      end
+
+      def calculate_chat_count
+        chat_counts = ChatMessage.all.select(
+          [
+            :conference_id, :speaker_id, ChatMessage.arel_table[:speaker_id].count.as('count')
+          ]
+        ).group(:conference_id, :speaker_id)
+
+        chat_counts.each do |chat_count|
+          talk_id = TalksSpeaker.where(speaker_id: chat_count.speaker_id).limit(1)[0].talk_id
+          Prometheus::Controller::CHAT_COUNT.set(
+            chat_count.count,
+            labels: { conference_id: chat_count.conference_id, talk_id: talk_id }
+          )
+        end
       end
     end
   end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -33,7 +33,15 @@ module Prometheus
       private
 
       def calculate_viewer_count
-        vcs = ViewerCount.all
+        accepted_talks = Talk.accepted.pluck(:id)
+
+
+        vcs = ViewerCount.select(
+          [
+            :conference_id, :track_id, :talk_id, ViewerCount.arel_table[:count].maximum.as('count')
+          ]
+        ).where(talk_id: accepted_talks).group(:conference_id, :track_id, :talk_id)
+
         vcs.each do |vc|
           Prometheus::Controller::VIEWER_COUNT.set(
             vc.count,
@@ -45,15 +53,14 @@ module Prometheus
       def calculate_chat_count
         chat_counts = ChatMessage.all.select(
           [
-            :conference_id, :speaker_id, ChatMessage.arel_table[:speaker_id].count.as('count')
+            :conference_id, :room_id, ChatMessage.arel_table[:room_id].count.as('count')
           ]
-        ).group(:conference_id, :speaker_id)
+        ).group(:conference_id, :room_id)
 
         chat_counts.each do |chat_count|
-          talk_id = TalksSpeaker.where(speaker_id: chat_count.speaker_id).limit(1)[0].talk_id
           Prometheus::Controller::CHAT_COUNT.set(
             chat_count.count,
-            labels: { conference_id: chat_count.conference_id, talk_id: talk_id }
+            labels: { conference_id: chat_count.conference_id, talk_id: chat_count.room_id }
           )
         end
       end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -35,11 +35,18 @@ module Prometheus
       def calculate_viewer_count
         accepted_talks = Talk.accepted.pluck(:id)
 
+        max_ids = ViewerCount.where(talk_id: accepted_talks).group(:talk_id).maximum(:id)
+
+        max_id_array=[]
+        max_ids.each do |max_id|
+          max_id_array.append(max_id.last)
+        end
+
         vcs = ViewerCount.select(
           [
-            :conference_id, :track_id, :talk_id, ViewerCount.arel_table[:count].maximum.as('count')
+            :conference_id, :track_id, :talk_id, :count
           ]
-        ).where(talk_id: accepted_talks).group(:conference_id, :track_id, :talk_id)
+        ).where(id: max_id_array)
 
         vcs.each do |vc|
           Prometheus::Controller::VIEWER_COUNT.set(

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,41 @@
+# prometheus.rb
+require 'prometheus/client'
+require 'prometheus/middleware/exporter'
+
+module Prometheus
+  module Controller
+    metrics_prefix = 'dreamkast'
+    prometheus = Prometheus::Client.registry
+    VIEWER_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_viewer_count".to_sym, docstring: "Count #{metrics_prefix} viewer number", labels: [:track_id])
+    CHAT_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_chat_count".to_sym, docstring: "Count #{metrics_prefix} chat number", labels: [:room_id])
+
+    prometheus.register(VIEWER_COUNT)
+    prometheus.register(CHAT_COUNT)
+  end
+
+  module Middleware
+    class CustomExporter < Prometheus::Middleware::Exporter
+      def respond_with(format)
+        conferences = Conference.all
+        puts(conferences)
+        conferences.each do |conference|
+          tracks = Track.where(conference_id: conference.id)
+          tracks.each do |track|
+            vc = ViewerCount.where(track_id: track.id).order(created_at: :desc).limit(1)[0]
+            puts(vc.to_s)
+            unless vc.nil?
+              Prometheus::Controller::VIEWER_COUNT.set(vc.count, labels: { track_id: track.id })
+            end
+          end
+          chat_counts = ChatMessage.where(conference_id: conference.id).group('room_id').count
+
+          chat_counts.each do |chat_count|
+            Prometheus::Controller::CHAT_COUNT.set(chat_count.count_all, labels: { room_id: chat_count.chat_messages_room_id })
+          end
+        end
+
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prometheus ExporterをDreamkastに追加。

# How this was tested.

以下のようなデータを用意。

`Chat_Messages`
```
id,body,children_count,room_type,conference_id,parent_id,profile_id,room_id,speaker_id
1,aaaa,0,0,3,,,,201
2,BBBBBBB,0,0,3,,,,201
3,CC,0,0,3,,,,202
4,CC,0,0,4,,,,301
5,CC,0,0,4,,,,301
```

`Viewer_Count`
```
id,count,stream_type,conference_id,talk_id,track_id
1,10,hoge,3,201,1
2,20,hoge,3,202,3
3,150,hoge,4,401,1
4,200,hoge,5,502,2
```

これで `curl 0.0.0.0:3000/metrics` で実行した結果いかに

```
# TYPE dreamkast_viewer_count gauge
# HELP dreamkast_viewer_count Count dreamkast viewer number
dreamkast_viewer_count{talk_id="201",track_id="1",conference_id="3"} 10.0
dreamkast_viewer_count{talk_id="202",track_id="3",conference_id="3"} 20.0
dreamkast_viewer_count{talk_id="401",track_id="1",conference_id="4"} 150.0
dreamkast_viewer_count{talk_id="502",track_id="2",conference_id="5"} 200.0
# TYPE dreamkast_chat_count gauge
# HELP dreamkast_chat_count Count dreamkast chat number
dreamkast_chat_count{conference_id="3",talk_id="201"} 2.0
dreamkast_chat_count{conference_id="3",talk_id="202"} 1.0
dreamkast_chat_count{conference_id="4",talk_id="301"} 2.0
```
