### PR TITLE
improve harvest job

### DIFF
--- a/app/models/media_package_harvest_job.rb
+++ b/app/models/media_package_harvest_job.rb
@@ -44,7 +44,7 @@ class MediaPackageHarvestJob < ApplicationRecord
   end
 
   def video_url
-    "https://#{cloudfront_domain_name(job.bucket_name)}/#{job.manifest_key}"
+    "https://#{cloudfront_domain_name(job.s3_destination.bucket_name)}/#{job.s3_destination.manifest_key}"
   end
 
   private

--- a/app/models/media_package_harvest_job.rb
+++ b/app/models/media_package_harvest_job.rb
@@ -60,7 +60,11 @@ class MediaPackageHarvestJob < ApplicationRecord
   end
 
   def manifest_key
-    "mediapackage/#{conference.abbr}/talks/#{talk_id}/playlist.m3u8"
+    "mediapackage/#{conference.abbr}/talks/#{talk_id}/#{id}/playlist.m3u8"
+  end
+
+  def video_url
+    "https://#{cloudfront_domain_name(job.bucket_name)}/#{job.manifest_key}"
   end
 
   def resource_name
@@ -80,6 +84,17 @@ class MediaPackageHarvestJob < ApplicationRecord
       'dreamkast-ivs-stream-archive-stg'
     else
       'dreamkast-ivs-stream-archive-dev'
+    end
+  end
+
+  def cloudfront_domain_name(bucket_name)
+    case bucket_name
+    when 'dreamkast-ivs-stream-archive-prd'
+      'd3pun3ptcv21q4.cloudfront.net'
+    when 'dreamkast-ivs-stream-archive-stg'
+      'd3i2o0iduabu0p.cloudfront.net'
+    else
+      'd1jzp6sbtx9by.cloudfront.net'
     end
   end
 end

--- a/app/models/media_package_harvest_job.rb
+++ b/app/models/media_package_harvest_job.rb
@@ -67,7 +67,6 @@ class MediaPackageHarvestJob < ApplicationRecord
     "mediapackage/#{conference.abbr}/talks/#{talk_id}/#{id}/playlist.m3u8"
   end
 
-
   def resource_name
     track = media_package_channel.track
     if review_app?

--- a/app/models/media_package_harvest_job.rb
+++ b/app/models/media_package_harvest_job.rb
@@ -43,6 +43,10 @@ class MediaPackageHarvestJob < ApplicationRecord
     logger.error(e.message)
   end
 
+  def video_url
+    "https://#{cloudfront_domain_name(job.bucket_name)}/#{job.manifest_key}"
+  end
+
   private
 
   def create_params
@@ -63,9 +67,6 @@ class MediaPackageHarvestJob < ApplicationRecord
     "mediapackage/#{conference.abbr}/talks/#{talk_id}/#{id}/playlist.m3u8"
   end
 
-  def video_url
-    "https://#{cloudfront_domain_name(job.bucket_name)}/#{job.manifest_key}"
-  end
 
   def resource_name
     track = media_package_channel.track

--- a/app/models/media_package_origin_endpoint.rb
+++ b/app/models/media_package_origin_endpoint.rb
@@ -73,7 +73,7 @@ class MediaPackageOriginEndpoint < ApplicationRecord
       },
       manifest_name: 'index',
       origination: 'ALLOW',
-      startover_window_seconds: 28800,
+      startover_window_seconds: 86400,
       time_delay_seconds: 5
     }
   end

--- a/app/views/admin/harvest_jobs/index.html.erb
+++ b/app/views/admin/harvest_jobs/index.html.erb
@@ -9,6 +9,7 @@
       <th scope="col">Harvest Job Status</th>
       <th scope="col">StartTime</th>
       <th scope="col">EndTime</th>
+      <th scope="col">Video URL</th>
     </tr>
     </thead>
     <tbody>
@@ -19,6 +20,7 @@
         <td><%= harvest_job.job&.status %></td>
         <td><%= harvest_job.start_time %></td>
         <td><%= harvest_job.end_time %></td>
+        <td><%= harvest_job.video_url %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/talks/partial_show/_talk_video_block_videojs.html.erb
+++ b/app/views/talks/partial_show/_talk_video_block_videojs.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-2">
   <video
     id="my-player"
-    class="video-js vjs-default-skin"
+    class="video-js video-js vjs-16-9 vjs-big-play-centered"
     data-setup='{"fluid": true}'
     controls
     preload="auto"

--- a/lib/tasks/polling_harvest_job_and_update_video.rake
+++ b/lib/tasks/polling_harvest_job_and_update_video.rake
@@ -16,10 +16,9 @@ namespace :util do
       harvest_job.update!(status: resp.status)
 
       puts("Harvest Job: id: #{resp.id}, status: #{resp.status}")
-      if resp.status == 'SUCCEEDED' && harvest_job.talk.video.video_id == ''
-        url = "https://#{cloudfront_domain_name(resp.s3_destination.bucket_name)}/#{resp.s3_destination.manifest_key}"
-        puts("Update video id: #{url}")
-        harvest_job.talk.video.update!(video_id: url)
+      if resp.status == 'SUCCEEDED'
+        puts("Update video id: #{harvest_job.video_url}")
+        harvest_job.talk.video.update!(video_id: harvest_job.video_url)
 
         body = []
         body << 'アーカイブの作成が完了しました:'
@@ -45,17 +44,6 @@ namespace :util do
       'staging.dev.cloudnativedays.jp'
     else
       'localhost:8080'
-    end
-  end
-
-  def cloudfront_domain_name(bucket_name)
-    case bucket_name
-    when 'dreamkast-ivs-stream-archive-prd'
-      'd3pun3ptcv21q4.cloudfront.net'
-    when 'dreamkast-ivs-stream-archive-stg'
-      'd3i2o0iduabu0p.cloudfront.net'
-    else
-      'd1jzp6sbtx9by.cloudfront.net'
     end
   end
 end


### PR DESCRIPTION
- 同じセッションでアーカイブ作成を複数回行った場合、後から作成されたものが使われる
- 複数回アーカイブを作っても別々のパスで保存して、talkのvideo_idを上書きすれば前のアーカイブを使えるようにする
- admin/harvest_jobsでHarvestJobで作ったアーカイブのURLを確認できるようにする
- MediaPackageでバッファする期間を24時間にする