### PR TITLE
Ignore CI when non-code is changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: build container image
 on:
   push:
     paths-ignore:
+      - '.github/**'
       - '**.md'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/**'
-      - '!.github/build.yml'
+      - '!.github/workflows/build.yml'
       - '**.md'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/**'
+      - '!.github/build.yml'
       - '**.md'
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,14 +4,14 @@ on:
   push:
     paths-ignore:
       - '.github/**'
-      - '!.github/ci.yml'
+      - '!.github/workflows/ci.yml'
       - '**.md'
     branches:
     - main
   pull_request:
     paths-ignore:
       - '.github/**'
-      - '!.github/ci.yml'
+      - '!.github/workflows/ci.yml'
       - '**.md'
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,15 @@ name: CI
 
 on:
   push:
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
     branches:
     - main
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
     branches:
       - main
     types: [opened, synchronize]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,12 +4,14 @@ on:
   push:
     paths-ignore:
       - '.github/**'
+      - '!.github/ci.yml'
       - '**.md'
     branches:
     - main
   pull_request:
     paths-ignore:
       - '.github/**'
+      - '!.github/ci.yml'
       - '**.md'
     branches:
       - main

--- a/.github/workflows/gitops-prd.yml
+++ b/.github/workflows/gitops-prd.yml
@@ -2,6 +2,9 @@ name: GitOps for production
 
 on:
   push:
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
     tags:
       - v*
 

--- a/.github/workflows/gitops-prd.yml
+++ b/.github/workflows/gitops-prd.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/**'
+      - '!.github/gitops-prd.yml'
       - '**.md'
     tags:
       - v*

--- a/.github/workflows/gitops-prd.yml
+++ b/.github/workflows/gitops-prd.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/**'
-      - '!.github/gitops-prd.yml'
+      - '!.github/workflows/gitops-prd.yml'
       - '**.md'
     tags:
       - v*

--- a/.github/workflows/gitops-stg.yml
+++ b/.github/workflows/gitops-stg.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/**'
+      - '!.github/gitops-stg.yml'
       - '**.md'
     branches:
     - main

--- a/.github/workflows/gitops-stg.yml
+++ b/.github/workflows/gitops-stg.yml
@@ -2,6 +2,9 @@ name: GitOps for staging
 
 on:
   push:
+    paths-ignore:
+      - '.github/**'
+      - '**.md'
     branches:
     - main
 

--- a/.github/workflows/gitops-stg.yml
+++ b/.github/workflows/gitops-stg.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/**'
-      - '!.github/gitops-stg.yml'
+      - '!.github/workflows/gitops-stg.yml'
       - '**.md'
     branches:
     - main


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/1213 が取り込まれたら入れる。

アプリケーションに関係のないMarkdownや変更対象のActionsが変更されたとき以外ビルドやテストを走らせないようにする。
CIが変わるときは加えてAction Lintも走るようになっている。