### PR TITLE
chore: Port swagger.yml from the apigateway exported one

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -388,18 +388,18 @@ paths:
   /api/v1/profile/{profileId}/points:
     get:
       tags:
-        - Dreamkast-function
+        - Point
       parameters:
-      - name: "conference"
-        in: "query"
-        required: true
-        schema:
-          type: "string"
-      - name: "profileId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "conference"
+          in: "query"
+          required: true
+          schema:
+            type: "string"
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "400 response"
@@ -449,16 +449,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ProfilePoints"
+    options:
+      parameters:
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
   /api/v1/talks/{talkId}/vote:
     post:
       tags:
-        - Dreamkast-function
+        - Vote
       parameters:
-      - name: "talkId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "talkId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -514,16 +535,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Empty"
+    options:
+      parameters:
+        - name: "talkId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
   /api/v1/profile/{profileId}/point:
     post:
       tags:
-        - Dreamkast-function
+        - Point
       parameters:
-      - name: "profileId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -595,16 +637,196 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    options:
+      parameters:
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+  /api/v1/app-data/{profileId}/conference/{conference}:
+    get:
+      tags:
+        - DkUiData
+      parameters:
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "conference"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "400":
+          description: "400 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DkUiData"
+    post:
+      tags:
+        - DkUiData
+      parameters:
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "conference"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DkUiDataMutation"
+        required: true
+      responses:
+        "400":
+          description: "400 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Empty"
+    options:
+      parameters:
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "conference"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
   /api/v1/tracks/{trackId}/viewer_count:
     get:
       tags:
-        - Dreamkast-function
+        - ViewerCount
       parameters:
-      - name: "trackId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "trackId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "400 response"
@@ -655,14 +877,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ViewerCount"
     options:
-      tags:
-        - Dreamkast-function
       parameters:
-      - name: "trackId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "trackId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "200":
           description: "200 response"
@@ -1133,7 +1353,7 @@ components:
     Vote:
       title: "voteResponse"
       required:
-      - "eventAbbr"
+        - "eventAbbr"
       type: "object"
       properties:
         eventAbbr:
@@ -1145,11 +1365,56 @@ components:
       properties:
         message:
           type: "string"
+    DkUiData:
+      title: "dkUiData"
+      required:
+        - "stampChallenges"
+        - "watchedTalksOnline"
+      type: "object"
+      properties:
+        watchedTalksOnline:
+          type: "object"
+          properties:
+            watchingTime:
+              type: "object"
+              additionalProperties: true
+            prevTimestamp:
+              type: "number"
+        stampChallenges:
+          type: "array"
+          items:
+            required:
+              - "slotId"
+              - "waiting"
+            type: "object"
+            properties:
+              condition:
+                type: "string"
+              waiting:
+                type: "boolean"
+              slotId:
+                type: "number"
+              timestamp:
+                type: "number"
+      additionalProperties: true
+    DkUiDataMutation:
+      title: "dkUiDataMutation"
+      required:
+        - "action"
+        - "payload"
+      type: "object"
+      properties:
+        payload:
+          type: "object"
+          additionalProperties: true
+        action:
+          type: "string"
+      additionalProperties: false
     ViewerCount:
       title: "viewerCountResponse"
       required:
-      - "trackId"
-      - "viewerCount"
+        - "trackId"
+        - "viewerCount"
       type: "object"
       properties:
         trackId:
@@ -1160,8 +1425,8 @@ components:
     ProfilePoints:
       title: "profilePointsResponse"
       required:
-      - "points"
-      - "total"
+        - "points"
+        - "total"
       type: "object"
       properties:
         total:
@@ -1171,8 +1436,8 @@ components:
           items:
             title: "profilePointResponse"
             required:
-            - "conference"
-            - "pointEventId"
+              - "conference"
+              - "pointEventId"
             type: "object"
             properties:
               conference:
@@ -1188,8 +1453,8 @@ components:
     ProfilePoint:
       title: "profilePointRequest"
       required:
-      - "conference"
-      - "pointEventId"
+        - "conference"
+        - "pointEventId"
       type: "object"
       properties:
         conference:
@@ -1197,4 +1462,3 @@ components:
         pointEventId:
           type: "string"
       additionalProperties: false
-

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -385,155 +385,21 @@ paths:
           description: Booth not found
 
   # dreamkast function
-  /api/v1/app-data/{profileId}/conference/{conference}:
-    get:
-      tags:
-        - DkUiData
-      parameters:
-        - name: "conference"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-        - name: "profileId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-      responses:
-        "400":
-          description: "400 response"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "500":
-          description: "500 response"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "200":
-          description: "200 response"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DkUiData"
-    post:
-      tags:
-        - DkUiData
-      parameters:
-        - name: "profileId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-        - name: "conference"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DkUiDataMutation"
-        required: true
-      responses:
-        "400":
-          description: "400 response"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "500":
-          description: "500 response"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "200":
-          description: "200 response"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Empty"
   /api/v1/profile/{profileId}/points:
     get:
       tags:
-        - Point
+        - Dreamkast-function
       parameters:
-        - name: "profileId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-        - name: "conference"
-          in: query
-          description: conference name (e.g. cndt2020)
-          required: false
-          schema:
-            type: string
+      - name: "conference"
+        in: "query"
+        required: true
+        schema:
+          type: "string"
+      - name: "profileId"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "400":
           description: "400 response"
@@ -586,13 +452,13 @@ paths:
   /api/v1/talks/{talkId}/vote:
     post:
       tags:
-        - Vote
+        - Dreamkast-function
       parameters:
-        - name: "talkId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "talkId"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -651,13 +517,13 @@ paths:
   /api/v1/profile/{profileId}/point:
     post:
       tags:
-        - Point
+        - Dreamkast-function
       parameters:
-        - name: "profileId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "profileId"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -732,13 +598,13 @@ paths:
   /api/v1/tracks/{trackId}/viewer_count:
     get:
       tags:
-        - ViewerCount
+        - Dreamkast-function
       parameters:
-        - name: "trackId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "trackId"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "400":
           description: "400 response"
@@ -789,12 +655,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/ViewerCount"
     options:
+      tags:
+        - Dreamkast-function
       parameters:
-        - name: "trackId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "trackId"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "200":
           description: "200 response"
@@ -805,21 +673,10 @@ paths:
             Access-Control-Allow-Methods:
               schema:
                 type: "string"
-            Vary:
-              schema:
-                type: "string"
             Access-Control-Allow-Headers:
               schema:
                 type: "string"
           content: {}
-  /api/v1/{proxy+}:
-    x-amazon-apigateway-any-method:
-      parameters:
-        - name: "proxy"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
 
 components:
   schemas:
@@ -834,11 +691,44 @@ components:
           type: string
         isAttendOffline:
           type: boolean
+        registeredTalks:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegisteredTalk'
       required:
         - id
         - name
         - email
         - isAttendOffline
+    RegisteredTalk:
+      type: object
+      properties:
+        talkId:
+          type: number
+        talkTitle:
+          type: string
+        talkSpeakers:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              twitterId:
+                type: string
+        talkStartTime:
+          type: string
+          format: date-time
+        talkEndTime:
+          type: string
+          format: date-time
+        trackName:
+          type: string
+        roomName:
+          type: string
+        conferenceDay:
+          type: string
+          format: date
     Event:
       type: object
       additionalProperties: false
@@ -1243,7 +1133,7 @@ components:
     Vote:
       title: "voteResponse"
       required:
-        - "eventAbbr"
+      - "eventAbbr"
       type: "object"
       properties:
         eventAbbr:
@@ -1255,56 +1145,11 @@ components:
       properties:
         message:
           type: "string"
-    DkUiData:
-      title: "dkUiData"
-      required:
-        - "stampChallenges"
-        - "watchedTalksOnline"
-      type: "object"
-      properties:
-        watchedTalksOnline:
-          type: "object"
-          properties:
-            watchingTime:
-              type: "object"
-              additionalProperties: true
-            prevTimestamp:
-              type: "number"
-        stampChallenges:
-          type: "array"
-          items:
-            required:
-              - "slotId"
-              - "waiting"
-            type: "object"
-            properties:
-              condition:
-                type: "string"
-              waiting:
-                type: "boolean"
-              slotId:
-                type: "number"
-              timestamp:
-                type: "number"
-      additionalProperties: true
-    DkUiDataMutation:
-      title: "dkUiDataMutation"
-      required:
-        - "action"
-        - "payload"
-      type: "object"
-      properties:
-        payload:
-          type: "object"
-          additionalProperties: true
-        action:
-          type: "string"
-      additionalProperties: false
     ViewerCount:
       title: "viewerCountResponse"
       required:
-        - "trackId"
-        - "viewerCount"
+      - "trackId"
+      - "viewerCount"
       type: "object"
       properties:
         trackId:
@@ -1315,8 +1160,8 @@ components:
     ProfilePoints:
       title: "profilePointsResponse"
       required:
-        - "points"
-        - "total"
+      - "points"
+      - "total"
       type: "object"
       properties:
         total:
@@ -1326,8 +1171,8 @@ components:
           items:
             title: "profilePointResponse"
             required:
-              - "conference"
-              - "pointEventId"
+            - "conference"
+            - "pointEventId"
             type: "object"
             properties:
               conference:
@@ -1343,8 +1188,8 @@ components:
     ProfilePoint:
       title: "profilePointRequest"
       required:
-        - "conference"
-        - "pointEventId"
+      - "conference"
+      - "pointEventId"
       type: "object"
       properties:
         conference:
@@ -1352,3 +1197,4 @@ components:
         pointEventId:
           type: "string"
       additionalProperties: false
+

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -385,21 +385,155 @@ paths:
           description: Booth not found
 
   # dreamkast function
+  /api/v1/app-data/{profileId}/conference/{conference}:
+    get:
+      tags:
+        - DkUiData
+      parameters:
+        - name: "conference"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "400":
+          description: "400 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DkUiData"
+    post:
+      tags:
+        - DkUiData
+      parameters:
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "conference"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DkUiDataMutation"
+        required: true
+      responses:
+        "400":
+          description: "400 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Empty"
   /api/v1/profile/{profileId}/points:
     get:
       tags:
-        - Dreamkast-function
+        - Point
       parameters:
-      - name: "conference"
-        in: "query"
-        required: true
-        schema:
-          type: "string"
-      - name: "profileId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "conference"
+          in: query
+          description: conference name (e.g. cndt2020)
+          required: false
+          schema:
+            type: string
       responses:
         "400":
           description: "400 response"
@@ -452,13 +586,13 @@ paths:
   /api/v1/talks/{talkId}/vote:
     post:
       tags:
-        - Dreamkast-function
+        - Vote
       parameters:
-      - name: "talkId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "talkId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -517,13 +651,13 @@ paths:
   /api/v1/profile/{profileId}/point:
     post:
       tags:
-        - Dreamkast-function
+        - Point
       parameters:
-      - name: "profileId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "profileId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -598,13 +732,13 @@ paths:
   /api/v1/tracks/{trackId}/viewer_count:
     get:
       tags:
-        - Dreamkast-function
+        - ViewerCount
       parameters:
-      - name: "trackId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "trackId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "400 response"
@@ -655,14 +789,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ViewerCount"
     options:
-      tags:
-        - Dreamkast-function
       parameters:
-      - name: "trackId"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "trackId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "200":
           description: "200 response"
@@ -673,10 +805,21 @@ paths:
             Access-Control-Allow-Methods:
               schema:
                 type: "string"
+            Vary:
+              schema:
+                type: "string"
             Access-Control-Allow-Headers:
               schema:
                 type: "string"
           content: {}
+  /api/v1/{proxy+}:
+    x-amazon-apigateway-any-method:
+      parameters:
+        - name: "proxy"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
 
 components:
   schemas:
@@ -691,44 +834,11 @@ components:
           type: string
         isAttendOffline:
           type: boolean
-        registeredTalks:
-          type: array
-          items:
-            $ref: '#/components/schemas/RegisteredTalk'
       required:
         - id
         - name
         - email
         - isAttendOffline
-    RegisteredTalk:
-      type: object
-      properties:
-        talkId:
-          type: number
-        talkTitle:
-          type: string
-        talkSpeakers:
-          type: array
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-              twitterId:
-                type: string
-        talkStartTime:
-          type: string
-          format: date-time
-        talkEndTime:
-          type: string
-          format: date-time
-        trackName:
-          type: string
-        roomName:
-          type: string
-        conferenceDay:
-          type: string
-          format: date
     Event:
       type: object
       additionalProperties: false
@@ -1133,7 +1243,7 @@ components:
     Vote:
       title: "voteResponse"
       required:
-      - "eventAbbr"
+        - "eventAbbr"
       type: "object"
       properties:
         eventAbbr:
@@ -1145,11 +1255,56 @@ components:
       properties:
         message:
           type: "string"
+    DkUiData:
+      title: "dkUiData"
+      required:
+        - "stampChallenges"
+        - "watchedTalksOnline"
+      type: "object"
+      properties:
+        watchedTalksOnline:
+          type: "object"
+          properties:
+            watchingTime:
+              type: "object"
+              additionalProperties: true
+            prevTimestamp:
+              type: "number"
+        stampChallenges:
+          type: "array"
+          items:
+            required:
+              - "slotId"
+              - "waiting"
+            type: "object"
+            properties:
+              condition:
+                type: "string"
+              waiting:
+                type: "boolean"
+              slotId:
+                type: "number"
+              timestamp:
+                type: "number"
+      additionalProperties: true
+    DkUiDataMutation:
+      title: "dkUiDataMutation"
+      required:
+        - "action"
+        - "payload"
+      type: "object"
+      properties:
+        payload:
+          type: "object"
+          additionalProperties: true
+        action:
+          type: "string"
+      additionalProperties: false
     ViewerCount:
       title: "viewerCountResponse"
       required:
-      - "trackId"
-      - "viewerCount"
+        - "trackId"
+        - "viewerCount"
       type: "object"
       properties:
         trackId:
@@ -1160,8 +1315,8 @@ components:
     ProfilePoints:
       title: "profilePointsResponse"
       required:
-      - "points"
-      - "total"
+        - "points"
+        - "total"
       type: "object"
       properties:
         total:
@@ -1171,8 +1326,8 @@ components:
           items:
             title: "profilePointResponse"
             required:
-            - "conference"
-            - "pointEventId"
+              - "conference"
+              - "pointEventId"
             type: "object"
             properties:
               conference:
@@ -1188,8 +1343,8 @@ components:
     ProfilePoint:
       title: "profilePointRequest"
       required:
-      - "conference"
-      - "pointEventId"
+        - "conference"
+        - "pointEventId"
       type: "object"
       properties:
         conference:
@@ -1197,4 +1352,3 @@ components:
         pointEventId:
           type: "string"
       additionalProperties: false
-


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast-functions/pull/52
上記のapigatewayの変更分を、swagger.ymlに反映しました。

加えて、dk-functionのapiにすべて `dreamkast-function` が入っていましたが、tagが入っているとRTK Queryのmutation後にreloadする対象と判定されてしまうため、関連があって必要なところのみtagをつけるようにしました