### PR TITLE
add index

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -408,6 +408,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_28_153413) do
     t.integer "speaker_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["talk_id"], name: "index_talks_speakers_on_talk_id"
   end
 
   create_table "tracks", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -453,6 +454,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_28_153413) do
     t.index ["conference_id"], name: "index_viewer_counts_on_conference_id"
     t.index ["talk_id"], name: "index_viewer_counts_on_talk_id"
     t.index ["track_id"], name: "index_viewer_counts_on_track_id"
+    t.index ["created_at"], name: "index_viewer_counts_on_created_at"
   end
 
   add_foreign_key "admin_profiles", "conferences"


### PR DESCRIPTION
もろもろ貼れてないINDEXを実行計画とにらめっこ

```sql
SELECT `viewer_counts`.*
FROM `viewer_counts`
WHERE `viewer_counts`.`track_id` = 29
ORDER BY `viewer_counts`.`created_at` DESC LIMIT 1;

SELECT `speakers`.*
FROM `speakers`
INNER JOIN `talks_speakers`
    ON `speakers`.`id` = `talks_speakers`.`speaker_id`
WHERE `talks_speakers`.`talk_id` = 1446;
```

viewer_countsに関してはdesc indexでもよかったけどbackwards index scanがそこまで足を引っ張らない程度のデータ量なのと、Active recordでの降順インデックスの書き方がわからなかったのでASC indexにしている。