### PR TITLE
Add exporter (変更案)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'jbuilder', '~> 2.7'
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+# Use Prometheus client
+gem 'prometheus-client', '~> 3.0.0'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,6 +387,7 @@ GEM
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
+    prometheus-client (3.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -620,6 +621,7 @@ DEPENDENCIES
   opentelemetry-exporter-jaeger
   opentelemetry-instrumentation-all
   opentelemetry-sdk
+  prometheus-client (~> 3.0.0)
   pry-rails
   puma (~> 4.3)
   pundit
@@ -659,4 +661,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.22
+   2.2.32

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -661,4 +661,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.32
+   2.2.22

--- a/app/middlewares/prometheus_exporter.rb
+++ b/app/middlewares/prometheus_exporter.rb
@@ -1,0 +1,32 @@
+module Prometheus
+  module Middleware
+    class CustomExporter < Prometheus::Middleware::Exporter
+      def respond_with(format)
+        @registry.metrics.each do |metrics|
+          send(metrics.name, metrics)
+        end
+        super
+      end
+
+      private
+
+      def dreamkast_viewer_count(metrics)
+        ViewerCount.latest_viewer_counts.each do |vc|
+          metrics.set(
+            vc.count,
+            labels: { talk_id: vc.talk_id, track_id: vc.track_id, conference_id: vc.conference_id }
+          )
+        end
+      end
+
+      def dreamkast_chat_count(metrics)
+        ChatMessage.counts.each do |chat_count|
+          metrics.set(
+            chat_count.count,
+            labels: { conference_id: chat_count.conference_id, talk_id: chat_count.room_id }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -42,4 +42,10 @@ class ChatMessage < ApplicationRecord
   belongs_to :profile
 
   enum message_type: { chat: 0, qa: 1 }
+
+  def counts
+    ChatMessage.all.select(
+      [:conference_id, :room_id, ChatMessage.arel_table[:room_id].count.as('count')]
+    ).where(conference_id: Conference.opened.ids).group(:conference_id, :room_id)
+  end
 end

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -43,7 +43,7 @@ class ChatMessage < ApplicationRecord
 
   enum message_type: { chat: 0, qa: 1 }
 
-  def counts
+  def self.counts
     ChatMessage.all.select(
       [:conference_id, :room_id, ChatMessage.arel_table[:room_id].count.as('count')]
     ).where(conference_id: Conference.opened.ids).group(:conference_id, :room_id)

--- a/app/models/viewer_count.rb
+++ b/app/models/viewer_count.rb
@@ -18,4 +18,12 @@
 #  index_viewer_counts_on_track_id       (track_id)
 #
 class ViewerCount < ApplicationRecord
+  def latest_viewer_counts
+    on_air_ids = Talk.where(conference_id: Conference.opened.ids).on_air.pluck(:id)
+    latest_viwer_count_ids = where(talk_id: on_air_ids).group(:talk_id).maximum(:id).values
+
+    select(
+      [:conference_id, :track_id, :talk_id, :count]
+    ).where(id: latest_viwer_count_ids)
+  end
 end

--- a/app/models/viewer_count.rb
+++ b/app/models/viewer_count.rb
@@ -18,7 +18,7 @@
 #  index_viewer_counts_on_track_id       (track_id)
 #
 class ViewerCount < ApplicationRecord
-  def latest_viewer_counts
+  def self.latest_number_of_viewers
     on_air_ids = Talk.where(conference_id: Conference.opened.ids).on_air.pluck(:id)
     latest_viwer_count_ids = where(talk_id: on_air_ids).group(:talk_id).maximum(:id).values
 

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'
-require 'prometheus/middleware/exporter'
-use Prometheus::Middleware::CustomExporter
 run Rails.application

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative 'config/environment'
-
+require 'prometheus/middleware/exporter'
+use Prometheus::Middleware::CustomExporter
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,9 @@ require_relative 'boot'
 
 require 'rails/all'
 require 'csv'
+require 'prometheus/client'
+require 'prometheus/middleware/exporter'
+require_relative '../app/middlewares/prometheus_exporter'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -35,7 +35,6 @@ module Prometheus
       def calculate_viewer_count
         accepted_talks = Talk.accepted.pluck(:id)
 
-
         vcs = ViewerCount.select(
           [
             :conference_id, :track_id, :talk_id, ViewerCount.arel_table[:count].maximum.as('count')

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -37,7 +37,7 @@ module Prometheus
 
         max_ids = ViewerCount.where(talk_id: accepted_talks).group(:talk_id).maximum(:id)
 
-        max_id_array=[]
+        max_id_array = []
         max_ids.each do |max_id|
           max_id_array.append(max_id.last)
         end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -6,8 +6,17 @@ module Prometheus
   module Controller
     metrics_prefix = 'dreamkast'
     prometheus = Prometheus::Client.registry
-    VIEWER_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_viewer_count".to_sym, docstring: "Count #{metrics_prefix} viewer number", labels: [:track_id])
-    CHAT_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_chat_count".to_sym, docstring: "Count #{metrics_prefix} chat number", labels: [:room_id])
+    VIEWER_COUNT = Prometheus::Client::Gauge.new(
+      "#{metrics_prefix}_viewer_count".to_sym,
+      docstring: "Count #{metrics_prefix} viewer number",
+      labels: [:talk_id, :track_id, :conference_id]
+    )
+
+    CHAT_COUNT = Prometheus::Client::Gauge.new(
+      "#{metrics_prefix}_chat_count".to_sym,
+      docstring: "Count #{metrics_prefix} chat number",
+      labels: [:conference_id, :talk_id]
+    )
 
     prometheus.register(VIEWER_COUNT)
     prometheus.register(CHAT_COUNT)
@@ -16,25 +25,37 @@ module Prometheus
   module Middleware
     class CustomExporter < Prometheus::Middleware::Exporter
       def respond_with(format)
-        conferences = Conference.all
-        puts(conferences)
-        conferences.each do |conference|
-          tracks = Track.where(conference_id: conference.id)
-          tracks.each do |track|
-            vc = ViewerCount.where(track_id: track.id).order(created_at: :desc).limit(1)[0]
-            puts(vc.to_s)
-            unless vc.nil?
-              Prometheus::Controller::VIEWER_COUNT.set(vc.count, labels: { track_id: track.id })
-            end
-          end
-          chat_counts = ChatMessage.where(conference_id: conference.id).group('room_id').count
-
-          chat_counts.each do |chat_count|
-            Prometheus::Controller::CHAT_COUNT.set(chat_count.count_all, labels: { room_id: chat_count.chat_messages_room_id })
-          end
-        end
-
+        calculate_viewer_count
+        calculate_chat_count
         super
+      end
+
+      private
+
+      def calculate_viewer_count
+        vcs = ViewerCount.all
+        vcs.each do |vc|
+          Prometheus::Controller::VIEWER_COUNT.set(
+            vc.count,
+            labels: { talk_id: vc.talk_id, track_id: vc.track_id, conference_id: vc.conference_id }
+          )
+        end
+      end
+
+      def calculate_chat_count
+        chat_counts = ChatMessage.all.select(
+          [
+            :conference_id, :speaker_id, ChatMessage.arel_table[:speaker_id].count.as('count')
+          ]
+        ).group(:conference_id, :speaker_id)
+
+        chat_counts.each do |chat_count|
+          talk_id = TalksSpeaker.where(speaker_id: chat_count.speaker_id).limit(1)[0].talk_id
+          Prometheus::Controller::CHAT_COUNT.set(
+            chat_count.count,
+            labels: { conference_id: chat_count.conference_id, talk_id: talk_id }
+          )
+        end
       end
     end
   end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -33,7 +33,15 @@ module Prometheus
       private
 
       def calculate_viewer_count
-        vcs = ViewerCount.all
+        accepted_talks = Talk.accepted.pluck(:id)
+
+
+        vcs = ViewerCount.select(
+          [
+            :conference_id, :track_id, :talk_id, ViewerCount.arel_table[:count].maximum.as('count')
+          ]
+        ).where(talk_id: accepted_talks).group(:conference_id, :track_id, :talk_id)
+
         vcs.each do |vc|
           Prometheus::Controller::VIEWER_COUNT.set(
             vc.count,
@@ -45,15 +53,14 @@ module Prometheus
       def calculate_chat_count
         chat_counts = ChatMessage.all.select(
           [
-            :conference_id, :speaker_id, ChatMessage.arel_table[:speaker_id].count.as('count')
+            :conference_id, :room_id, ChatMessage.arel_table[:room_id].count.as('count')
           ]
-        ).group(:conference_id, :speaker_id)
+        ).group(:conference_id, :room_id)
 
         chat_counts.each do |chat_count|
-          talk_id = TalksSpeaker.where(speaker_id: chat_count.speaker_id).limit(1)[0].talk_id
           Prometheus::Controller::CHAT_COUNT.set(
             chat_count.count,
-            labels: { conference_id: chat_count.conference_id, talk_id: talk_id }
+            labels: { conference_id: chat_count.conference_id, talk_id: chat_count.room_id }
           )
         end
       end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -35,11 +35,18 @@ module Prometheus
       def calculate_viewer_count
         accepted_talks = Talk.accepted.pluck(:id)
 
+        max_ids = ViewerCount.where(talk_id: accepted_talks).group(:talk_id).maximum(:id)
+
+        max_id_array=[]
+        max_ids.each do |max_id|
+          max_id_array.append(max_id.last)
+        end
+
         vcs = ViewerCount.select(
           [
-            :conference_id, :track_id, :talk_id, ViewerCount.arel_table[:count].maximum.as('count')
+            :conference_id, :track_id, :talk_id, :count
           ]
-        ).where(talk_id: accepted_talks).group(:conference_id, :track_id, :talk_id)
+        ).where(id: max_id_array)
 
         vcs.each do |vc|
           Prometheus::Controller::VIEWER_COUNT.set(

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,41 @@
+# prometheus.rb
+require 'prometheus/client'
+require 'prometheus/middleware/exporter'
+
+module Prometheus
+  module Controller
+    metrics_prefix = 'dreamkast'
+    prometheus = Prometheus::Client.registry
+    VIEWER_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_viewer_count".to_sym, docstring: "Count #{metrics_prefix} viewer number", labels: [:track_id])
+    CHAT_COUNT = Prometheus::Client::Gauge.new("#{metrics_prefix}_chat_count".to_sym, docstring: "Count #{metrics_prefix} chat number", labels: [:room_id])
+
+    prometheus.register(VIEWER_COUNT)
+    prometheus.register(CHAT_COUNT)
+  end
+
+  module Middleware
+    class CustomExporter < Prometheus::Middleware::Exporter
+      def respond_with(format)
+        conferences = Conference.all
+        puts(conferences)
+        conferences.each do |conference|
+          tracks = Track.where(conference_id: conference.id)
+          tracks.each do |track|
+            vc = ViewerCount.where(track_id: track.id).order(created_at: :desc).limit(1)[0]
+            puts(vc.to_s)
+            unless vc.nil?
+              Prometheus::Controller::VIEWER_COUNT.set(vc.count, labels: { track_id: track.id })
+            end
+          end
+          chat_counts = ChatMessage.where(conference_id: conference.id).group('room_id').count
+
+          chat_counts.each do |chat_count|
+            Prometheus::Controller::CHAT_COUNT.set(chat_count.count_all, labels: { room_id: chat_count.chat_messages_room_id })
+          end
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,18 +1,1 @@
-Rails.application.config.middleware.use(Prometheus::Middleware::CustomExporter)
-
-prometheus = Prometheus::Client.registry
-
-viwer_count = Prometheus::Client::Gauge.new(
-  :dreamkast_viewer_count,
-  docstring: "Count dreamkast viewer number",
-  labels: [:talk_id, :track_id, :conference_id]
-)
-
-chat_count = Prometheus::Client::Gauge.new(
-  :dreamkast_chat_count,
-  docstring: "Count dreamkast chat number",
-  labels: [:conference_id, :talk_id]
-)
-
-prometheus.register(viwer_count)
-prometheus.register(chat_count)
+Rails.application.config.middleware.use(Prometheus::Middleware::DreamkastExporter)

--- a/spec/factories/chat_message.rb
+++ b/spec/factories/chat_message.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
+  sequence :body do |i|
+    "chat message #{i}"
+  end
+
   factory :message_from_alice, class: ChatMessage do
     id { 1 }
     body { 'chat message 1' }
@@ -17,5 +21,30 @@ FactoryBot.define do
     room_type { 'talk' }
     message_type { 0 }
     profile_id { 3 }
+  end
+
+  factory :messages, class: ChatMessage do
+    body { generate :body }
+    conference_id { 1 }
+    room_id { 1 }
+    room_type { 'talk' }
+    message_type { 0 }
+    profile_id { 1 }
+
+    trait :roomid1 do
+      room_id { 1 }
+    end
+
+    trait :roomid2 do
+      room_id { 2 }
+    end
+
+    trait :alice do
+      profile_id { 1 }
+    end
+
+    trait :bob do
+      profile_id { 3 }
+    end
   end
 end

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -70,7 +70,7 @@ FactoryBot.define do
   end
 
   factory :talk3, class: Talk do
-    id { 5 }
+    id { 3 }
     title { 'talk3' }
     start_time { '13:00' }
     end_time { '13:40' }
@@ -86,7 +86,7 @@ FactoryBot.define do
 
 
   factory :talk_rejekt, class: Talk do
-    id { 3 }
+    id { 5 }
     title { 'Rejected Talk' }
     start_time { '19:00' }
     end_time { '21:00' }

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -21,5 +21,13 @@ FactoryBot.define do
     on_air { false }
     slido_id { '1234' }
     video_id { '1234' }
+
+    trait :on_air do
+      on_air { true }
+    end
+
+    trait :off_air do
+      on_air { false }
+    end
   end
 end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -29,5 +29,13 @@ FactoryBot.define do
     trait :off_air do
       on_air { false }
     end
+
+    trait :talk1 do
+      talk_id { 1 }
+    end
+
+    trait :talk3 do
+      talk_id { 3 }
+    end
   end
 end

--- a/spec/factories/viewer_counts.rb
+++ b/spec/factories/viewer_counts.rb
@@ -25,4 +25,25 @@ FactoryBot.define do
     talk_id { 12 }
     count { 2 }
   end
+
+  sequence :countup do |i|
+    i
+  end
+  
+  factory :viewer_count, class: ViewerCount do
+    conference_id { 1 }
+    track_id { 1 }
+    stream_type { 'IVS' }
+    talk_id { 1 }
+    count { generate :countup }
+    trait :talk1 do
+      talk_id { 1 }
+      track_id { 1 }
+    end
+    trait :talk3 do
+      talk_id { 3 }
+      track_id { 3 }
+    end
+  end
 end
+

--- a/spec/factories/viewer_counts.rb
+++ b/spec/factories/viewer_counts.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
   sequence :countup do |i|
     i
   end
-  
+
   factory :viewer_count, class: ViewerCount do
     conference_id { 1 }
     track_id { 1 }
@@ -46,4 +46,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe(ChatMessage, type: :model) do
+  describe 'get message count' do
+    context 'with opened conference' do
+      before do
+        create(:talk1, conference: cndt2020)
+        create_list(:messages, 10, :alice, :roomid1, profile: alice)
+        create_list(:messages, 12, :bob, :roomid2, profile: bob)
+      end
+      let!(:cndt2020) { create(:cndt2020, :opened) }
+      let!(:alice) { create(:alice, :on_cndt2020, conference: cndt2020) }
+      let!(:bob) { create(:bob, :on_cndt2020, conference: cndt2020) }
+
+      context 'should return correct count' do
+        it { expect(ChatMessage.counts.find_by(room_id: 1, conference_id: 1).count).to(eq(10)) }
+        it { expect(ChatMessage.counts.find_by(room_id: 2, conference_id: 1).count).to(eq(12)) }
+      end
+    end
+    context 'with archived conference' do
+      let!(:cndt2020) { create(:cndt2020, :archived) }
+
+      context 'should not return message count' do
+        it { expect(ChatMessage.counts.find_by(room_id: 1, conference_id: 1)).to(be(nil)) }
+        it { expect(ChatMessage.counts.find_by(room_id: 2, conference_id: 1)).to(be(nil)) }
+      end
+    end
+  end
+end

--- a/spec/models/viewer_count_spec.rb
+++ b/spec/models/viewer_count_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe(ViewerCount, type: :model) do
         create_list(:viewer_count, 3, :talk1)
         create_list(:viewer_count, 3, :talk3)
       end
-      before(:each) do
+      after(:each) do
         FactoryBot.rewind_sequences
       end
 
@@ -65,6 +65,9 @@ RSpec.describe(ViewerCount, type: :model) do
         create(:video, :on_air, :talk3)
         create_list(:viewer_count, 3, :talk1)
         create_list(:viewer_count, 3, :talk3)
+      end
+      after(:each) do
+        FactoryBot.rewind_sequences
       end
 
       context 'if talk is off air' do

--- a/spec/models/viewer_count_spec.rb
+++ b/spec/models/viewer_count_spec.rb
@@ -24,30 +24,52 @@ RSpec.describe(ViewerCount, type: :model) do
     context 'with opened conference' do
       before do
         create(:cndt2020, :opened)
+        create(:talk1)
+        create(:talk3)
+        create_list(:viewer_count, 3, :talk1)
+        create_list(:viewer_count, 3, :talk3)
       end
 
       context 'if talk is on air' do
         before do
-          create(:talk1, :on_air)
+          create(:video, :on_air, :talk1)
+          create(:video, :on_air, :talk3)
         end
-        it { expect(最新のviewercountが返る) }
-        it { expect(過去のviewercountは返らない) }
+
+        it 'include latest count' do
+          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 1).count).to(eq(3))
+          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 3).count).to(eq(6))
+        end
       end
 
       context 'if talk is off air' do
         before do
-          create(:talk1, :off_air) 
+          create(:video, :off_air, :talk1)
+          create(:video, :on_air, :talk3)
         end
-        it { expect(viewercountが返らない) }
+        it "doesn't include off air talk" do
+          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 1)).to(be(nil))
+          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 3).count).to(eq(12))
+        end
       end
     end
-
     context 'with registered conference' do
       before do
         create(:cndt2020, :registered)
-        create(:talk1, :on_air) 
+        create(:talk1)
+        create(:talk3)
+        create(:video, :on_air, :talk1)
+        create(:video, :on_air, :talk3)
+        create_list(:viewer_count, 3, :talk1)
+        create_list(:viewer_count, 3, :talk3)
       end
-      it { expect(viewercountが返らない) }
+
+      context 'if talk is off air' do
+        it 'doesnt include latest count' do
+          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 1)).to(be(nil))
+          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 3)).to(be(nil))
+        end
+      end
     end
   end
 end

--- a/spec/models/viewer_count_spec.rb
+++ b/spec/models/viewer_count_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe(ViewerCount, type: :model) do
         create_list(:viewer_count, 3, :talk1)
         create_list(:viewer_count, 3, :talk3)
       end
+      before(:each) do
+        FactoryBot.rewind_sequences
+      end
 
       context 'if talk is on air' do
         before do
@@ -49,7 +52,7 @@ RSpec.describe(ViewerCount, type: :model) do
         end
         it "doesn't include off air talk" do
           expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 1)).to(be(nil))
-          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 3).count).to(eq(12))
+          expect(ViewerCount.latest_number_of_viewers.find_by(talk_id: 3).count).to(eq(6))
         end
       end
     end

--- a/spec/models/viewer_count_spec.rb
+++ b/spec/models/viewer_count_spec.rb
@@ -20,5 +20,34 @@
 require 'rails_helper'
 
 RSpec.describe(ViewerCount, type: :model) do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'get_latest_number_of_viewer' do
+    context 'with opened conference' do
+      before do
+        create(:cndt2020, :opened)
+      end
+
+      context 'if talk is on air' do
+        before do
+          create(:talk1, :on_air)
+        end
+        it { expect(最新のviewercountが返る) }
+        it { expect(過去のviewercountは返らない) }
+      end
+
+      context 'if talk is off air' do
+        before do
+          create(:talk1, :off_air) 
+        end
+        it { expect(viewercountが返らない) }
+      end
+    end
+
+    context 'with registered conference' do
+      before do
+        create(:cndt2020, :registered)
+        create(:talk1, :on_air) 
+      end
+      it { expect(viewercountが返らない) }
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,4 +72,5 @@ RSpec.configure do |config|
     schema_path: Rails.root.join('schemas', 'swagger.yml').to_s,
   }
   include Committee::Rails::Test::Methods
+  config.include ActiveJob::TestHelper
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,5 +72,5 @@ RSpec.configure do |config|
     schema_path: Rails.root.join('schemas', 'swagger.yml').to_s,
   }
   include Committee::Rails::Test::Methods
-  config.include ActiveJob::TestHelper
+  config.include(ActiveJob::TestHelper)
 end

--- a/spec/requests/exporter_spec.rb
+++ b/spec/requests/exporter_spec.rb
@@ -12,6 +12,9 @@ describe Prometheus::Middleware::DreamkastExporter, type: :request do
       create(:video, :on_air, :talk1)
       create(:video, :on_air, :talk3)
     end
+    before(:each) do
+      FactoryBot.rewind_sequences
+    end
 
     let!(:cndt2020) { create(:cndt2020, :opened) }
     let!(:alice) { create(:alice, :on_cndt2020, conference: cndt2020) }

--- a/spec/requests/exporter_spec.rb
+++ b/spec/requests/exporter_spec.rb
@@ -12,7 +12,7 @@ describe Prometheus::Middleware::DreamkastExporter, type: :request do
       create(:video, :on_air, :talk1)
       create(:video, :on_air, :talk3)
     end
-    before(:each) do
+    after(:each) do
       FactoryBot.rewind_sequences
     end
 

--- a/spec/requests/exporter_spec.rb
+++ b/spec/requests/exporter_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe Prometheus::Middleware::DreamkastExporter, type: :request do
+  context 'GET /metrics' do
+    before do
+      create(:talk1, conference: cndt2020)
+      create(:talk3, conference: cndt2020)
+      create_list(:messages, 10, :alice, :roomid1, profile: alice)
+      create_list(:messages, 12, :bob, :roomid2, profile: bob)
+      create_list(:viewer_count, 3, :talk1)
+      create_list(:viewer_count, 3, :talk3)
+      create(:video, :on_air, :talk1)
+      create(:video, :on_air, :talk3)
+    end
+
+    let!(:cndt2020) { create(:cndt2020, :opened) }
+    let!(:alice) { create(:alice, :on_cndt2020, conference: cndt2020) }
+    let!(:bob) { create(:bob, :on_cndt2020, conference: cndt2020) }
+
+    it 'returns a success response with event top page' do
+      get '/metrics'
+      expect(response).to(be_successful)
+      expect(response).to(have_http_status('200'))
+      expect(response.body).to(include('dreamkast_viewer_count{talk_id="1",track_id="1",conference_id="1"} 3.0'))
+      expect(response.body).to(include('dreamkast_chat_count{conference_id="1",talk_id="2"} 12.0'))
+    end
+  end
+end


### PR DESCRIPTION
原案 #1127 に、以下の修正を追加

- Openedなカンファレンスのみ取得対象に
- exporterの処理部分をinitializerからmiddlewareに移行
- 情報を取得する部分はmodelに移行(役割の明確化とテスタビリティ向上のため)
- テストを追加
- config.ruに追加するのでは無くRailsの仕組みでRack middlewareを読み込むように