### PR TITLE
登壇者お知らせの公開時に通知されなかったため、メール送信処理を追加

### DIFF
--- a/app/mailers/speaker_mailer.rb
+++ b/app/mailers/speaker_mailer.rb
@@ -17,4 +17,12 @@ class SpeakerMailer < ApplicationMailer
 
     mail(to: speaker.email, subject: "【#{@conference.name}】プロポーザルを受け付けました")
   end
+
+  def inform_speaker_announcement(conference, speaker, announcement)
+    @conference = conference
+    @speaker = speaker
+    @speaker_announcement = announcement
+
+    mail(to: @speaker.email, subject: "#{@conference.abbr}運営からのお知らせ")
+  end
 end

--- a/app/mailers/speaker_mailer.rb
+++ b/app/mailers/speaker_mailer.rb
@@ -18,10 +18,9 @@ class SpeakerMailer < ApplicationMailer
     mail(to: speaker.email, subject: "【#{@conference.name}】プロポーザルを受け付けました")
   end
 
-  def inform_speaker_announcement(conference, speaker, announcement)
+  def inform_speaker_announcement(conference, speaker)
     @conference = conference
     @speaker = speaker
-    @speaker_announcement = announcement
 
     mail(to: @speaker.email, subject: "#{@conference.abbr}運営からのお知らせ")
   end

--- a/app/models/speaker_announcement.rb
+++ b/app/models/speaker_announcement.rb
@@ -20,6 +20,9 @@ class SpeakerAnnouncement < ApplicationRecord
   enum receiver: { person: 0, all_speaker: 1, only_accepted: 2, only_rejected: 3 }
   JA_RECEIVER = { person: '個人', all_speaker: '全員', only_accepted: 'CFP採択者', only_rejected: 'CFP非採択者' }.freeze
 
+  after_create :inform_announcement
+  before_update :inform_announcement_at_update
+
   belongs_to :conference
   has_many :speaker_announcement_middles, dependent: :destroy
   has_many :speakers, through: :speaker_announcement_middles
@@ -43,8 +46,28 @@ class SpeakerAnnouncement < ApplicationRecord
     where(receiver: [:person, :all_speaker])
   }
 
+  def inform_announcement
+    if should_inform?
+      speakers.each do |speaker|
+        SpeakerMailer.inform_speaker_announcement(conference, speaker, self).deliver_later
+      end
+    end
+  end
+
+  def inform_announcement_at_update
+    if should_inform? && publish_changed?
+      speakers.each do |speaker|
+        SpeakerMailer.inform_speaker_announcement(conference, speaker, self).deliver_later
+      end
+    end
+  end
+
   def speaker_names
     return speakers.map(&:name).join(',') if person?
     JA_RECEIVER[receiver.to_sym]
+  end
+
+  def should_inform?
+    publish && person?
   end
 end

--- a/app/models/speaker_announcement.rb
+++ b/app/models/speaker_announcement.rb
@@ -21,7 +21,7 @@ class SpeakerAnnouncement < ApplicationRecord
   JA_RECEIVER = { person: '個人', all_speaker: '全員', only_accepted: 'CFP採択者', only_rejected: 'CFP非採択者' }.freeze
 
   after_create -> { inform('create') }
-  after_update -> { inform('update') }
+  before_update -> { inform('update') }
 
   belongs_to :conference
   has_many :speaker_announcement_middles, dependent: :destroy
@@ -48,7 +48,7 @@ class SpeakerAnnouncement < ApplicationRecord
 
   def inform(context)
     if should_inform?(context)
-      speakers.each { |speaker| SpeakerMailer.inform_speaker_announcement(conference, speaker, self).deliver_later }
+      speakers.each { |speaker| SpeakerMailer.inform_speaker_announcement(conference, speaker).deliver_later }
     end
   end
 
@@ -60,9 +60,9 @@ class SpeakerAnnouncement < ApplicationRecord
   def should_inform?(context)
     case context
     when 'create'
-      publish && person?
+      publish
     when 'update'
-      publish && person? && publish_changed?
+      publish && publish_changed?
     end
   end
 end

--- a/app/views/speaker_mailer/inform_speaker_announcement.text.erb
+++ b/app/views/speaker_mailer/inform_speaker_announcement.text.erb
@@ -1,1 +1,6 @@
-<%= @speaker_announcement.body %>
+<%= @speaker.name %>様
+
+新しいお知らせが到着しました。
+
+確認するには、イベントサイトのスピーカーダッシュボードをご確認ください。
+https://event.cloudnativedays.jp/<%= @conference.abbr %>

--- a/app/views/speaker_mailer/inform_speaker_announcement.text.erb
+++ b/app/views/speaker_mailer/inform_speaker_announcement.text.erb
@@ -1,0 +1,1 @@
+<%= @speaker_announcement.body %>

--- a/spec/factories/speaker_announcements.rb
+++ b/spec/factories/speaker_announcements.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     publish_time { Time.now }
     body { 'test announcement for alice' }
     publish { false }
+    receiver { :person }
     trait :published do
       publish { true }
     end

--- a/spec/mailers/speaker_mailer_spec.rb
+++ b/spec/mailers/speaker_mailer_spec.rb
@@ -1,20 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe(SpeakerMailer, type: :mailer) do
-  shared_examples_for :has_basic_information do
-    it { is_expected.to(have_sent_email.with_subject("【#{conference.name}】プロポーザルを受け付けました")) }
-    it { is_expected.to(have_sent_email.to(speaker.email)) }
-    it { is_expected.to(have_sent_email.from('noreply@mail.cloudnativedays.jp')) }
-
-    it { expect(mail.body.encoded).to(include("こんにちは、#{speaker.name} さん。")) }
-    it { expect(mail.body.encoded).to(include("#{conference.name} のプロポーザルを以下の内容で受け付けました。")) }
-    it { expect(mail.body.encoded).to(include("タイトル: #{talk.title}")) }
-    it { expect(mail.body.encoded).to(include("概要: #{talk.abstract}")) }
-    it { expect(mail.body.encoded).to(include("受講者レベル: #{talk.difficulty}")) }
-    it { expect(mail.body.encoded).to(include("資料URL: #{talk.document_url}")) }
-  end
-
   describe '#cfp_registered' do
+    shared_examples_for :has_basic_information do
+      it { is_expected.to(have_sent_email.with_subject("【#{conference.name}】プロポーザルを受け付けました")) }
+      it { is_expected.to(have_sent_email.to(speaker.email)) }
+      it { is_expected.to(have_sent_email.from('noreply@mail.cloudnativedays.jp')) }
+
+      it { expect(mail.body.encoded).to(include("こんにちは、#{speaker.name} さん。")) }
+      it { expect(mail.body.encoded).to(include("#{conference.name} のプロポーザルを以下の内容で受け付けました。")) }
+      it { expect(mail.body.encoded).to(include("タイトル: #{talk.title}")) }
+      it { expect(mail.body.encoded).to(include("概要: #{talk.abstract}")) }
+      it { expect(mail.body.encoded).to(include("受講者レベル: #{talk.difficulty}")) }
+      it { expect(mail.body.encoded).to(include("資料URL: #{talk.document_url}")) }
+    end
     let!(:conference) { create(:one_day) }
     let!(:speaker) { create(:speaker_alice, conference: conference) }
     let!(:talk) { create(:talk1, conference: conference) }
@@ -78,5 +77,20 @@ RSpec.describe(SpeakerMailer, type: :mailer) do
       it { expect(mail.body.encoded).to(include('チェックボックス1: 1-A')) }
       it { expect(mail.body.encoded).to(include('ラジオボタン3: 3-A')) }
     end
+  end
+
+  describe '#inform_speaker_announcement' do
+    shared_examples_for :has_basic_information do
+      it { is_expected.to(have_sent_email.with_subject('oneday運営からのお知らせ')) }
+      it { expect(mail.body.encoded).to(include("#{speaker.name}様")) }
+      it { expect(mail.body.encoded).to(include('新しいお知らせが到着しました。')) }
+      it { expect(mail.body.encoded).to(include('確認するには、イベントサイトのスピーカーダッシュボードをご確認ください。')) }
+      it { expect(mail.body.encoded).to(include('https://event.cloudnativedays.jp/oneday')) }
+    end
+    subject(:mail) { described_class.inform_speaker_announcement(conference, speaker).deliver_now }
+    let!(:conference) { create(:one_day) }
+    let!(:speaker) { create(:speaker_alice, conference: conference) }
+
+    it_should_behave_like :has_basic_information
   end
 end

--- a/spec/models/speaker_annoucement_spec.rb
+++ b/spec/models/speaker_annoucement_spec.rb
@@ -95,4 +95,66 @@ RSpec.describe(SpeakerAnnouncement, type: :model) do
       end
     end
   end
+
+  describe '#should_inform?' do
+    subject { announcement.should_inform?(context) }
+    let!(:announcement) { SpeakerAnnouncement.create(param) }
+    context 'when create' do
+      subject { announcement.should_inform?(context) }
+      let!(:announcement) { SpeakerAnnouncement.create(param) }
+      let!(:context) { 'create' }
+      context 'when publish is true' do
+        context 'when receiver is person' do
+          let!(:param) {
+            default_param[:publish] = true
+            default_param[:receiver] = :person
+            default_param
+          }
+          it { is_expected.to(be_truthy) }
+        end
+        context 'when receiver is not person' do
+          let!(:param) {
+            default_param[:publish] = true
+            default_param[:receiver] = :only_accepted
+            default_param
+          }
+          it { is_expected.to(be_falsey) }
+        end
+      end
+      context 'when publish is false' do
+        context 'when receiver is person' do
+          let!(:param) {
+            default_param[:publish] = false
+            default_param[:receiver] = :person
+            default_param
+          }
+          it { is_expected.to(be_falsey) }
+        end
+        context 'when receiver is not person' do
+          let!(:param) {
+            default_param[:publish] = false
+            default_param[:receiver] = :only_accepted
+            default_param
+          }
+          it { is_expected.to(be_falsey) }
+        end
+      end
+    end
+    context 'when update' do
+      let!(:context) { 'create' }
+      let!(:param) {
+        default_param[:publish] = false
+        default_param[:receiver] = :person
+        default_param
+      }
+      context 'publish to true' do
+        before { announcement.update(publish: true) }
+        it { is_expected.to(be_truthy) }
+      end
+      context 'publish does not be changed' do
+        before { announcement.update(body: 'test body') }
+        it { is_expected.to(be_falsey) }
+      end
+    end
+  end
 end

--- a/spec/models/speaker_annoucement_spec.rb
+++ b/spec/models/speaker_annoucement_spec.rb
@@ -100,60 +100,39 @@ RSpec.describe(SpeakerAnnouncement, type: :model) do
     subject { announcement.should_inform?(context) }
     let!(:announcement) { SpeakerAnnouncement.create(param) }
     context 'when create' do
-      subject { announcement.should_inform?(context) }
-      let!(:announcement) { SpeakerAnnouncement.create(param) }
       let!(:context) { 'create' }
       context 'when publish is true' do
-        context 'when receiver is person' do
-          let!(:param) {
-            default_param[:publish] = true
-            default_param[:receiver] = :person
-            default_param
-          }
-          it { is_expected.to(be_truthy) }
-        end
-        context 'when receiver is not person' do
-          let!(:param) {
-            default_param[:publish] = true
-            default_param[:receiver] = :only_accepted
-            default_param
-          }
-          it { is_expected.to(be_falsey) }
-        end
+        let!(:param) {
+          default_param[:publish] = true
+          default_param
+        }
+        it { is_expected.to(be_truthy) }
       end
       context 'when publish is false' do
-        context 'when receiver is person' do
-          let!(:param) {
-            default_param[:publish] = false
-            default_param[:receiver] = :person
-            default_param
-          }
-          it { is_expected.to(be_falsey) }
-        end
-        context 'when receiver is not person' do
-          let!(:param) {
-            default_param[:publish] = false
-            default_param[:receiver] = :only_accepted
-            default_param
-          }
-          it { is_expected.to(be_falsey) }
-        end
+        let!(:param) {
+          default_param[:publish] = false
+          default_param
+        }
+        it { is_expected.to(be_falsey) }
       end
     end
     context 'when update' do
-      let!(:context) { 'create' }
+      let!(:context) { 'update' }
       let!(:param) {
         default_param[:publish] = false
-        default_param[:receiver] = :person
         default_param
       }
       context 'publish to true' do
-        before { announcement.update(publish: true) }
-        it { is_expected.to(be_truthy) }
+        it {
+          announcement.publish = true
+          is_expected.to(be_truthy)
+        }
       end
       context 'publish does not be changed' do
-        before { announcement.update(body: 'test body') }
-        it { is_expected.to(be_falsey) }
+        it {
+          announcement.body = 'test body'
+          is_expected.to(be_falsey)
+        }
       end
     end
   end


### PR DESCRIPTION

#1199 

個人宛通知を公開で作成した場合と、非公開の個人宛通知を公開にした場合に通知するようにしました。
後者については `publish_changed?` と `publish == true` で判定しているため「非公開 -> 公開 -> 非公開 -> 公開」などの場合再度通知されてしまいますが、運用上発生しえないだろうと考えたのでこの P/R ではケアしていません。 