### PR TITLE
一般参加申し込み前の操作ができなくなる現象の対応

### DIFF
--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -2,8 +2,8 @@ module Secured
   extend ActiveSupport::Concern
 
   included do
-    before_action :redirect_to_registration, if: :should_redirect?
-    before_action :logged_in_using_omniauth?, :need_order?, if: :use_secured_before_action?
+    before_action :to_preparance, :redirect_to_registration, if: :should_redirect?
+    before_action :logged_in_using_omniauth?, :to_preparance, :need_order?, if: :use_secured_before_action?
     helper_method :admin?, :speaker?, :beta_user?
   end
 
@@ -13,6 +13,12 @@ module Secured
     else
       redirect_to('/auth/login?origin=' + request.fullpath)
     end
+  end
+
+  def to_preparance
+    # ログイン状態
+    # かつカンファレンスが一般参加応募不可状態
+    redirect_to(preparation_url) if conference.attendee_entry_disabled? && logged_in?
   end
 
   def should_redirect?

--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -33,6 +33,10 @@ class EventController < ApplicationController
     @conference = Conference.find_by(abbr: params[:event])
   end
 
+  def preparation
+    render('event/preparation')
+  end
+
   private
 
   def use_secured_before_action?

--- a/app/views/event/preparation.html.erb
+++ b/app/views/event/preparation.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+  <div class="row justify-content-lg-center">
+    <div class="col-12 col-lg-8 registration-form py-4" style="text-align:center">
+      <h2 class="mb-4" style="text-align:center">準備中...</h2>
+      <h3 >現在一般参加機能を鋭意準備中です</h3>
+      <br>
+      <h4>本サイトを利用する場合</h4>
+      <h4>ログアウトしてからご利用ください</h4>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,8 @@ Rails.application.routes.draw do
 
     resources :orders, only: [:new, :create]
     resources :cancel_orders
+
+    get 'preparation' => 'event#preparation'
   end
 
   mount AvatarUploader.upload_endpoint(:cache) => '/upload/avatar'


### PR DESCRIPTION
#1771 

以下の対応を追加
- ログイン状態で一般参加申し込み不可の状態でアクセスすると準備中ページに遷移するように変更
- 一般参加期間前なのと、参加者情報の編集もできなくなるので一旦参加者登録自体をブロック

特に後者の変更については機会損失の可能性もあると思うので、ちょっとご相談させてください。
編集には今のところチケット情報が必要になるので編集だけ可というのはすぐには難しいです。

下記スクショでは「SessionListを利用する場合」になっていますが、実際は「本サイトを利用する場合」になっています。
![スクリーンショット 2023-01-24 194237](https://user-images.githubusercontent.com/40717789/214279277-9a758bf5-4725-4b9c-ab6e-d9fb4a04ea9f.png)