### PR TITLE
カンファレンスの状態改善その2

### DIFF
--- a/app/forms/conference_form.rb
+++ b/app/forms/conference_form.rb
@@ -117,7 +117,7 @@ class ConferenceForm
 
   def default_attributes
     {
-      status: conference.status,
+      status: conference.conference_status,
       cfp_result_visible: conference.cfp_result_visible,
       speaker_entry: conference.speaker_entry,
       attendee_entry: conference.attendee_entry,

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -34,12 +34,11 @@ class Conference < ApplicationRecord
   STATUS_CLOSED = 'closed'.freeze
   STATUS_ARCHIVED = 'archived'.freeze
 
-  enum status: { registered: 0, opened: 1, closed: 2, archived: 3 }
   enum conference_status: {
-    tmp_registered: STATUS_REGISTERED,
-    tmp_opened: STATUS_OPENED,
-    tmp_closed: STATUS_CLOSED,
-    tmp_archived: STATUS_ARCHIVED
+    registered: STATUS_REGISTERED,
+    opened: STATUS_OPENED,
+    closed: STATUS_CLOSED,
+    archived: STATUS_ARCHIVED
   }
   enum speaker_entry: { speaker_entry_disabled: 0, speaker_entry_enabled: 1 }
   enum attendee_entry: { attendee_entry_disabled: 0, attendee_entry_enabled: 1 }

--- a/app/views/api/v1/conferences/index.json.jbuilder
+++ b/app/views/api/v1/conferences/index.json.jbuilder
@@ -2,7 +2,7 @@ json.array!(@conferences) do |conference|
   json.id(conference.id)
   json.name(conference.name)
   json.abbr(conference.abbr)
-  json.status(conference.status)
+  json.status(conference.conference_status)
   json.theme(conference.theme)
   json.about(conference.about)
   json.privacy_policy(conference.privacy_policy)

--- a/app/views/api/v1/conferences/show.json.jbuilder
+++ b/app/views/api/v1/conferences/show.json.jbuilder
@@ -1,7 +1,7 @@
 json.id(@conference.id)
 json.name(@conference.name)
 json.abbr(@conference.abbr)
-json.status(@conference.status)
+json.status(@conference.conference_status)
 json.theme(@conference.theme)
 json.about(@conference.about)
 json.privacy_policy(@conference.privacy_policy)

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
     privacy_policy { 'This is Privacy Policy' }
     privacy_policy_for_speaker { 'This is Privacy Policy for speaker' }
     status { 0 }
+    conference_status { Conference::StATUS_REGISTERED }
     speaker_entry { 1 }
     attendee_entry { 1 }
     show_timetable { 1 }
@@ -52,20 +53,24 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 
     trait :registered do
       status { 0 }
+      conference_status { Conference::STATUS_REGISTERED }
     end
 
     trait :opened do
       status { 1 }
+      conference_status { Conference::STATUS_OPENED }
       speaker_entry { 0 } # Generally, speaker_entry should be disabled while conference is opened
     end
 
     trait :closed do
       status { 2 }
+      conference_status { Conference::STATUS_CLOSED }
       speaker_entry { 0 }
     end
 
     trait :archived do
       status { 3 }
+      conference_status { Conference::STATUS_ARCHIVED }
       speaker_entry { 0 }
     end
 
@@ -108,6 +113,7 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
     privacy_policy { 'This is Privacy Policy' }
     privacy_policy_for_speaker { 'This is Privacy Policy for speaker' }
     status { 2 }
+    conference_status { Conference::SATUS_CLOSED }
     speaker_entry { 1 }
     attendee_entry { 1 }
     show_timetable { 1 }
@@ -140,6 +146,7 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
     name { 'One Day Conference' }
     abbr { 'oneday' }
     status { 2 }
+    conference_status { Conference::STATUS_CLOSED }
     speaker_entry { 1 }
     attendee_entry { 1 }
     show_timetable { 1 }
@@ -154,6 +161,7 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
     name { 'Two Day Conference' }
     abbr { 'twoday' }
     status { 2 }
+    conference_status { Conference::STATUS_CLOSED }
     speaker_entry { 1 }
     attendee_entry { 1 }
     show_timetable { 1 }
@@ -174,6 +182,7 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
     privacy_policy { 'This is Privacy Policy' }
     privacy_policy_for_speaker { 'This is Privacy Policy for speaker' }
     status { 2 }
+    conference_status { Conference::STATUS_CLOSED }
     speaker_entry { 1 }
     attendee_entry { 1 }
     show_timetable { 1 }

--- a/spec/requests/timetable_spec.rb
+++ b/spec/requests/timetable_spec.rb
@@ -112,7 +112,7 @@ describe TimetableController, type: :request do
       end
 
       context 'when conference status is archived' do
-        before { Conference.find_by(abbr: 'cndo2021').update!(status: 3) }
+        before { Conference.find_by(abbr: 'cndo2021').update!(conference_status: Conference::STATUS_ARCHIVED) }
         it 'access to /cndo2021/timetables' do
           get '/cndo2021/timetables'
           expect(response).to(be_successful)


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/1719 の後にマージ＆リリースする。

https://github.com/cloudnativedaysjp/dreamkast/pull/1719 で追加した `conference_status` カラムを使うように全体を変更する。

このPRの後、statusカラムを削除する。

https://github.com/cloudnativedaysjp/dreamkast/discussions/1368
