### PR TITLE
migration のモデルコメントへの適用変更漏れを修正

### DIFF
--- a/app/models/speaker_announcement.rb
+++ b/app/models/speaker_announcement.rb
@@ -6,6 +6,7 @@
 #  body          :text(65535)      not null
 #  publish       :boolean          default(FALSE)
 #  publish_time  :datetime         not null
+#  receiver      :integer          default("person"), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  conference_id :bigint           not null

--- a/spec/factories/speaker_announcements.rb
+++ b/spec/factories/speaker_announcements.rb
@@ -6,7 +6,7 @@
 #  body          :text(65535)      not null
 #  publish       :boolean          default(FALSE)
 #  publish_time  :datetime         not null
-#  receiver      :integer          default("private"), not null
+#  receiver      :integer          default("person"), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  conference_id :bigint           not null


### PR DESCRIPTION
モデルへのスキーマコメントで差分が発生してしまっているので修正