### PR TITLE
Nginx config to route sub-pages including image assets

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -29,6 +29,15 @@ server {
         proxy_pass http://host.docker.internal:3001/_next;
     }
     
+    location ~ ^/(.*)/ui/(.*) {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 1000M;
+        proxy_pass http://host.docker.internal:3001/$1/ui/$2;
+    }
+
     location ~ ^/(.*)/ui {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
local devしているときに、 `(.*)/ui/...` とネストされたリソースにアクセスしたときに一律 `/ui` にroutingされてしまっていて、画像が表示されなくなっていたので、location directiveを追加しました。
まとめることもできそうな気がしたのですが、 trailing slashがないケースがうまく動かず、諦めてこの構成にしています。。。
良い案があれば教えてほしいです。

また、現在は `ui/...` にはimage assetsしか配置してないのでproxy_passだけで良いかなと思ったのですが、将来的に他のページをnextで追加する可能性もあるかなと思い、 `/ui` と同じ定義に揃えています。