### PR TITLE
add_csv_columns

### DIFF
--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -69,6 +69,12 @@ class Speaker < ApplicationRecord
     end
   end
 
+  def avatar_full_url
+    if has_avatar?
+      "https://#{ENV.fetch('S3_BUCKET', '')}.s3.#{ENV.fetch('S3_REGION', '')}.amazonaws.com#{avatar_url}"
+    end
+  end
+
   def twitter_link
     link_to(ActionController::Base.helpers.image_tag('Twitter_Social_Icon_Circle_Color.png', width: 20), "https://twitter.com/#{twitter_id}") if twitter_id.present?
   end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -106,7 +106,7 @@ class Talk < ApplicationRecord
 
     # this column was added later,
     # so it is added at the end for processing by the broadcast team.
-    columns_added_later = %w[avatar_url date track_id(A,B...)]
+    columns_added_later = %w[avatar_url date track_id]
     columns.concat(columns_added_later)
 
     csv = CSV.generate do |csv|

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -98,7 +98,7 @@ class Talk < ApplicationRecord
 
   def self.export_csv(conference, talks, track_name = 'all', date = 'all')
     filename = "#{conference.abbr}_#{date}_#{track_name}"
-    columns = %w[id title abstract speaker session_time difficulty category created_at twitter_id company start_to_end]
+    columns = %w[id title abstract speaker avatar_url date track_id session_time difficulty category created_at twitter_id company start_to_end]
     labels = conference.proposal_item_configs.map(&:label).uniq
     labels.delete('session_time')
     columns.concat(labels)
@@ -112,6 +112,9 @@ class Talk < ApplicationRecord
                talk.title,
                talk.abstract,
                talk.speaker_names.join('/ '),
+               talk.avatar_urls.join('/ '),
+               talk.conference_day.date,
+               talk.track.name,
                talk.time,
                talk.talk_difficulty&.name,
                talk.talk_category&.name,
@@ -192,6 +195,10 @@ class Talk < ApplicationRecord
 
   def speaker_names
     speakers.map(&:name)
+  end
+
+  def avatar_urls
+    speakers.map(&:avatar_full_url)
   end
 
   def speaker_company_names

--- a/spec/models/speaker_spec.rb
+++ b/spec/models/speaker_spec.rb
@@ -43,4 +43,14 @@ RSpec.describe(Speaker, type: :model) do
       it { expect(subject).to(be_falsey) }
     end
   end
+
+  describe '#avatar_full_url' do
+    subject { speaker.avatar_full_url }
+    before { allow(speaker).to(receive(:avatar_url).and_return('/test_image.jpg')) }
+    let!(:speaker) { create(:speaker_alice) }
+
+    context 'when speaker has avatar_data' do
+      it { is_expected.to(eq("https://#{ENV.fetch('S3_BUCKET', '')}.s3.#{ENV.fetch('S3_REGION', '')}.amazonaws.com/test_image.jpg")) }
+    end
+  end
 end


### PR DESCRIPTION
#1294

Track の CSV 出力にカラムを追加しました.
１点懸念点としては, プロフィール画像の URL ですが S3 のバケットが非公開のため実際には都度の署名付き URL が必要になるため CSV には有効な URL を出力できないのですがそれでも問題ないでしょうか？
後は下記確認していただきたいです.

- date の format は `2022-04-01` 
- 開催日は Talk の行われる日を出力する
- 各々のカラム名/順番について