### PR TITLE
Adjust collation to production

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
       TZ: 'Asia/Tokyo'
     cap_add:
       - SYS_NICE
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci --default-authentication-plugin=mysql_native_password
     volumes:
     - mysql-data:/var/lib/mysql
     - ./db/docker-entrypoint-initdb.d/1_allow-host-ip.sql:/docker-entrypoint-initdb.d/1_allow-host-ip.sql


### PR DESCRIPTION
collation is `utf8mb4_0900_ai_ci` in production, but mysql container use `utf8mb4_unicode_ci` by docker-compose.

```
mysql>  show global variables like 'collation%'
    -> ;
+----------------------+--------------------+
| Variable_name        | Value              |
+----------------------+--------------------+
| collation_connection | utf8mb4_0900_ai_ci |
| collation_database   | utf8mb4_0900_ai_ci |
| collation_server     | utf8mb4_0900_ai_ci |
+----------------------+--------------------+
3 rows in set (0.01 sec)
```

