### PR TITLE
fix: Extend SLOT_MAP to avoid out of range

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -69,7 +69,7 @@ class Talk < ApplicationRecord
   # validates :end_time, presence: true
   validate :validate_proposal_item_configs, on: :entry_form
 
-  SLOT_MAP = ['1200', '1400', '1500', '1600', '1700', '1800', '1900', '2000']
+  SLOT_MAP = ['1200', '1400', '1500', '1600', '1700', '1800', '1900', '2000', '2100', '2200', '2500']
 
   scope :on_air, -> {
     includes(:video).where(videos: { on_air: 1 })


### PR DESCRIPTION
現在/api/v1/talksをcallすると11/1のプレイベントの夜イベの値が帰ってくるが、SLOT_MAPの値を超過していてfor loopでヒットせず、結果SLOT_MAP自体が返されてしまいjbuilder側の `to_i` でエラーを引き起こしていたので、値を追加しました。

本番は発生しない気がしつつ、夜イベで影響がでないとも限らないので、予防です