### PR TITLE
Fix something

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -82,7 +82,7 @@ class Profile < ApplicationRecord
   validates :company_address_level1, presence: true, length: { maximum: 256 }
   validates :company_address_level2, presence: true, length: { maximum: 1024 }
   validates :company_address_line1, presence: true, length: { maximum: 1024 }
-  validates :company_address_line2, presence: true, length: { maximum: 1024 }
+  validates :company_address_line2, presence: false, length: { maximum: 1024 }
   validates :company_tel, presence: true, length: { maximum: 128 }, tel: true
   validates :company_fax, presence: false, length: { maximum: 128 }
   validates :department, presence: false, length: { maximum: 128 }

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -85,8 +85,8 @@ class Profile < ApplicationRecord
   validates :company_address_line2, presence: false, length: { maximum: 1024 }
   validates :company_tel, presence: true, length: { maximum: 128 }, tel: true
   validates :company_fax, presence: false, length: { maximum: 128 }
-  validates :department, presence: false, length: { maximum: 128 }
-  validates :position, presence: false, length: { maximum: 128 }
+  validates :department, presence: true, length: { maximum: 128 }
+  validates :position, presence: true, length: { maximum: 128 }
   validates :number_of_employee_id, presence: true, length: { maximum: 128 }
   validates :annual_sales_id, presence: true, length: { maximum: 128 }
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -90,8 +90,8 @@
   </div>
 
   <div class="form-row form-group">
-    <%= form.label :company_address_line2, "勤務先住所: 建物名など" %><span class="required">*</span>
-    <%= form.text_field :company_address_line2, required: true, class: "form-control", autocomplete: "address-line2"%>
+    <%= form.label :company_address_line2, "勤務先住所: 建物名など" %>
+    <%= form.text_field :company_address_line2, required: false, class: "form-control", autocomplete: "address-line2"%>
   </div>
 
   <div class="form-row form-group">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -104,6 +104,16 @@
     <%= form.text_field :company_fax, required: false, class: "form-control", placeholder: "0300000000", pattern: "[\\d+-]*" %>
   </div>
 
+  <div class="form-row form-group">
+    <%= form.label :department, "勤務先部署･所属 / 学部･学科･学年" %>*
+    <%= form.text_field :department, required: true, class: "form-control", placeholder: "クラウド開発部門" %>
+  </div>
+
+  <div class="form-row form-group">
+    <%= form.label :position, "勤務先役職" %>*
+    <%= form.text_field :position, required: true, class: "form-control", placeholder: "一般 / 管理職 / CTO など" %>
+  </div>
+
   <% if action_name == "new" %>
   <div class="privacy_policy">
     <%= markdown @conference.privacy_policy %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -105,12 +105,12 @@
   </div>
 
   <div class="form-row form-group">
-    <%= form.label :department, "勤務先部署･所属 / 学部･学科･学年" %>*
+    <%= form.label :department, "勤務先部署･所属 / 学部･学科･学年" %><span class="required">*</span>
     <%= form.text_field :department, required: true, class: "form-control", placeholder: "クラウド開発部門" %>
   </div>
 
   <div class="form-row form-group">
-    <%= form.label :position, "勤務先役職" %>*
+    <%= form.label :position, "勤務先役職" %><span class="required">*</span>
     <%= form.text_field :position, required: true, class: "form-control", placeholder: "一般 / 管理職 / CTO など" %>
   </div>
 

--- a/db/fixtures/development/privacy_policy_cnsec2022.md
+++ b/db/fixtures/development/privacy_policy_cnsec2022.md
@@ -23,9 +23,9 @@
 
 - [日本マイクロソフト株式会社](https://privacy.microsoft.com/ja-jp/privacystatement)
 - [HashiCorp Japan株式会社](https://www.hashicorp.com/privacy)
-- F5ネットワークスジャパン合同会社
+- [F5ネットワークスジャパン合同会社](https://www.f5.com/ja_jp/company/policies/privacy-notice)
 - [Snyk株式会社](https://snyk.io/policies/privacy/)
-- mabl株式会社
+- [mabl株式会社](https://www.mabl.com/privacy)
 - [グーグル・クラウド・ジャパン合同会社](https://policies.google.com/privacy)
 
 #### 当社の個人情報のお取扱いに関するお問い合わせ

--- a/db/fixtures/production/privacy_policy_cnsec2022.md
+++ b/db/fixtures/production/privacy_policy_cnsec2022.md
@@ -23,9 +23,9 @@
 
 - [日本マイクロソフト株式会社](https://privacy.microsoft.com/ja-jp/privacystatement)
 - [HashiCorp Japan株式会社](https://www.hashicorp.com/privacy)
-- F5ネットワークスジャパン合同会社
+- [F5ネットワークスジャパン合同会社](https://www.f5.com/ja_jp/company/policies/privacy-notice)
 - [Snyk株式会社](https://snyk.io/policies/privacy/)
-- mabl株式会社
+- [mabl株式会社](https://www.mabl.com/privacy)
 - [グーグル・クラウド・ジャパン合同会社](https://policies.google.com/privacy)
 
 #### 当社の個人情報のお取扱いに関するお問い合わせ

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe(Profile, type: :model) do
   end
 
   [:sub, :email, :first_name, :last_name, :company_name, :company_email,
-   :company_postal_code, :company_address_level1, :company_address_level2, :company_address_line1, :company_address_line2,
+   :company_postal_code, :company_address_level1, :company_address_level2, :company_address_line1,
    :company_tel, :department, :position].each do |param|
     it "is invalid without #{param}" do
       @profile[param] = nil

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe(Profile, type: :model) do
 
   [:sub, :email, :first_name, :last_name, :company_name, :company_email,
    :company_postal_code, :company_address_level1, :company_address_level2, :company_address_line1, :company_address_line2,
-   :company_tel].each do |param|
+   :company_tel, :department, :position].each do |param|
     it "is invalid without #{param}" do
       @profile[param] = nil
       expect(@profile).to(be_invalid)


### PR DESCRIPTION
> ・新規登録のページで所属部署名、役職（肩書）のフリー記入欄
> ・Karteに所属部署(プルダウン)と役職区分(プルダウン)

とのことで、こちら側に所属部署名と役職を復活。

あと
- 建物名をオプションに
- プライバシーポリシーのリンクを追加