### PR TITLE
Improve experience for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ vendor
 .gem_rbs_collection
 
 package-lock.json
+
+localstack

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM ruby:3.1.3-slim
+WORKDIR /app
+RUN apt-get update && apt-get -y install libmariadb3 libvips42 shared-mime-info git vim curl wget

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SENTRY_DSN=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=ap-northeast-1
-DREAMKAST_API_ADDR="http://localhost:3000"
+DREAMKAST_API_ADDR="http://localhost:8080"
 S3_BUCKET=dreamkast-test-bucket
 S3_REGION=
 MYSQL_HOST=db
@@ -59,7 +59,7 @@ docker compose -f compose-dev.yaml up -d
 
 Wait until the dreamkast app to start (almost 3 minutes)
 
-After that, access to `http://localhost:3000` in your browser.
+After that, access to `http://localhost:8080` in your browser.
 
 ### Using local environment
 

--- a/README.md
+++ b/README.md
@@ -15,29 +15,53 @@ See [Docs](docs/README.md)
 - Docker Compose
 - Auth0 application keys
 
-## How to create auth0 applications keys
+## How to setup dev environment
 
-See [Auth0 document](https://auth0.com/docs/quickstart/webapp/rails/01-login)
+### Using docker compose(quickest)
 
-After create configuration, create `.env` file in the top-level directory.
-
+1. Retrieve ECR credential
 ```
-AUTH0_CLIENT_ID=FVYbe7dsf1fowelsdlkdsfLwofArfNUznaeku
-AUTH0_CLIENT_SECRET=jBeB2Jd4sdfsdfdgetwarzOXYsdEyasdfq3wer3r9wglkj129UoF_XJuD
-AUTH0_DOMAIN=yourdomain.auth0.com
-```
-
-Docker compose read `.env` file automatically.
-
-If you are running a rails server without Docker compose, you need to set environment variables like this.
-
-```
-export AUTH0_CLIENT_ID=FVYbe7dsf1fowelsdlkdsfLwofArfNUznaeku
-export AUTH0_CLIENT_SECRET=jBeB2Jd4sdfsdfdgetwarzOXYsdEyasdfq3wer3r9wglkj129UoF_XJuD
-export AUTH0_DOMAIN=yourdomain.auth0.com
+# Login AWS with SSO to retrieve ECR credential. If you are not assigned to GAFA account or you don't know how to use AWS SSO, please ask Dreamkast team.
+aws configure sso
+aws ecr get-login-password --region ap-northeast-1 --profile dreamkast-core-XXXXX | docker login --username AWS --password-stdin https://607167088920.dkr.ecr.ap-northeast-1.amazonaws.com
 ```
 
-## How to setup environment
+2. Create `.env`. This is an example.
+```
+tee .env <<EOF
+AUTH0_CLIENT_ID=
+AUTH0_CLIENT_SECRET=
+AUTH0_DOMAIN=
+SENTRY_DSN=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=ap-northeast-1
+DREAMKAST_API_ADDR="http://localhost:3000"
+S3_BUCKET=dreamkast-test-bucket
+S3_REGION=
+MYSQL_HOST=db
+MYSQL_USER=root
+MYSQL_PASSWORD=root
+MYSQL_DATABASE=dreamkast
+REDIS_URL=redis://redis:6379
+RAILS_MASTER_KEY=
+SQS_FIFO_QUEUE_URL=http://localstack:4566/000000000000/default
+EOF
+```
+
+You need to ask Dreamkast team to get full-filled file.
+
+3. docker compose up
+
+```
+docker compose -f compose-dev.yaml up -d
+```
+
+Wait until the dreamkast app to start (almost 3 minutes)
+
+After that, access to `http://localhost:3000` in your browser.
+
+### Using local environment
 
 This repository works with
 
@@ -102,12 +126,17 @@ Run the application
 $ ./entrypoint.sh
 ```
 
-## For local development
-
 Run Webpack dev server in case you want to edit JavaScript.
 
 ```
 $ ./bin/webpack-dev-server
+```
+
+## DB migration and to add seed data
+
+```
+$ bundle exec rails db:migrate
+$ bundle exec rails db:seed
 ```
 
 ## Ruby Type
@@ -128,19 +157,6 @@ If you want to generate RBS for your application code, you can use `rbs prototyp
 
 ```
 $ rbs prototype rb ./app/models/access_log.rb > sig/app/models/access_log.rbs
-```
-
-## DB migration and to add seed data
-
-```
-$ bundle exec rails db:migrate
-$ bundle exec rails db:seed
-```
-
-## Mock SQS for local chat development
-
-```
-aws --endpoint-url http://localhost:9324 sqs create-queue --queue-name chat
 ```
 
 ## How to use REST API for VideoRegistration
@@ -210,4 +226,3 @@ curl -X PUT -H "Authorization: Bearer $TOKEN" https://$DREAMKAST_DOMAIN/api/v1/t
 git config pre-commit.ruby "bundle exec ruby"
 git config pre-commit.checks "[rubocop]"
 ```
-

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -8,7 +8,7 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && yarn install --check-files && bundle exec rake webpacker:compile && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
+    entrypoint: /bin/sh -c "bundle install && docker/wait-for-it.sh db:3306 --timeout=600 && yarn install --check-files && bundle exec rake webpacker:compile && bundle exec rails db:migrate && bundle exec rails db:seed && (./entrypoint.sh & ./bin/webpack-dev-server)"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development
@@ -40,40 +40,25 @@ services:
     depends_on:
       - db
       - localstack
-  dev:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-      args:
-        - RAILS_ENV=development
-    volumes:
-      - .:/app
-    entrypoint: /bin/sh -c "sleep infinity"
-    tty: true
-    stdin_open: true
-    tmpfs:
-      - /app/tmp
-    environment:
-      <<: *dkenv
-  webpack-dev-server:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        - RAILS_ENV=development
-    volumes:
-      - .:/app
-    entrypoint: /bin/sh -c "yarn install --check-files && bundle exec rake webpacker:compile && ./bin/webpack-dev-server"
-    tty: true
-    stdin_open: true
-    environment:
-      <<: *dkenv
-    tmpfs:
-      - /app/tmp
-    ports:
-      - "3035:3035"
-    depends_on:
-      - app
+  # webpack-dev-server:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #     args:
+  #       - RAILS_ENV=development
+  #   volumes:
+  #     - .:/app
+  #   entrypoint: /bin/sh -c "bundle install && yarn install --check-files && bundle exec rake webpacker:compile && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh & ./bin/webpack-dev-server"
+  #   environment:
+  #     <<: *dkenv
+  #   tty: true
+  #   stdin_open: true
+  #   tmpfs:
+  #     - /app/tmp
+  #   ports:
+  #     - "3035:3035"
+  #   depends_on:
+  #     - app
   fifo-worker:
     build: .
     entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue fifo"

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -6,7 +6,9 @@ services:
       dockerfile: Dockerfile
       args:
         - RAILS_ENV=development
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed_fu && ./entrypoint.sh"
+    volumes:
+      - .:/app
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh && ./bin/webpack-dev-server"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -8,7 +8,8 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh && ./bin/webpack-dev-server"
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600"
+    command: /bin/sh -c "bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,39 +1,5 @@
 version: "3.8"
 services:
-  dev:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-      args:
-        - RAILS_ENV=development
-    volumes:
-      - .:/app
-    entrypoint: /bin/sh -c "sleep infinity"
-    tty: true
-    stdin_open: true
-    tmpfs:
-      - /app/tmp
-    environment:
-      <<: *dkenv
-  webpack-dev-server:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        - RAILS_ENV=development
-    volumes:
-      - .:/app
-    entrypoint: /bin/sh -c "yarn install --check-files && bundle exec rake webpacker:compile && ./bin/webpack-dev-server"
-    tty: true
-    stdin_open: true
-    environment:
-      <<: *dkenv
-    tmpfs:
-      - /app/tmp
-    ports:
-      - "3035:3035"
-    depends_on:
-      - app
   app:
     build:
       context: .
@@ -74,6 +40,40 @@ services:
     depends_on:
       - db
       - localstack
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        - RAILS_ENV=development
+    volumes:
+      - .:/app
+    entrypoint: /bin/sh -c "sleep infinity"
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /app/tmp
+    environment:
+      <<: *dkenv
+  webpack-dev-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - RAILS_ENV=development
+    volumes:
+      - .:/app
+    entrypoint: /bin/sh -c "yarn install --check-files && bundle exec rake webpacker:compile && ./bin/webpack-dev-server"
+    tty: true
+    stdin_open: true
+    environment:
+      <<: *dkenv
+    tmpfs:
+      - /app/tmp
+    ports:
+      - "3035:3035"
+    depends_on:
+      - app
   fifo-worker:
     build: .
     entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue fifo"

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -8,8 +8,7 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600"
-    command: /bin/sh -c "bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -3,7 +3,6 @@ services:
   dev:
     build:
       context: .
-      target: dev
       dockerfile: Dockerfile.dev
       args:
         - RAILS_ENV=development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -40,28 +40,6 @@ services:
     depends_on:
       - db
       - localstack
-<<<<<<< HEAD
-  # webpack-dev-server:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile
-  #     args:
-  #       - RAILS_ENV=development
-  #   volumes:
-  #     - .:/app
-  #   entrypoint: /bin/sh -c "bundle install && yarn install --check-files && bundle exec rake webpacker:compile && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh & ./bin/webpack-dev-server"
-  #   environment:
-  #     <<: *dkenv
-  #   tty: true
-  #   stdin_open: true
-  #   tmpfs:
-  #     - /app/tmp
-  #   ports:
-  #     - "3035:3035"
-  #   depends_on:
-  #     - app
-=======
->>>>>>> 2199f4a1318c544ff462751df75e2e740ac9f2ff
   fifo-worker:
     build: .
     entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue fifo"
@@ -113,17 +91,10 @@ services:
     environment:
       - SERVICES=sqs
       - DEFAULT_REGION=ap-northeast-1
-<<<<<<< HEAD
-      - DATA_DIR=/tmp/localstack/data
-    volumes:
-      - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
-      - ./localstack:/tmp/localstack
-=======
       - DATA_DIR=/var/lib/localstack/data
     volumes:
       - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
       - ./localstack:/var/lib/localstack
->>>>>>> 2199f4a1318c544ff462751df75e2e740ac9f2ff
     ports:
       - 4566:4566
     healthcheck:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -8,7 +8,7 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh && ./bin/webpack-dev-server"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -40,6 +40,7 @@ services:
     depends_on:
       - db
       - localstack
+<<<<<<< HEAD
   # webpack-dev-server:
   #   build:
   #     context: .
@@ -59,6 +60,8 @@ services:
   #     - "3035:3035"
   #   depends_on:
   #     - app
+=======
+>>>>>>> 2199f4a1318c544ff462751df75e2e740ac9f2ff
   fifo-worker:
     build: .
     entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue fifo"
@@ -110,10 +113,17 @@ services:
     environment:
       - SERVICES=sqs
       - DEFAULT_REGION=ap-northeast-1
+<<<<<<< HEAD
       - DATA_DIR=/tmp/localstack/data
     volumes:
       - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
       - ./localstack:/tmp/localstack
+=======
+      - DATA_DIR=/var/lib/localstack/data
+    volumes:
+      - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
+      - ./localstack:/var/lib/localstack
+>>>>>>> 2199f4a1318c544ff462751df75e2e740ac9f2ff
     ports:
       - 4566:4566
     healthcheck:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -3,12 +3,13 @@ services:
   dev:
     build:
       context: .
-      dockerfile: Dockerfile
+      target: dev
+      dockerfile: Dockerfile.dev
       args:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "sleep 1"
+    entrypoint: /bin/sh -c "sleep infinity"
     tty: true
     stdin_open: true
     tmpfs:
@@ -23,7 +24,7 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "./bin/webpack-dev-server"
+    entrypoint: /bin/sh -c "yarn install --check-files && bundle exec rake webpacker:compile && ./bin/webpack-dev-server"
     tty: true
     stdin_open: true
     tmpfs:

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -13,8 +13,8 @@ services:
     stdin_open: true
     tmpfs:
       - /app/tmp
-    depends_on:
-      - app
+    environment:
+      <<: *dkenv
   webpack-dev-server:
     build:
       context: .
@@ -26,6 +26,8 @@ services:
     entrypoint: /bin/sh -c "yarn install --check-files && bundle exec rake webpacker:compile && ./bin/webpack-dev-server"
     tty: true
     stdin_open: true
+    environment:
+      <<: *dkenv
     tmpfs:
       - /app/tmp
     ports:
@@ -40,7 +42,7 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 &&  bundle exec rake webpacker:compile && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -8,7 +8,7 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 &&  bundle exec rake webpacker:compile && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && yarn install --check-files && bundle exec rake webpacker:compile && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,5 +1,37 @@
 version: "3.8"
 services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - RAILS_ENV=development
+    volumes:
+      - .:/app
+    entrypoint: /bin/sh -c "sleep 1"
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /app/tmp
+    depends_on:
+      - app
+  webpack-dev-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - RAILS_ENV=development
+    volumes:
+      - .:/app
+    entrypoint: /bin/sh -c "./bin/webpack-dev-server"
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /app/tmp
+    ports:
+      - "3035:3035"
+    depends_on:
+      - app
   app:
     build:
       context: .
@@ -8,7 +40,7 @@ services:
         - RAILS_ENV=development
     volumes:
       - .:/app
-    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh && ./bin/webpack-dev-server"
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed && ./entrypoint.sh"
     environment: &dkenv
       RAILS_ENV: development
       NODE_ENV: development

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,0 +1,106 @@
+version: "3.8"
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - RAILS_ENV=development
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec rails db:migrate && bundle exec rails db:seed_fu && ./entrypoint.sh"
+    environment: &dkenv
+      RAILS_ENV: development
+      NODE_ENV: development
+      SENTRY_DSN: ${SENTRY_DSN}
+      S3_REGION: ap-northeast-1
+      S3_BUCKET: ${S3_BUCKET}
+      AUTH0_CLIENT_ID: ${AUTH0_CLIENT_ID}
+      AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET}
+      AUTH0_DOMAIN: ${AUTH0_DOMAIN}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      DREAMKAST_API_ADDR: "https://api.dev.cloudnativedays.jp"
+      AWS_REGION: ap-northeast-1
+      MYSQL_HOST: db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: dreamkast
+      REDIS_URL: redis://redis:6379
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      SQS_FIFO_QUEUE_URL: http://localstack:4566/000000000000/default
+      REVIEW_APP: "true"
+      DREAMKAST_NAMESPACE: "localhost"
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /app/tmp
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - localstack
+  fifo-worker:
+    build: .
+    entrypoint: /bin/sh -c "docker/wait-for-it.sh db:3306 --timeout=600 && bundle exec aws_sqs_active_job --queue fifo"
+    environment:
+      <<: *dkenv
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /app/tmp
+    depends_on:
+      db:
+          condition: service_started
+      localstack:
+          condition: service_healthy
+  db:
+    image: mysql/mysql-server:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: dreamkast
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      TZ: 'Asia/Tokyo'
+    cap_add:
+      - SYS_NICE
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_0900_ai_ci --default-authentication-plugin=mysql_native_password
+    volumes:
+    - mysql-data:/var/lib/mysql
+    - ./db/docker-entrypoint-initdb.d/1_allow-host-ip.sql:/docker-entrypoint-initdb.d/1_allow-host-ip.sql
+    ports:
+    - "3306:3306"
+  redis:
+    image: "redis:6"
+    volumes:
+      - redis-data:/data
+    ports:
+      - "6379:6379"
+  nginx:
+    image: nginx
+    volumes:
+    - ./config/default.conf:/etc/nginx/conf.d/default.conf
+    ports:
+    - 8080:80
+  ui:
+    image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui:main
+    ports:
+    - 3001:3001
+  localstack:
+    image: localstack/localstack:latest
+    environment:
+      - SERVICES=sqs
+      - DEFAULT_REGION=ap-northeast-1
+      - DATA_DIR=/tmp/localstack/data
+    volumes:
+      - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
+      - ./localstack:/tmp/localstack
+    ports:
+      - 4566:4566
+    healthcheck:
+      test: awslocal sqs list-queues --output=text | grep default
+      interval: 10s
+      timeout: 60s
+      retries: 10
+      start_period: 1s
+volumes:
+  mysql-data:
+  redis-data:


### PR DESCRIPTION
必要ファイル (.env)を用意した後に

```
docker compose -f compose-dev.yaml up -d
```

だけで開発環境が上がるようにした。

DockerのDev Environmentとの互換性を考慮して `compose-dev.yaml` を使うようにしている。