### PR TITLE
fix: Correct my_profile url path in swagger.yml

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -11,7 +11,7 @@ servers:
   - url: http://api-mock.dev.cloudnativedays.jp/
   - url: http://dreamkast-api-mock.udcp.info/
 paths:
-  /api/v1/${eventAbbr}/my_profile:
+  /api/v1/{eventAbbr}/my_profile:
     get:
       tags:
         - Profile


### PR DESCRIPTION
swagger.ymlのurl pathに誤りがあったので、修正しました。
瞬殺系なので、さっと見ていただけると助かります！