### PR TITLE
カンファレンスの状態改善その1

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -10,6 +10,7 @@
 #  cfp_result_visible         :boolean          default(FALSE)
 #  coc                        :text(65535)
 #  committee_name             :string(255)      default("CloudNative Days Committee"), not null
+#  conference_status          :string(255)      default(NULL)
 #  copyright                  :string(255)
 #  name                       :string(255)
 #  privacy_policy             :text(65535)
@@ -28,7 +29,18 @@
 #
 
 class Conference < ApplicationRecord
+  STATUS_REGISTERED = 'registered'.freeze
+  STATUS_OPENED = 'opened'.freeze
+  STATUS_CLOSED = 'closed'.freeze
+  STATUS_ARCHIVED = 'archived'.freeze
+
   enum status: { registered: 0, opened: 1, closed: 2, archived: 3 }
+  enum conference_status: {
+    tmp_registered: STATUS_REGISTERED,
+    tmp_opened: STATUS_OPENED,
+    tmp_closed: STATUS_CLOSED,
+    tmp_archived: STATUS_ARCHIVED
+  }
   enum speaker_entry: { speaker_entry_disabled: 0, speaker_entry_enabled: 1 }
   enum attendee_entry: { attendee_entry_disabled: 0, attendee_entry_enabled: 1 }
   enum show_timetable: { show_timetable_disabled: 0, show_timetable_enabled: 1 }

--- a/db/migrate/20221219102416_add_conference_status_to_conferences.rb
+++ b/db/migrate/20221219102416_add_conference_status_to_conferences.rb
@@ -1,0 +1,21 @@
+class AddConferenceStatusToConferences < ActiveRecord::Migration[7.0]
+  def up
+    add_column :conferences, :conference_status, :string, default: ""
+    Conference.all.each do |conference|
+      case conference.status
+      when Conference::STATUS_REGISTERED
+        conference.update!(conference_status: Conference::STATUS_REGISTERED)
+      when Conference::STATUS_OPENED
+        conference.update!(conference_status: Conference::STATUS_OPENED)
+      when Conference::STATUS_CLOSED
+        conference.update!(conference_status: Conference::STATUS_CLOSED)
+      when Conference::STATUS_ARCHIVED
+        conference.update!(conference_status: Conference::STATUS_ARCHIVED)
+      end
+    end
+  end
+
+  def down
+    remove_column :conferences, :conference_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_05_135248) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_19_102416) do
   create_table "access_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "sub"
@@ -132,6 +132,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_135248) do
     t.boolean "show_sponsors", default: false
     t.string "brief"
     t.string "committee_name", default: "CloudNative Days Committee", null: false
+    t.string "conference_status", default: ""
     t.index ["status"], name: "index_conferences_on_status"
   end
 

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -10,6 +10,7 @@
 #  cfp_result_visible         :boolean          default(FALSE)
 #  coc                        :text(65535)
 #  committee_name             :string(255)      default("CloudNative Days Committee"), not null
+#  conference_status          :string(255)      default(NULL)
 #  copyright                  :string(255)
 #  name                       :string(255)
 #  privacy_policy             :text(65535)

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -10,6 +10,7 @@
 #  cfp_result_visible         :boolean          default(FALSE)
 #  coc                        :text(65535)
 #  committee_name             :string(255)      default("CloudNative Days Committee"), not null
+#  conference_status          :string(255)      default(NULL)
 #  copyright                  :string(255)
 #  name                       :string(255)
 #  privacy_policy             :text(65535)


### PR DESCRIPTION
statusは数値で扱っているが、新しい状態を追加するときに数値の順序を考慮すると面倒なので、文字列で扱えるようにする。
まずは新しいカラムを追加して、既存のConferenceについてstatusと値を揃える。
このPRの変更では動作の変更はない。

この後、別PRで新しいカラムを使うように変更する予定。

https://github.com/cloudnativedaysjp/dreamkast/discussions/1368