### PR TITLE
chore: Fix nginx config to pass next webpack-hmr

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -20,6 +20,15 @@ server {
         proxy_pass http://host.docker.internal:3000/cable;
     }
 
+    location ^~ /_next/webpack-hmr {
+        proxy_set_header Host $http_host;
+        proxy_set_header Upgrade websocket;
+        proxy_set_header Connection Upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass http://host.docker.internal:3001/_next/webpack-hmr;
+    }
+
     location ^~ /_next {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
nextのhot reloadのws通信が通ってなかった問題を直しました。
reloadすればよいだけではあるのですが、css周りをいじるときは重宝するのと、ひたすらwebsocketの再試行が走っていて煩わしくもあるので...
wsを通すdirectiveを追加しています。