### PR TITLE
LiveStream の region を US に変更する

### DIFF
--- a/app/helpers/media_live_helper.rb
+++ b/app/helpers/media_live_helper.rb
@@ -2,9 +2,9 @@ module MediaLiveHelper
   def media_live_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::MediaLive::Client.new(region: 'us-east-1', credentials: creds)
+      Aws::MediaLive::Client.new(region: AWS_LIVE_STREAM_REGION, credentials: creds)
     else
-      Aws::MediaLive::Client.new(region: 'us-east-1')
+      Aws::MediaLive::Client.new(region: AWS_LIVE_STREAM_REGION)
     end
   end
 

--- a/app/helpers/media_live_helper.rb
+++ b/app/helpers/media_live_helper.rb
@@ -2,9 +2,9 @@ module MediaLiveHelper
   def media_live_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::MediaLive::Client.new(region: 'ap-northeast-1', credentials: creds)
+      Aws::MediaLive::Client.new(region: 'us-east-1', credentials: creds)
     else
-      Aws::MediaLive::Client.new(region: 'ap-northeast-1')
+      Aws::MediaLive::Client.new(region: 'us-east-1')
     end
   end
 

--- a/app/helpers/media_package_helper.rb
+++ b/app/helpers/media_package_helper.rb
@@ -4,9 +4,9 @@ module MediaPackageHelper
   def media_package_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::MediaPackage::Client.new(region: 'ap-northeast-1', credentials: creds)
+      Aws::MediaPackage::Client.new(region: 'us-east-1', credentials: creds)
     else
-      Aws::MediaPackage::Client.new(region: 'ap-northeast-1')
+      Aws::MediaPackage::Client.new(region: 'us-east-1')
     end
   end
 

--- a/app/helpers/media_package_helper.rb
+++ b/app/helpers/media_package_helper.rb
@@ -4,9 +4,9 @@ module MediaPackageHelper
   def media_package_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::MediaPackage::Client.new(region: 'us-east-1', credentials: creds)
+      Aws::MediaPackage::Client.new(region: AWS_LIVE_STREAM_REGION, credentials: creds)
     else
-      Aws::MediaPackage::Client.new(region: 'us-east-1')
+      Aws::MediaPackage::Client.new(region: AWS_LIVE_STREAM_REGION)
     end
   end
 

--- a/app/helpers/ssm_helper.rb
+++ b/app/helpers/ssm_helper.rb
@@ -4,9 +4,9 @@ module SsmHelper
   def ssm_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::SSM::Client.new(region: 'us-east-1', credentials: creds)
+      Aws::SSM::Client.new(region: AWS_LIVE_STREAM_REGION, credentials: creds)
     else
-      Aws::SSM::Client.new(region: 'us-east-1')
+      Aws::SSM::Client.new(region: AWS_LIVE_STREAM_REGION)
     end
   end
 

--- a/app/helpers/ssm_helper.rb
+++ b/app/helpers/ssm_helper.rb
@@ -4,9 +4,9 @@ module SsmHelper
   def ssm_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::SSM::Client.new(region: 'ap-northeast-1', credentials: creds)
+      Aws::SSM::Client.new(region: 'us-east-1', credentials: creds)
     else
-      Aws::SSM::Client.new(region: 'ap-northeast-1')
+      Aws::SSM::Client.new(region: 'us-east-1')
     end
   end
 

--- a/app/models/live_stream_ivs.rb
+++ b/app/models/live_stream_ivs.rb
@@ -96,20 +96,24 @@ class LiveStreamIvs < LiveStream
   def ivs_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::IVS::Client.new(region: 'ap-northeast-1', credentials: creds)
+      Aws::IVS::Client.new(region: 'us-east-1', credentials: creds)
     else
-      Aws::IVS::Client.new(region: 'ap-northeast-1')
+      Aws::IVS::Client.new(region: 'us-east-1')
     end
   end
 
   def recording_configuration_arn
     case env_name
     when 'production'
-      'arn:aws:ivs:ap-northeast-1:607167088920:recording-configuration/DoiBRZMiClzN'
+      'arn:aws:ivs:us-east-1:607167088920:recording-configuration/rEy1r00HJaMP'
     when 'staging'
-      'arn:aws:ivs:ap-northeast-1:607167088920:recording-configuration/BfS5HX3B0J4r'
+      'arn:aws:ivs:us-east-1:607167088920:recording-configuration/VnSqwzabuOsQ'
+    when 'review_app'
+      'arn:aws:ivs:us-east-1:607167088920:recording-configuration/3gSuTxXYtRkg'
+    when 'others'
+      'arn:aws:ivs:us-east-1:607167088920:recording-configuration/3gSuTxXYtRkg'
     else
-      'arn:aws:ivs:ap-northeast-1:607167088920:recording-configuration/DkqVCWZLeG8B'
+      ''
     end
   end
 end

--- a/app/models/live_stream_ivs.rb
+++ b/app/models/live_stream_ivs.rb
@@ -96,9 +96,9 @@ class LiveStreamIvs < LiveStream
   def ivs_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::IVS::Client.new(region: 'us-east-1', credentials: creds)
+      Aws::IVS::Client.new(region: AWS_LIVE_STREAM_REGION, credentials: creds)
     else
-      Aws::IVS::Client.new(region: 'us-east-1')
+      Aws::IVS::Client.new(region: AWS_LIVE_STREAM_REGION)
     end
   end
 

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -181,11 +181,11 @@ class LiveStreamMediaLive < LiveStream
   def bucket_name
     case env_name
     when 'production'
-      'dreamkast-archive-prd'
+      'dreamkast-ivs-stream-archive-prd'
     when 'staging'
-      'dreamkast-archive-stg'
+      'dreamkast-ivs-stream-archive-stg'
     else
-      'dreamkast-archive-dev'
+      'dreamkast-ivs-stream-archive-dev'
     end
   end
 

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -113,11 +113,9 @@ class LiveStreamMediaLive < LiveStream
 
     input_security_group_resp = media_live_client.create_input_security_group(create_input_security_groups_params)
     params = { input_security_group_id: input_security_group_resp.security_group.id }
-    update!(params:)
 
     input_resp = media_live_client.create_input(create_input_params(input_security_group_resp.security_group.id))
     params = params.merge(input_id: input_resp.input.id, input_arn: input_resp.input.arn)
-    update!(params:)
 
     channel_resp = media_live_client.create_channel(create_channel_params(input_resp.input.id, input_resp.input.name))
     params = params.merge(channel_id: channel_resp.channel.id, channel_arn: channel_resp.channel.arn)

--- a/app/models/live_stream_media_live.rb
+++ b/app/models/live_stream_media_live.rb
@@ -113,9 +113,11 @@ class LiveStreamMediaLive < LiveStream
 
     input_security_group_resp = media_live_client.create_input_security_group(create_input_security_groups_params)
     params = { input_security_group_id: input_security_group_resp.security_group.id }
+    update!(params:)
 
     input_resp = media_live_client.create_input(create_input_params(input_security_group_resp.security_group.id))
     params = params.merge(input_id: input_resp.input.id, input_arn: input_resp.input.arn)
+    update!(params:)
 
     channel_resp = media_live_client.create_channel(create_channel_params(input_resp.input.id, input_resp.input.name))
     params = params.merge(channel_id: channel_resp.channel.id, channel_arn: channel_resp.channel.arn)

--- a/app/models/media_package_harvest_job.rb
+++ b/app/models/media_package_harvest_job.rb
@@ -80,19 +80,19 @@ class MediaPackageHarvestJob < ApplicationRecord
   def bucket_name
     case env_name
     when 'production'
-      'dreamkast-archive-prd'
+      'dreamkast-ivs-stream-archive-prd'
     when 'staging'
-      'dreamkast-archive-stg'
+      'dreamkast-ivs-stream-archive-stg'
     else
-      'dreamkast-archive-dev'
+      'dreamkast-ivs-stream-archive-dev'
     end
   end
 
   def cloudfront_domain_name(bucket_name)
     case bucket_name
-    when 'dreamkast-archive-prd'
+    when 'dreamkast-ivs-stream-archive-prd'
       'd3pun3ptcv21q4.cloudfront.net'
-    when 'dreamkast-archive-stg'
+    when 'dreamkast-ivs-stream-archive-stg'
       'd3i2o0iduabu0p.cloudfront.net'
     else
       'd1jzp6sbtx9by.cloudfront.net'

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -12,3 +12,5 @@ else
     region: 'ap-northeast-1'
   )
 end
+
+AWS_LIVE_STREAM_REGION = ENV.fetch('AWS_LIVE_STREAM_REGION', 'us-east-1')

--- a/lib/tasks/aws.rake
+++ b/lib/tasks/aws.rake
@@ -14,9 +14,9 @@ namespace :aws do
   def ivs_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::IVS::Client.new(region: 'us-east-1', credentials: creds)
+      Aws::IVS::Client.new(region: AWS_LIVE_STREAM_REGION, credentials: creds)
     else
-      Aws::IVS::Client.new(region: 'us-east-1')
+      Aws::IVS::Client.new(region: AWS_LIVE_STREAM_REGION)
     end
   end
 

--- a/lib/tasks/aws.rake
+++ b/lib/tasks/aws.rake
@@ -14,9 +14,9 @@ namespace :aws do
   def ivs_client
     creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
     if creds.set?
-      Aws::IVS::Client.new(region: 'ap-northeast-1', credentials: creds)
+      Aws::IVS::Client.new(region: 'us-east-1', credentials: creds)
     else
-      Aws::IVS::Client.new(region: 'ap-northeast-1')
+      Aws::IVS::Client.new(region: 'us-east-1')
     end
   end
 


### PR DESCRIPTION
AWS 上のリソースが以前のものが残っていたのもあり、基本は #1345 の revert のままにしました。
今後 region 変更の可能性などを踏まえてグローバル定数に region を定義するようにしています。

admin 画面からリソースを作成し、OBS で配信できることと rtmp で視聴できることを確認しました。

Infra への対応は不要かと思いますが、その点ご確認いただければと思います。