### PR TITLE
CNDT2022のアーカイブ表示を一時的に止める

### DIFF
--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -46,8 +46,9 @@
       <% if display_video?(talk) %>
         <% if %w(cndt2020 cndo2021 cicd2021).include?(@conference.abbr) %>
           <%= render 'talks/partial_show/talk_video_block', talk: talk %>
-        <% else %>
+        <% elsif @conference.abbr != 'cndt2022' %>
           <%= render 'talks/partial_show/talk_video_block_videojs', talk: talk %>
+        <% else %>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
セッション終了前の動画が見えてしまっている