### PR TITLE
Add index on proposals for talks controller

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,6 +246,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_28_153413) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["talk_id"], name: "index_proposals_on_talk_id"
   end
 
   create_table "registered_talks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
https://grafana.cloudnativedays.jp/explore?orgId=1&left=%7B%22datasource%22:%22Jaeger%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22query%22:%2237f1c7007d1e9e729d61599955345d5d%22%7D%5D,%22range%22:%7B%22from%22:%22now-3h%22,%22to%22:%22now%22%7D%7D

このクエリをかなり早くできそう（JOINさせる時にフルスキャンが走らなくなる）

```sql
SELECT 
    `talks`.`id` AS t0_r0,
    `talks`.`title` AS t0_r1,
    `talks`.`abstract` AS t0_r2,
    `talks`.`movie_url` AS t0_r3,
    `talks`.`start_time` AS t0_r4,
    `talks`.`end_time` AS t0_r5,
    `talks`.`talk_difficulty_id` AS t0_r6,
    `talks`.`talk_category_id` AS t0_r7,
    `talks`.`created_at` AS t0_r8,
    `talks`.`updated_at` AS t0_r9,
    `talks`.`conference_id` AS t0_r10,
    `talks`.`conference_day_id` AS t0_r11,
    `talks`.`track_id` AS t0_r12,
    `talks`.`video_published` AS t0_r13,
    `talks`.`document_url` AS t0_r14,
    `talks`.`show_on_timetable` AS t0_r15,
    `talks`.`talk_time_id` AS t0_r16,
    `talks`.`expected_participants` AS t0_r17,
    `talks`.`execution_phases` AS t0_r18,
    `talks`.`sponsor_id` AS t0_r19,
    `talks`.`start_offset` AS t0_r20,
    `talks`.`end_offset` AS t0_r21,
    `proposals`.`id` AS t1_r0,
    `proposals`.`talk_id` AS t1_r1,
    `proposals`.`conference_id` AS t1_r2,
    `proposals`.`status` AS t1_r3,
    `proposals`.`created_at` AS t1_r4,
    `proposals`.`updated_at` AS t1_r5
FROM `talks`
LEFT OUTER JOIN `proposals`
    ON `proposals`.`talk_id` = `talks`.`id`
LEFT JOIN `conference_days`
    ON `talks`.`conference_day_id` = `conference_days`.`id`
WHERE `talks`.`conference_id` = 6 AND `talks`.`show_on_timetable` = TRUE AND `proposals`.`status` = 1
ORDER BY 
    `conference_days`.`date` ASC,
    `talks`.`start_time` ASC
```