### PR TITLE
リード出力のためのrakeタスクを追加

### DIFF
--- a/app/models/audience_count.rb
+++ b/app/models/audience_count.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: audience_counts
+#
+#  id         :bigint           not null, primary key
+#  min        :integer
+#  sub        :string(255)
+#  talk_name  :string(255)
+#  track_name :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  talk_id    :integer
+#
+# Indexes
+#
+#  index_audience_counts_on_talk_id  (talk_id)
+#
+class AudienceCount < ApplicationRecord
+  belongs_to :profile, class_name: 'Profile', foreign_key: 'sub', primary_key: 'sub'
+  belongs_to :talk
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -64,6 +64,8 @@ class Profile < ApplicationRecord
 
   belongs_to_active_hash :company_name_prefix, shortcuts: [:name], class_name: '::FormModels::CompanyNamePrefix'
   belongs_to_active_hash :company_name_suffix, shortcuts: [:name], class_name: '::FormModels::CompanyNameSuffix'
+  belongs_to_active_hash :annual_sales, shortcuts: [:name], class_name: '::FormModels::AnnualSales'
+  belongs_to_active_hash :number_of_employee, shortcuts: [:name], class_name: '::FormModels::NumberOfEmployee'
 
   belongs_to :conference
   has_many :registered_talks
@@ -74,6 +76,8 @@ class Profile < ApplicationRecord
   has_many :orders
   has_many :check_ins
   has_one :public_profile, dependent: :destroy
+  has_one :profile_survey, foreign_key: 'sub', primary_key: 'sub', class_name: 'ProfileSurvey'
+  has_many :audience_counts, foreign_key: 'sub', primary_key: 'sub', class_name: 'AudienceCount'
 
   before_create do
     self.calendar_unique_code = SecureRandom.uuid

--- a/app/models/profile_survey.rb
+++ b/app/models/profile_survey.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: profile_surveys
+#
+#  id         :bigint           not null, primary key
+#  department :string(255)
+#  filled_at  :datetime
+#  generation :string(255)
+#  industry   :string(255)
+#  occupation :string(255)
+#  position   :string(255)
+#  sub        :string(255)
+#  url        :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class ProfileSurvey < ApplicationRecord
+  belongs_to :profile, class_name: 'Profile', foreign_key: 'sub', primary_key: 'sub'
+end

--- a/app/models/registered_talk.rb
+++ b/app/models/registered_talk.rb
@@ -8,6 +8,11 @@
 #  profile_id :integer
 #  talk_id    :integer
 #
+# Indexes
+#
+#  index_registered_talks_on_profile_id  (profile_id)
+#  index_registered_talks_on_talk_id     (talk_id)
+#
 
 class RegisteredTalk < ApplicationRecord
   belongs_to :talk

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -46,6 +46,7 @@ class Talk < ApplicationRecord
 
   has_one :video_registration, dependent: :destroy
   has_one :video, dependent: :destroy
+  has_many :audience_counts
   belongs_to :talk_time, optional: true
   has_many :talks_speakers
   has_many :registered_talks

--- a/db/migrate/20221127144943_create_audience_counts.rb
+++ b/db/migrate/20221127144943_create_audience_counts.rb
@@ -1,0 +1,14 @@
+class CreateAudienceCounts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :audience_counts do |t|
+      t.string :sub
+      t.integer :min
+      t.string :track_name
+      t.integer :talk_id
+      t.string :talk_name
+
+      t.timestamps
+    end
+    add_index :audience_counts, :talk_id
+  end
+end

--- a/db/migrate/20221127151200_create_profile_surveys.rb
+++ b/db/migrate/20221127151200_create_profile_surveys.rb
@@ -1,0 +1,16 @@
+class CreateProfileSurveys < ActiveRecord::Migration[7.0]
+  def change
+    create_table :profile_surveys do |t|
+      t.string :sub
+      t.datetime :filled_at
+      t.string :url
+      t.string :generation
+      t.string :industry
+      t.string :department
+      t.string :occupation
+      t.string :position
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221130125533_add_index_to_registered_talks.rb
+++ b/db/migrate/20221130125533_add_index_to_registered_talks.rb
@@ -1,0 +1,6 @@
+class AddIndexToRegisteredTalks < ActiveRecord::Migration[7.0]
+  def change
+    add_index :registered_talks, :profile_id
+    add_index :registered_talks, :talk_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_18_045613) do
     t.index ["conference_id"], name: "index_announcements_on_conference_id"
   end
 
+  create_table "audience_counts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "sub"
+    t.integer "min"
+    t.string "track_name"
+    t.integer "talk_id"
+    t.string "talk_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["talk_id"], name: "index_audience_counts_on_talk_id"
+  end
+
   create_table "booths", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.bigint "sponsor_id", null: false
@@ -215,6 +226,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_18_045613) do
     t.index ["ticket_id"], name: "index_orders_tickets_on_ticket_id"
   end
 
+  create_table "profile_surveys", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "sub"
+    t.datetime "filled_at"
+    t.string "url"
+    t.string "generation"
+    t.string "industry"
+    t.string "department"
+    t.string "occupation"
+    t.string "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "sub"
     t.string "email"
@@ -294,6 +318,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_18_045613) do
     t.integer "talk_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_registered_talks_on_profile_id"
+    t.index ["talk_id"], name: "index_registered_talks_on_talk_id"
   end
 
   create_table "rooms", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/lib/tasks/generate_lead_cicd2023.rake
+++ b/lib/tasks/generate_lead_cicd2023.rake
@@ -1,0 +1,85 @@
+namespace :util do
+  desc 'generate_lead_cicd2023'
+  task generate_lead_cicd2023: :environment do
+    ActiveRecord::Base.logger = Logger.new($stdout)
+    Rails.logger.level = Logger::DEBUG
+
+    conference = Conference.find_by(abbr: 'cicd2023')
+
+    attr = [
+      'セッション登録フラグ',
+      'セッション視聴フラグ',
+      '現地チェックイン',
+      '姓',
+      '名',
+      'セイ',
+      'メイ',
+      '前株',
+      '会社名/所属団体名',
+      '後株',
+      '所属部署名',
+      '郵便番号',
+      '都道府県',
+      '勤務先住所1（都道府県以下）',
+      '勤務先住所2（ビル名）',
+      '電話番号',
+      'FAX番号',
+      'メールアドレス（PC）',
+      '従業員数',
+      '年商規模',
+      '業種',
+      '所属部署',
+      '職種',
+      '役職区分'
+    ]
+
+    conference.sponsors.each do |s|
+      talk_id = s.talks[0]&.id || 0
+      event_id = conference.id
+      sponsor_types = s.sponsor_types.map(&:name)
+
+      target_sponsor_type = sponsor_types & ['Session']
+      #target_sponsor_type = sponsor_types & ['Platinum']
+
+      threshold = ['f5', 'techmatrix', 'acquia', 'freee'].include?(s.abbr) ? 1 : 5
+
+      if target_sponsor_type.any?
+        generated_csv = CSV.generate do |csv|
+          csv << attr
+          Profile.where(conference_id: event_id).includes(:registered_talks, :audience_counts).each do |profile|
+            line = [
+              profile.registered_talks.where(talk_id:).exists? ? 1 : 0,
+              profile.audience_counts.where("talk_id = #{talk_id} AND  min > #{threshold}").exists? ? 1 : 0,
+              profile.check_ins.find_by(ticket_id: 'f4d09974-c6af-4fab-bb60-d394058e9eb8').present? ? 1 : 0,
+              profile.last_name,
+              profile.first_name,
+              profile.last_name_kana,
+              profile.first_name_kana,
+              profile.company_name_prefix&.name,
+              profile.company_name,
+              profile.company_name_suffix&.name,
+              profile.department,
+              profile.company_postal_code,
+              profile.company_address_level1,
+              profile.company_address_level2 + profile.company_address_line1,
+              profile.company_address_line2,
+              profile.company_tel,
+              profile.company_fax,
+              profile.company_email,
+              profile.number_of_employee.name,
+              profile.annual_sales.name,
+              profile.industry_name,
+              profile.department,
+              profile.occupation_name,
+              profile.position,
+            ]
+            csv << line
+          end
+        end
+        File.open("./tmp/csv/#{target_sponsor_type[0]}_#{s.abbr}_#{talk_id}.csv", 'w', encoding: 'UTF-8') do |file|
+          file.write(generated_csv)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/generate_lead_cndf2023.rake
+++ b/lib/tasks/generate_lead_cndf2023.rake
@@ -1,0 +1,91 @@
+namespace :util do
+  desc 'generate_lead_cndf2023'
+  task generate_lead_cndf2023: :environment do
+    ActiveRecord::Base.logger = Logger.new($stdout)
+    Rails.logger.level = Logger::DEBUG
+
+    conference = Conference.find_by(abbr: 'cndf2023')
+
+    attr = [
+      'イベント参加',
+      'セッション登録フラグ',
+      'セッション視聴フラグ',
+      '現地チェックイン',
+      '姓',
+      '名',
+      'セイ',
+      'メイ',
+      '前株',
+      '会社名/所属団体名',
+      '後株',
+      '所属部署名',
+      '郵便番号',
+      '都道府県',
+      '勤務先住所1（都道府県以下）',
+      '勤務先住所2（ビル名）',
+      '電話番号',
+      'FAX番号',
+      'メールアドレス（PC）',
+      '従業員数',
+      '年商規模',
+      '業種',
+      '所属部署',
+      '職種'
+    ]
+
+    conference.sponsors.each do |s|
+      talk_id = s.talks[0]&.id || 0
+      event_id = conference.id
+      sponsor_types = s.sponsor_types.map(&:name)
+
+      target_sponsor_type = sponsor_types & ['Diamond', 'Platinum']
+      #target_sponsor_type = sponsor_types & ['Platinum']
+
+      #threshold = ['f5', 'techmatrix', 'acquia', 'freee'].include?(s.abbr) ? 1 : 5
+      threshold = 1
+
+      if target_sponsor_type.any?
+        generated_csv = CSV.generate do |csv|
+          csv << attr
+          Profile.where(conference_id: event_id).includes(:registered_talks, :audience_counts).each do |profile|
+            flagged = false
+            if profile.registered_talks.where(talk_id:).exists? || profile.audience_counts.where("talk_id = #{talk_id} AND  min > #{threshold}").exists? || profile.check_ins.find_by(ticket_id: 'a7a3e5d5-0d8e-1c29-1c29-7004affe194a').present?
+              flagged = true
+            end
+            line = [
+              #profile.audience_counts.where("talk_id = #{talk_id} AND  min > #{threshold}").exists? || profile.check_ins.find_by(ticket_id: 'a7a3e5d5-0d8e-1c29-1c29-7004affe194a').present? ? 1 : 0,
+              profile.audience_counts.where("min > #{threshold}").exists? || profile.check_ins.find_by(ticket_id: 'a7a3e5d5-0d8e-1c29-1c29-7004affe194a').present? ? 1 : 0,
+              profile.registered_talks.where(talk_id:).exists? ? 1 : 0,
+              profile.audience_counts.where("talk_id = #{talk_id} AND  min > #{threshold}").exists? ? 1 : 0,
+              profile.check_ins.find_by(ticket_id: 'a7a3e5d5-0d8e-1c29-1c29-7004affe194a').present? ? 1 : 0,
+              profile.last_name,
+              profile.first_name,
+              profile.last_name_kana,
+              profile.first_name_kana,
+              profile.company_name_prefix&.name,
+              profile.company_name,
+              profile.company_name_suffix&.name,
+              profile.department,
+              profile.company_postal_code,
+              profile.company_address_level1,
+              profile.company_address_level2 + profile.company_address_line1,
+              profile.company_address_line2,
+              profile.company_tel,
+              profile.company_fax,
+              profile.company_email,
+              profile.number_of_employee.name,
+              profile.annual_sales.name,
+              profile.industry_name,
+              profile.department,
+              profile.position
+            ]
+            csv << line if s.abbr != 'アクイアジャパン' || flagged
+          end
+        end
+        File.open("./tmp/csv/#{target_sponsor_type[0]}_#{s.abbr}_#{talk_id}.csv", 'w', encoding: 'UTF-8') do |file|
+          file.write(generated_csv)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/generate_lead_cndt2022.rake
+++ b/lib/tasks/generate_lead_cndt2022.rake
@@ -1,0 +1,103 @@
+namespace :util do
+  desc 'generate_lead_cndt2022'
+  task generate_lead_cndt2022: :environment do
+    ActiveRecord::Base.logger = Logger.new($stdout)
+    Rails.logger.level = Logger::DEBUG
+
+    conference = Conference.find_by(abbr: 'cndt2022')
+
+    attr = [
+      'セッション登録フラグ',
+      'セッション視聴フラグ',
+      '現地チェックイン',
+      '姓',
+      '名',
+      'セイ',
+      'メイ',
+      '前株',
+      '会社名/所属団体名',
+      '後株',
+      '所属部署名',
+      '郵便番号',
+      '都道府県',
+      '勤務先住所1（都道府県以下）',
+      '勤務先住所2（ビル名）',
+      '電話番号',
+      'FAX番号',
+      'メールアドレス（PC）',
+      '従業員数',
+      '年商規模',
+      '業種',
+      '所属部署',
+      '職種',
+      '役職区分'
+    ]
+
+    conference.sponsors.each do |s|
+      talk_id = s.talks[0]&.id || 0
+      event_id = conference.id
+      sponsor_types = s.sponsor_types.map(&:name)
+
+      # target_sponsor_type = sponsor_types & ['Diamond','Platinum', 'Gold', 'Silver']
+      target_sponsor_type = sponsor_types & ['Platinum']
+
+      threshold = ['f5', 'techmatrix', 'acquia', 'freee'].include?(s.abbr) ? 1 : 5
+
+      attr += ['メールを希望', '電話を希望'] if ['ibm', 'redhat'].include?(s.abbr)
+
+      if target_sponsor_type.any?
+        generated_csv = CSV.generate do |csv|
+          csv << attr
+          Profile.includes(:profile_survey).where(conference_id: event_id).includes(:registered_talks, :audience_counts).each do |profile|
+            flagged = false
+            if target_sponsor_type[0] == 'Diamond' ||
+               (target_sponsor_type[0] == 'Platinum' && (profile.registered_talks.where(talk_id:).exists? || profile.audience_counts.where("talk_id = #{talk_id} AND  min > #{threshold}").exists?)) ||
+               (target_sponsor_type[0] == 'Platinum' && (profile.registered_talks.where(talk_id:).exists? || profile.audience_counts.where("talk_id = #{talk_id} AND  min > #{threshold}").exists?))
+              flagged = true
+            end
+            line = [
+              profile.registered_talks.where(talk_id:).exists? ? 1 : 0,
+              profile.audience_counts.where("talk_id = #{talk_id} AND  min > #{threshold}").exists? ? 1 : 0,
+              profile.check_ins.find_by(ticket_id: '7b02e975-8418-4b40-a01d-f8011cc705e3').present? ? 1 : 0,
+              profile.last_name,
+              profile.first_name,
+              profile.last_name_kana,
+              profile.first_name_kana,
+              profile.company_name_prefix&.name,
+              profile.company_name,
+              profile.company_name_suffix&.name,
+              profile.department,
+              profile.company_postal_code,
+              profile.company_address_level1,
+              profile.company_address_level2 + profile.company_address_line1,
+              profile.company_address_line2,
+              profile.company_tel,
+              profile.company_fax,
+              profile.company_email,
+              profile.number_of_employee.name,
+              profile.annual_sales.name,
+              profile.profile_survey&.industry,
+              profile.profile_survey&.department,
+              profile.profile_survey&.occupation,
+              profile.profile_survey&.position
+            ]
+            if s.abbr == 'ibm'
+              line.append(profile.agreements.where(form_item_id: 6)&.present? ? 1 : 0)
+              line.append(profile.agreements.where(form_item_id: 7)&.present? ? 1 : 0)
+            end
+
+            if s.abbr == 'redhat'
+              line.append(profile.agreements.where(form_item_id: 8)&.present? ? 1 : 0)
+              line.append(profile.agreements.where(form_item_id: 9)&.present? ? 1 : 0)
+            end
+
+            csv << line if flagged
+          end
+        end
+        File.open("./tmp/csv/#{target_sponsor_type[0]}_#{s.abbr}_#{talk_id}.csv", 'w', encoding: 'UTF-8') do |file|
+          file.write(generated_csv)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/audience_counts.rb
+++ b/spec/factories/audience_counts.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: audience_counts
+#
+#  id         :bigint           not null, primary key
+#  min        :integer
+#  sub        :string(255)
+#  talk_name  :string(255)
+#  track_name :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  talk_id    :integer
+#
+# Indexes
+#
+#  index_audience_counts_on_talk_id  (talk_id)
+#
+FactoryBot.define do
+  factory :audience_count do
+    sub { 'MyString' }
+    min { 1 }
+    track_name { 'MyString' }
+    talk_id { 1 }
+    talk_name { 'MyString' }
+  end
+end

--- a/spec/factories/profile_surveys.rb
+++ b/spec/factories/profile_surveys.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: profile_surveys
+#
+#  id         :bigint           not null, primary key
+#  department :string(255)
+#  filled_at  :datetime
+#  generation :string(255)
+#  industry   :string(255)
+#  occupation :string(255)
+#  position   :string(255)
+#  sub        :string(255)
+#  url        :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :profile_survey do
+    sub { 'MyString' }
+    filled_at { '2022-11-28 00:12:00' }
+    url { 'MyString' }
+    generation { 'MyString' }
+    industry { 'MyString' }
+    department { 'MyString' }
+    occupation { 'MyString' }
+    position { 'MyString' }
+  end
+end

--- a/spec/factories/registered_talks.rb
+++ b/spec/factories/registered_talks.rb
@@ -8,6 +8,11 @@
 #  profile_id :integer
 #  talk_id    :integer
 #
+# Indexes
+#
+#  index_registered_talks_on_profile_id  (profile_id)
+#  index_registered_talks_on_talk_id     (talk_id)
+#
 
 FactoryBot.define do
   factory :registered_talk, class: RegisteredTalk

--- a/spec/models/audience_count_spec.rb
+++ b/spec/models/audience_count_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: audience_counts
+#
+#  id         :bigint           not null, primary key
+#  min        :integer
+#  sub        :string(255)
+#  talk_name  :string(255)
+#  track_name :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  talk_id    :integer
+#
+# Indexes
+#
+#  index_audience_counts_on_talk_id  (talk_id)
+#
+require 'rails_helper'
+
+RSpec.describe(AudienceCount, type: :model) do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/profile_survey_spec.rb
+++ b/spec/models/profile_survey_spec.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: profile_surveys
+#
+#  id         :bigint           not null, primary key
+#  department :string(255)
+#  filled_at  :datetime
+#  generation :string(255)
+#  industry   :string(255)
+#  occupation :string(255)
+#  position   :string(255)
+#  sub        :string(255)
+#  url        :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe(ProfileSurvey, type: :model) do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/registered_talk_spec.rb
+++ b/spec/models/registered_talk_spec.rb
@@ -8,6 +8,11 @@
 #  profile_id :integer
 #  talk_id    :integer
 #
+# Indexes
+#
+#  index_registered_talks_on_profile_id  (profile_id)
+#  index_registered_talks_on_talk_id     (talk_id)
+#
 
 require 'rails_helper'
 


### PR DESCRIPTION
リードを出力するためのタスクを追加。
KarteからエクスポートしたAudience CountとProfile SurveyをDBにimportして使う仕組み。

リード出力は各イベントごとに1ショットしかやらない&ひたすらループで出力するのでDBにものすごく負担がかかる･･･ので、Production環境ではは使わず、ダンプしたDBをローカルにimportして出力する想定。なのでAdmin UIの実装は無し

将来的にDkでやるべきかは要相談