### PR TITLE
GuestProfile インスタンスを Profile インスタンスにある程度合わせる

### DIFF
--- a/app/models/guest_profile.rb
+++ b/app/models/guest_profile.rb
@@ -17,4 +17,26 @@ class GuestProfile
   def save
     true
   end
+
+  # do not return method_missing
+  # for methods to which Profile instance can respond,
+  # but return an appropriate value
+  def method_missing(method, *args)
+    if Profile.new.respond_to?(method)
+      match = method.to_s.match(/(.*?)([?=!]?)$/)
+      case match[2]
+      when '='
+        return args
+      when '?'
+        return true
+      else
+        return nil
+      end
+    end
+    super
+  end
+
+  def respond_to_missing?(method, include_privete = false)
+    Profile.new.respond_to?(method) || super
+  end
 end

--- a/app/models/guest_profile.rb
+++ b/app/models/guest_profile.rb
@@ -23,6 +23,7 @@ class GuestProfile
   # but return an appropriate value
   def method_missing(method, *args)
     if Profile.new.respond_to?(method)
+      Rails.logger.warn("GuestProfile call goast method: #{method}")
       match = method.to_s.match(/(.*?)([?=!]?)$/)
       case match[2]
       when '='

--- a/app/models/guest_profile.rb
+++ b/app/models/guest_profile.rb
@@ -23,7 +23,7 @@ class GuestProfile
   # but return an appropriate value
   def method_missing(method, *args)
     if Profile.new.respond_to?(method)
-      Rails.logger.warn("GuestProfile call goast method: #{method}")
+      Rails.logger.error("GuestProfile call goast method: #{method}")
       match = method.to_s.match(/(.*?)([?=!]?)$/)
       case match[2]
       when '='


### PR DESCRIPTION
GuestProfile は原則として Profile インスタンスと I/F を合わせたい。
しかし、ActiveRecord 含めスーパークラスのメソッドをすべて実装するのは難しい。
そのため迂回策として、Profile インスタンスが応答可能な method / attribute の場合は GuestProfile インスタンスでも NoMethodError を出さずに適当な値を返すようにする。

正確なクラスを返せないため、メソッドチェーンに使われているメソッドには対応できない場合もあり、その場合は GuestProfile に実装する必要がある。