### PR TITLE
Workaround to fix number of seet for keynotes

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -406,6 +406,14 @@ https://event.cloudnativedays.jp/#{conference.abbr}/talks/#{id}
     event
   end
 
+  def number_of_seats
+    # Workaround for CNDT2022
+    if [1601, 1603, 1561, 1547, 1516, 1539, 1596, 1582, 1546, 1523, 1600, 1626].include?(id)
+      return 454
+    end
+    self[:number_of_seats]
+  end
+
   def remaining_seats
     number_of_seats - acquired_seats
   end


### PR DESCRIPTION
キーノートの残席がTrackAのみになっていて売り切れているが、実際には他の部屋でパブリックビューイング出来るので、キーノートだけ残席を会場全体の数にするワークアラウンド。

本当はキーノートかどうかをフラグで判断したかったが、キーノートなのにキーノートカテゴリにしていないセッションも多いため苦肉の策でID直指定している。今回のみのワークアラウンドとしたい