### PR TITLE
Not to bind userinfo for machine account access

### DIFF
--- a/app/controllers/concerns/secured_public_api.rb
+++ b/app/controllers/concerns/secured_public_api.rb
@@ -31,7 +31,7 @@ module SecuredPublicApi
     @current_user[:info] = {}
     @current_user[:extra] = {}
     @current_user[:extra][:raw_info] = claim
-    if claim['https://cloudnativedays.jp/userinfo']['name'].present?
+    if claim['https://cloudnativedays.jp/userinfo'].present?
       userinfo = claim['https://cloudnativedays.jp/userinfo']
       @current_user[:info][:name] = userinfo['name']
       @current_user[:info][:nickname] = userinfo['nickname']


### PR DESCRIPTION
access_tokenからcustom claimを引いてくるところで、userからのログインであれば問題ないのですが、auth0のclient_idとclient_secretを使ったclient credential flowでのアクセス（すなわちマシンアカウントによるアクセス）の場合にuserinfoの各fieldがundefinedになってしまい、userinfoのbinding時にこける事象がでました。

userinfoについて、マシンアカウントと通常ユーザの区別をどうするよ、というところを議論すべきかと思うのですが、broadcastチームでvideo_registration endpointが叩けなくて困っているとのことなので、とりあえず入れさせてください。

（この対処が必ずしもわるいわけではなく、とりあえずuserinfoには空hashを突っ込んでおく、という整理もありかと思っています。それでよければ、追加の議論・対処不要です）
