### PR TITLE
fix: return error if omitting conferenceDayIds param

### DIFF
--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::TalksController < ApplicationController
     conference = Conference.find_by(abbr: params[:eventAbbr])
     query = { conference_id: conference.id }
     query[:track_id] = params[:trackId] if params[:trackId]
-    @talks = Talk.includes([:conference, :conference_day, :talk_time, :talk_difficulty, :talk_category, :talks_speakers, :video, :speakers]).where(query)
+    @talks = Talk.includes([:conference, :conference_day, :talk_time, :talk_difficulty, :talk_category, :talks_speakers, :video, :speakers]).accepted_and_intermission.where(query)
     if params[:conferenceDayIds]
       @talks = @talks.where(params[:conferenceDayIds].split(',').map { |id| "conference_day_id = #{id}" }.join(' OR '))
     end

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -108,6 +108,12 @@ FactoryBot.define do
     track_id { 3 }
     show_on_timetable { true }
     video_published { false }
+
+    trait :accepted do
+      after(:build) do |talk|
+        create(:proposal, talk:, status: 1, conference_id: talk.conference_id)
+      end
+    end
   end
 
 

--- a/spec/requests/api/v1/talk_index_spec.rb
+++ b/spec/requests/api/v1/talk_index_spec.rb
@@ -5,9 +5,9 @@ describe TalksController, type: :request do
     describe 'talk belongs to conference_day' do
       before do
         create(:cndt2020)
-        create(:talk1)
+        create(:talk1, :accepted)
         create(:talk2)
-        create(:talk3)
+        create(:talk3, :accepted)
       end
 
       it 'confirm json schema' do
@@ -39,7 +39,7 @@ describe TalksController, type: :request do
     describe 'talk doesn\'t belong to conference_day' do
       before do
         create(:cndt2020)
-        create(:talk1, conference_day_id: nil)
+        create(:talk1, :accepted, conference_day_id: nil)
       end
 
       it 'confirm json schema' do


### PR DESCRIPTION
conferenceDayIdsを指定しない場合、rejectedなtalkも返そうとするが、それらにはstart_timeが設定されていないのでjsonのビルドでエラーになる。
`v1/talks` APIの返値にrejectedなtalkを含む必要はないと思われるため、AcceptedなセッションもしくはIntermissionのみ返すようにします。もしrejectedなtalkもAPIで取得する必要がある場合は `v1/proposals` のようなAPIを別途追加します。


fix: https://github.com/cloudnativedaysjp/dreamkast/issues/1616