### PR TITLE
Use SecuredPublicApi for ChatMessages and Profiles

### DIFF
--- a/app/controllers/api/v1/chat_messages_controller.rb
+++ b/app/controllers/api/v1/chat_messages_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::ChatMessagesController < ApplicationController
   include SecuredPublicApi
-  before_action :authenticate_request!
   before_action :set_profile
 
   skip_before_action :verify_authenticity_token

--- a/app/controllers/api/v1/chat_messages_controller.rb
+++ b/app/controllers/api/v1/chat_messages_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ChatMessagesController < ApplicationController
-  include SecuredApi
+  include SecuredPublicApi
+  before_action :authenticate_request!
   before_action :set_profile
 
   skip_before_action :verify_authenticity_token
@@ -27,7 +28,7 @@ class Api::V1::ChatMessagesController < ApplicationController
 
     attr = { profile_id: @profile.id, body:, conference_id: conference.id, room_id:, room_type:, message_type: }
 
-    speaker = Speaker.find_by(conference: @conference.id, email: @current_user[:info][:email])
+    speaker = Speaker.find_by(conference: conference.id, email: @current_user[:info][:email])
     attr[:speaker_id] = speaker.id if speaker.present?
 
     if reply_to

--- a/app/controllers/api/v1/debug_controller.rb
+++ b/app/controllers/api/v1/debug_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::DebugController < ApplicationController
   include SecuredPublicApi
-  before_action :authenticate_request!, only: [:index]
 
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::ProfilesController < ApplicationController
   include SecuredPublicApi
-  before_action :authenticate_request!
   before_action :set_profile
 
   skip_before_action :verify_authenticity_token

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::ProfilesController < ApplicationController
-  include SecuredApi
+  include SecuredPublicApi
+  before_action :authenticate_request!
   before_action :set_profile
+
+  skip_before_action :verify_authenticity_token
 
   def my_profile
     render(:my_profile, formats: :json, type: :jbuilder)

--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::TalksController < ApplicationController
   include SecuredPublicApi
-  before_action :authenticate_request!, only: [:update]
 
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::TalksController < ApplicationController
   include SecuredPublicApi
 
+  skip_before_action :authenticate_request!, only: [:index, :show]
   skip_before_action :verify_authenticity_token
 
   def index

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -103,3 +103,31 @@ def claim
     "scope": "openid profile email"
   }')]
 end
+
+def alice_claim
+  [JSON.parse('{
+    "https://cloudnativedays.jp/roles": [
+      "CNDT2022-Admin"
+    ],
+    "https://cloudnativedays.jp/userinfo": {
+      "given_name": "Alice",
+      "family_name": "alice",
+      "nickname": "alice",
+      "name": "alice",
+      "picture": "https://alice.example.com",
+      "locale": "en",
+      "email": "alice@example.com",
+      "email_verified": true
+    },
+    "iss": "https://dreamkast.us.auth0.com/",
+    "sub": "google-oauth2|alice",
+    "aud": [
+      "https://event.cloudnativedays.jp/",
+      "https://dreamkast.us.auth0.com/userinfo"
+    ],
+    "iat": 1662643742,
+    "exp": 1663003742,
+    "azp": "0cWWdpGt4CpWjHJ9QIHtPm5GrJLS25lz",
+    "scope": "openid profile email"
+  }')]
+end

--- a/spec/requests/api/v1/chat_message_index_spec.rb
+++ b/spec/requests/api/v1/chat_message_index_spec.rb
@@ -20,7 +20,7 @@ describe Api::V1::ChatMessagesController, type: :request do
 
   describe 'GET /api/v1/chat_messages' do
     before do
-      allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).and_return(session[:userinfo]))
+      allow(JsonWebToken).to(receive(:verify).and_return(alice_claim))
       create(:talk1, conference: cndt2020)
       create(:message_from_alice, profile: alice)
     end

--- a/spec/requests/api/v1/chat_message_update_spec.rb
+++ b/spec/requests/api/v1/chat_message_update_spec.rb
@@ -21,8 +21,8 @@ describe Api::V1::ChatMessagesController, type: :request do
   describe 'PUT /api/v1/chat_message/:id' do
     describe 'update own chat message' do
       before do
-        allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).and_return(info: { email: alice.email }))
-        create(:talk1)
+        allow(JsonWebToken).to(receive(:verify).and_return(alice_claim))
+        create(:talk1, conference: cndt2020)
         create(:message_from_alice, profile: alice)
       end
       let!(:cndt2020) { create(:cndt2020) }
@@ -43,7 +43,7 @@ describe Api::V1::ChatMessagesController, type: :request do
 
   describe 'update others chat message' do
     before do
-      allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).and_return(info: { email: alice.email }))
+      allow(JsonWebToken).to(receive(:verify).and_return(alice_claim))
       create(:talk1, conference: cndt2020)
     end
     let!(:cndt2020) { create(:cndt2020) }


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast-ui/pull/305 とセットで動くrails側の修正です。
dk-ui側を先にmergeしてもcookieで動きますが、こちらをmergeすることでJWTでの連携に切り替えることができます。

先にmergeしてしまうとUI側が動かなくなりますので、 https://github.com/cloudnativedaysjp/dreamkast-ui/pull/305 のmergeがblockingになります。
紛らわしいので、上記がmergeされるまではdraft PRにしておきます。