### PR TITLE
複数インスタンスあると画像のアップロードがうまくいかない

### DIFF
--- a/app/javascript/packs/cropbox.js
+++ b/app/javascript/packs/cropbox.js
@@ -38,6 +38,7 @@ function cropUpload(fileInput) {
       guides: false,
       autoCropArea: 1.0,
       background: false,
+      checkCrossOrigin: false,
       crop: function (event) {
         let data = JSON.parse(hiddenInput.value)
         data['metadata']['crop'] = event.detail

--- a/app/jobs/promote_job.rb
+++ b/app/jobs/promote_job.rb
@@ -1,6 +1,7 @@
 class PromoteJob < ApplicationJob
   def perform(record, name, file_data)
     attacher = Shrine::Attacher.retrieve(model: record, name: name, file: file_data)
+    return unless attacher.file.exists?
     attacher.create_derivatives
     attacher.atomic_promote
   end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -30,7 +30,7 @@ else
 
   Shrine.storages = {
     video_file: Shrine::Storage::S3.new(prefix: 'video_file', **s3_options),
-    cache: Shrine::Storage::FileSystem.new('public', prefix: 'uploads/cache'),
+    cache: Shrine::Storage::S3.new(prefix: 'cache', **s3_options),
     store: Shrine::Storage::S3.new(**s3_options),
   }
 end


### PR DESCRIPTION
#1233 

Pod 内のファイルシステムにキャッシュを作成していたが, 複数インスタンスを起動して連続した処理が分散されることで 404 が発生していた

キャッシュを S3 上に `cache` プレフィックスを付けて作成するように修正した. 
cropperjs で S3 の署名付きURLを利用する場合既知の不具合が存在するらしく、`checkCrossOrigin` 属性を false に変更.

https://github.com/fengyuanchen/cropperjs#checkcrossorigin
https://github.com/fengyuanchen/cropperjs/issues/824


Promote job によって永続化に成功した場合はキャッシュは不要となるので下記どちらかの対応があると良さそう
* 定期的に時間等の条件によってキャッシュを削除するタスクを作成する
* S3 のライフサイクルを設定する

https://shrinerb.com/docs/getting-started#clearing-cache