### PR TITLE
beta ユーザー専用ページを表示できる concern を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class Forbidden < ActionController::ActionControllerError; end
+class NotFound < ActionController::ActionControllerError; end
 
 class ApplicationController < ActionController::Base
   include EnvHelper
@@ -8,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   unless Rails.env.development?
     rescue_from Exception, with: :render_500
-    rescue_from ActiveRecord::RecordNotFound, with: :render_404
+    rescue_from ActiveRecord::RecordNotFound, NotFound, with: :render_404
     rescue_from Forbidden, with: :render_403
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class Forbidden < ActionController::ActionControllerError; end
+
 class NotFound < ActionController::ActionControllerError; end
 
 class ApplicationController < ActionController::Base

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -3,7 +3,7 @@ module Secured
 
   included do
     before_action :logged_in_using_omniauth?, :new_user?, if: :use_secured_before_action?
-    helper_method :admin?, :speaker?
+    helper_method :admin?, :speaker?, :beta_user?
   end
 
   def logged_in_using_omniauth?
@@ -32,6 +32,10 @@ module Secured
 
   def speaker?
     @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Speaker")
+  end
+
+  def beta_user?
+    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
   end
 
   def conference

--- a/app/controllers/concerns/secured_beta.rb
+++ b/app/controllers/concerns/secured_beta.rb
@@ -1,0 +1,23 @@
+module SecuredBeta
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_current_user, :is_beta_user?
+    # helper_method :beta_user?
+  end
+  def beta_user?
+    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
+  end
+
+  def is_beta_user?
+    raise(NotFound) unless beta_user? || admin?
+  end
+
+  def set_current_user
+    @current_user ||= session[:userinfo]
+  end
+
+  def admin?
+    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+  end
+end

--- a/app/controllers/concerns/secured_beta.rb
+++ b/app/controllers/concerns/secured_beta.rb
@@ -3,8 +3,8 @@ module SecuredBeta
 
   included do
     before_action :set_current_user, :is_beta_user?
-    # helper_method :beta_user?
   end
+
   def beta_user?
     @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
   end

--- a/app/helpers/beta_helper.rb
+++ b/app/helpers/beta_helper.rb
@@ -1,0 +1,10 @@
+module BetaHelper
+  BETA_TEXT = 'β feature'.freeze
+  def partial_beta_view(&block)
+    if beta_user? || admin?
+      p_tag = content_tag(:p, BETA_TEXT, class: 'beta-icon')
+      p_tag.concat(content_tag(:div, capture(&block)))
+      content_tag(:div, p_tag, class: 'beta-container')
+    end
+  end
+end

--- a/app/javascript/stylesheets/_beta.scss
+++ b/app/javascript/stylesheets/_beta.scss
@@ -1,0 +1,12 @@
+.beta-container {
+  .beta-icon {
+      background: $fresh-green;
+      color: #FFF;
+      box-sizing: border-box;
+      border-radius: 100vh;
+      text-align: center;
+      width: 5rem;
+      margin-bottom: 0.5rem;
+      margin-top: 1.5rem;
+  }
+}

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -6,6 +6,7 @@ $orange: #f4623a;
 $purple: #BD4392;
 $dark-blue: #206A9B;
 $brown: #5c4d42;
+$fresh-green: #00993E;
 
 //- Override primary color
 $primary: $dark-blue;

--- a/app/javascript/stylesheets/cnsec2022.scss
+++ b/app/javascript/stylesheets/cnsec2022.scss
@@ -10,6 +10,7 @@
 @import "./message_box.scss";
 @import "./_tracks.scss";
 @import "./_admin.scss";
+@import "./_beta.scss";
 @import "./_booth.scss";
 @import "./_links.scss";
 @import "./_talks.scss";


### PR DESCRIPTION
ベータユーザ向けにページを作成できるように concern を作成しました.
単純にページを制御するだけであれば Auth0 でロールを割り振れば行けそうです.

以下は既存の waiting ページにβ版機能を差し込む際のイメージです.
```waiting.html.erb
<%= partial_beta_view do %>
    <h3>エッジの効いた機能</h3>
    <span>とにかくすごい機能</span>
<% end %>
```
![スクリーンショット 2022-06-20 233349](https://user-images.githubusercontent.com/40717789/174627069-67da3dbd-e327-4172-b5c6-e047a7f96fac.png)

