### PR TITLE
Additional location directive of nginx to address local SAM

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -1,3 +1,7 @@
+upstream sam {
+    server host.docker.internal:3002;
+}
+
 server {
     listen       80;
     server_name  localhost;
@@ -54,6 +58,22 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 1000M;
         proxy_pass http://host.docker.internal:3001/$1/ui;
+    }
+
+    location ~ ^/api/v1/profile/(.*)/point(.*) {
+        proxy_pass http://sam/$request_uri;
+    }
+
+    location ~ ^/api/v1/talks/(.*)/vote {
+        proxy_pass http://sam/$request_uri;
+    }
+
+    location ~ ^/api/v1/tracks/(.*)/viewer_count {
+        proxy_pass http://sam/$request_uri;
+    }
+
+    location ~ ^/api/v1/app-data/(.*) {
+        proxy_pass http://sam/$request_uri;
     }
 
 }


### PR DESCRIPTION
local devでSAMを叩くためのnginxのproxy routing追加です。
とりあえず動作確認したければ、cdkとsamをインストールして、dreamkast-functionにてこれを実行してもらえると動きます。

```
EVENTABBR=cndt2022 cdk synth -c config=dev --no-staging && sam local start-api -t cdk.out/stateless-dev.template.json -p 3002 --profile <your_profile> --debug
```

SAMをcontainerで動くようにしてdocker-composeでさっと立ち上げられるようにしたいですが、そこまではまだできていません。
SAMはlocalのport: 3002にで動かして、そこにnginxでつなぎにくるだけの構成です。