### PR TITLE
fifo-workerをdocker-compose上、railsをlocalで動かした時にActionCableのbroadcastが動かない問題を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ COPY --link --from=node /app/node_modules /app/node_modules
 COPY --link --from=fetch-lib /usr/local/bundle /usr/local/bundle
 RUN apt-get update && apt-get install -y libvips42
 ENV AWS_ACCESS_KEY_ID=''
-RUN --mount=type=cache,uid=1000,target=/app/tmp/cache SECRET_KEY_BASE=hoge RAILS_ENV=production DB_ADAPTER=nulldb bin/rails assets:precompile
+ARG RAILS_ENV='production'
+RUN --mount=type=cache,uid=1000,target=/app/tmp/cache SECRET_KEY_BASE=hoge RAILS_ENV=${RAILS_ENV} DB_ADAPTER=nulldb bin/rails assets:precompile
 
 FROM ruby:3.1.2-slim
 
@@ -40,7 +41,8 @@ COPY --link --from=node /opt/yarn-v$YARN_VERSION /opt/yarn
 COPY --link --from=node /usr/local/bin/node /usr/local/bin/
 RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
     && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg
-ENV RAILS_ENV=production, RAILS_LOG_TO_STDOUT=ON, RAILS_SERVE_STATIC_FILES=enabled
+ARG RAILS_ENV='production'
+ENV RAILS_ENV=${RAILS_ENV}, RAILS_LOG_TO_STDOUT=ON, RAILS_SERVE_STATIC_FILES=enabled
 WORKDIR /app
 COPY --link --from=node /app/node_modules /app/node_modules
 COPY --link --from=fetch-lib /usr/local/bundle /usr/local/bundle

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,15 @@
 version: "3.8"
 services:
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - RAILS_ENV=development
     entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed_fu && ./entrypoint.sh"
     environment: &dkenv
-      RAILS_ENV: production
-      NODE_ENV: production
+      RAILS_ENV: development
+      NODE_ENV: development
       SENTRY_DSN: ${SENTRY_DSN}
       S3_REGION: ap-northeast-1
       S3_BUCKET: ${S3_BUCKET}


### PR DESCRIPTION
docker-compose上でfifo-workerを動かした時、RAILS_ENVがproductionになる。railsをlocalで動かした時はRAILS_ENVはdevelopmentになる。これにより使われるActionCableの設定が変わり、broadcastがうまく動かなくなっていた。
開発ではproductionではなくdevelopmentを使う方がよいだろうから、developmentを使うように修正。