### PR TITLE
add registered talks to display registered talks in dreamkast-ui

### DIFF
--- a/app/views/api/v1/profiles/my_profile.json.jbuilder
+++ b/app/views/api/v1/profiles/my_profile.json.jbuilder
@@ -2,7 +2,7 @@ json.id(@profile.id)
 json.email(@profile.email)
 json.name("#{@profile.last_name} #{@profile.first_name}")
 json.isAttendOffline(@profile.attend_offline?)
-json.registeredTalks(@profile.registered_talks.includes([talk: [:speakers, :conference_day, track: :room]]).map do |registered_talk|
+json.registeredTalks(@profile.registered_talks.includes([talk: [:speakers, :conference_day, { track: :room }]]).map do |registered_talk|
   {
     talkId: registered_talk.talk.id,
     talkTitle: registered_talk.talk.title,

--- a/app/views/api/v1/profiles/my_profile.json.jbuilder
+++ b/app/views/api/v1/profiles/my_profile.json.jbuilder
@@ -2,7 +2,7 @@ json.id(@profile.id)
 json.email(@profile.email)
 json.name("#{@profile.last_name} #{@profile.first_name}")
 json.isAttendOffline(@profile.attend_offline?)
-json.registeredTalks(@profile.registered_talks.map do |registered_talk|
+json.registeredTalks(@profile.registered_talks.includes([talk: [:speakers, :conference_day, track: :room]]).map do |registered_talk|
   {
     talkId: registered_talk.talk.id,
     talkTitle: registered_talk.talk.title,

--- a/app/views/api/v1/profiles/my_profile.json.jbuilder
+++ b/app/views/api/v1/profiles/my_profile.json.jbuilder
@@ -2,3 +2,15 @@ json.id(@profile.id)
 json.email(@profile.email)
 json.name("#{@profile.last_name} #{@profile.first_name}")
 json.isAttendOffline(@profile.attend_offline?)
+json.registeredTalks(@profile.registered_talks.map do |registered_talk|
+  {
+    talkId: registered_talk.talk.id,
+    talkTitle: registered_talk.talk.title,
+    talkSpeakers: registered_talk.talk.speakers.map { |speaker| { name: speaker.name, twitterId: speaker.twitter_id } },
+    talkStartTime: registered_talk.talk.start_time.rfc3339,
+    talkEndTime: registered_talk.talk.end_time.rfc3339,
+    trackName: registered_talk.talk.track.name,
+    roomName: registered_talk.talk.track.room.name,
+    conferenceDay: registered_talk.talk.conference_day.date
+  }
+end)

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -691,11 +691,44 @@ components:
           type: string
         isAttendOffline:
           type: boolean
+        registeredTalks:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegisteredTalk'
       required:
         - id
         - name
         - email
         - isAttendOffline
+    RegisteredTalk:
+      type: object
+      properties:
+        talkId:
+          type: number
+        talkTitle:
+          type: string
+        talkSpeakers:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              twitterId:
+                type: string
+        talkStartTime:
+          type: string
+          format: date-time
+        talkEndTime:
+          type: string
+          format: date-time
+        trackName:
+          type: string
+        roomName:
+          type: string
+        conferenceDay:
+          type: string
+          format: date
     Event:
       type: object
       additionalProperties: false


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast-ui/pull/332 でUIに登録済みセッションを表示するページを追加するのだが、そのページに必要な登録済みセッションに関する情報をmy profile apiで返すようにします。