### PR TITLE
CFP決定以前にCSVがDLできない不具合の修正

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -132,8 +132,8 @@ class Talk < ApplicationRecord
           row << (v.instance_of?(Array) ? v.join(', ') : v)
         end
         row << talk.avatar_urls.join('/ ')
-        row << talk.conference_day.date
-        row << talk.track.name
+        row << (talk.conference_day.nil? ? nil : talk.conference_day.date)
+        row << (talk.track.nil? ? nil : talk.track.name)
         csv << row
       end
     end

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -47,6 +47,7 @@ FactoryBot.define do
     show_on_timetable { true }
     video_published { true }
     document_url { 'http://' }
+    created_at { Time.new(2022, 9, 1, 10) }
 
     trait :video_published do
       video_published { true }
@@ -179,5 +180,18 @@ FactoryBot.define do
     show_on_timetable { true }
     video_published { true }
     document_url { 'http://' }
+  end
+
+  factory :has_no_conference_days, class: Talk do
+    id { 100 }
+    title { 'not accepted talk' }
+    abstract { 'あいうえおかきくけこさしすせそ' }
+    conference_id { 1 }
+    talk_difficulty_id { 1 }
+    talk_category_id { 1 }
+    show_on_timetable { false }
+    video_published { false }
+    document_url { 'http://' }
+    created_at { Time.new(2022, 9, 1, 10) }
   end
 end

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -94,7 +94,7 @@ describe Talk, type: :model do
     let!(:proposal_item_config_1) { create(:proposal_item_configs_presentation_method, :live, conference: cndt2020) }
     let!(:proposal_item_config_2) { create(:proposal_item_configs_presentation_method, :video, conference: cndt2020) }
     let(:expected) {
-      "id,title,abstract,speaker,session_time,difficulty,category,created_at,twitter_id,company,start_to_end,presentation_method,avatar_url,date,track_id\n1,talk1,あいうえおかきくけこさしすせそ,\"\",40,,,2022-09-01 10:00:00 +0900,\"\",\"\",12:00-12:40,,\"\",2020-09-08,A\n"
+      "id,title,abstract,speaker,session_time,difficulty,category,created_at,twitter_id,company,start_to_end,presentation_method,avatar_url,date,track_id\n1,talk1,あいうえおかきくけこさしすせそ,\"\",40,,,#{talk.created_at.strftime('%Y-%m-%d %H:%M:%S +0900')},\"\",\"\",12:00-12:40,,\"\",2020-09-08,A\n"
     }
 
     context 'has full attributes' do
@@ -108,7 +108,7 @@ describe Talk, type: :model do
     context 'on registration term' do
       let!(:talk) { create(:has_no_conference_days) }
       let(:expected) {
-        "id,title,abstract,speaker,session_time,difficulty,category,created_at,twitter_id,company,start_to_end,presentation_method,avatar_url,date,track_id\n100,not accepted talk,あいうえおかきくけこさしすせそ,\"\",40,,,2022-09-01 10:00:00 +0900,\"\",\"\",\"\",,\"\",,\n"
+        "id,title,abstract,speaker,session_time,difficulty,category,created_at,twitter_id,company,start_to_end,presentation_method,avatar_url,date,track_id\n100,not accepted talk,あいうえおかきくけこさしすせそ,\"\",40,,,#{talk.created_at.strftime('%Y-%m-%d %H:%M:%S +0900')},\"\",\"\",\"\",,\"\",,\n"
       }
       it 'export csv without attributes will be decided later' do
         File.open("./#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -87,4 +87,34 @@ describe Talk, type: :model do
       end
     end
   end
+
+  describe '#export_csv' do
+    let!(:cndt2020) { create(:cndt2020) }
+    let!(:talk) { create(:talk1) }
+    let!(:proposal_item_config_1) { create(:proposal_item_configs_presentation_method, :live, conference: cndt2020) }
+    let!(:proposal_item_config_2) { create(:proposal_item_configs_presentation_method, :video, conference: cndt2020) }
+    let(:expected) {
+      "id,title,abstract,speaker,session_time,difficulty,category,created_at,twitter_id,company,start_to_end,presentation_method,avatar_url,date,track_id\n1,talk1,あいうえおかきくけこさしすせそ,\"\",40,,,2022-09-01 10:00:00 +0900,\"\",\"\",12:00-12:40,,\"\",2020-09-08,A\n"
+    }
+
+    context 'has full attributes' do
+      it 'export csv' do
+        File.open("./#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
+          expect(file.read).to(eq(expected))
+        end
+      end
+    end
+
+    context 'on registration term' do
+      let!(:talk) { create(:has_no_conference_days) }
+      let(:expected) {
+        "id,title,abstract,speaker,session_time,difficulty,category,created_at,twitter_id,company,start_to_end,presentation_method,avatar_url,date,track_id\n100,not accepted talk,あいうえおかきくけこさしすせそ,\"\",40,,,2022-09-01 10:00:00 +0900,\"\",\"\",\"\",,\"\",,\n"
+      }
+      it 'export csv without attributes will be decided later' do
+        File.open("./#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
+          expect(file.read).to(eq(expected))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#1484 

CSV の項目追加時(#1304)にCFP採択以前の状態でのダウンロードに関する実装が漏れていたことが原因のよう