### PR TITLE
mail 送信時のエラーを修正

### DIFF
--- a/app/jobs/mail_delivery_job.rb
+++ b/app/jobs/mail_delivery_job.rb
@@ -4,7 +4,7 @@ class MailDeliveryJob < ApplicationJob
 
   discard_on ActiveRecord::ActiveRecordError
 
-  def perform(mailer, mail_method, delivery_method, *args)
+  def perform(mailer, mail_method, delivery_method, args:)
     mailer.constantize.public_send(mail_method, *args).send(delivery_method)
   end
 end


### PR DESCRIPTION

mail 送信時にエラーが発生していた. #1210 
主な原因は Rails 6.0 で採用されている MailDeliveryJob の仕様変更が影響していたこと.

どのタイミングで発生し始めたのかは未調査だが, Mailer に渡す第3引数が parameterize されたことによって構造が変化していた.
そのため, `args` 引数について名前付き引数に変更する必要があった.
```
args => [#Conference, #Talk, #Speaker] //期待する値 
args => { :args => [#Conference, #Talk, #Speaker] } //取得していた値 
```

https://github.com/rails/rails/pull/34367#discussion_r230235318
https://github.com/rails/rails/blob/06c116fe1a02c20ff9aa8c5f1ad96d5bcde29690/actionmailer/lib/action_mailer/mail_delivery_job.rb#L16