### PR TITLE
Grafanaリンクを恒常化

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -31,12 +31,8 @@ class ContentsController < ApplicationController
   end
 
   def o11y
-    if params[:event] == 'o11y2022'
-      @conference = Conference.find_by(abbr: params[:event])
-      render("#{@conference.abbr}_o11y".to_sym)
-    else
-      redirect_to("/#{params[:event]}")
-    end
+    @conference = Conference.find_by(abbr: params[:event])
+    render(:o11y)
   end
 
   private

--- a/app/views/contents/o11y.html.erb
+++ b/app/views/contents/o11y.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
   <div class="row p-md-4" id="o11y">
     <div class="col-12 my-4">
-      <h2 class="text-center">Observability ConferenceをObserveしよう！</h2>
-      <p>せっかくObservabilityのカンファレンスをやるのであれば、カンファレンス自体の可観測性を高めていくと良いのでは？ そんな思いから、Observability ConferenceのさまざまなメトリクスをGrafanaで可視化し、それを公開してしまおう！　という企画です。</p>
+      <h2 class="text-center"><%= @conference.name %>をObserveしよう！</h2>
+      <p>せっかくクラウドネイティブのカンファレンスをやるのであれば、カンファレンス自体の可観測性を高めていくと良いのでは？ そんな思いから、本カンファレンスのさまざまなメトリクスをGrafanaで可視化し、それを公開してしまおう！ という企画です。</p>
       
       <p>Grafanaとは、データベースに格納されている大量の数値データを分析およびインタラクティブな視覚化を可能にする、マルチプラットフォームで動作するOSSのWebアプリケーションです。</p>
       <p>さあ、どんなメトリクスが見られるのでしょうか。是非アクセスしてみてください!</p>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -34,6 +34,7 @@
                 <%= link_to 'セッションリスト', talks_path, class: "dropdown-item", data: {"turbolinks" => false} %>
               </div>
             </li>
+            <li class="nav-item"><%= link_to "Grafana", o11y_path, class: "nav-link js-scroll-trigger" %></li>
 
             <% case event_name %>
             <% when 'cndt2020' %>
@@ -49,7 +50,6 @@
               <li class="nav-item"><%= link_to "Hands-on (Co-located)", hands_on_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
               <li class="nav-item"><%= link_to "Job Board", job_board_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
             <% when 'o11y2022' %>
-              <li class="nav-item"><%= link_to "Grafana", o11y_path, class: "nav-link js-scroll-trigger" %></li>
               <li class="nav-item"><%= link_to "Committee", team_path, class: "nav-link js-scroll-trigger" %></li>
               <li class="nav-item"><%= link_to "Hands-on (Co-located)", hands_on_path, class: "nav-link js-scroll-trigger", data: {"turbolinks" => false}  %></li>
             <% end %>


### PR DESCRIPTION
Fix #1305 

これまではO11yだけにGrafanaリンクを出していたが、これはもう常時表示にしてしまって構わない。
過去のイベントダッシュボードにも出るが、今後は過去イベントにはログイン出来なくする #1273 修正が入るし、そもそもリンクが出ても特に困らないので、この修正で常時表示にしちゃう