### PR TITLE
Use bundler-cache option of Setup Ruby action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1.1
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - name: Bundle install
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run rubocop
       run: |
         bundle exec rubocop


### PR DESCRIPTION
Ref. https://github.com/ruby/setup-ruby#single-job

bundle install時のオプションは以下の箇所を見る限りは互換性の問題がなさそう。公式のものに乗っかってしまう方が良いのでお手製のActionは消してしまう。

https://github.com/ruby/setup-ruby/blob/master/bundler.js#L179
https://github.com/ruby/setup-ruby/blob/master/bundler.js#L137-L142