### PR TITLE
Privacy policyをAdminページから登録するように

### DIFF
--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -48,7 +48,6 @@ class Admin::ConferencesController < ApplicationController
                                        :privacy_policy,
                                        :privacy_policy_for_speaker,
                                        links_attributes: [:id, :title, :url, :description, :_destroy],
-                                       conference_days_attributes: [:id, :date],
-                                      )
+                                       conference_days_attributes: [:id, :date])
   end
 end

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -45,7 +45,10 @@ class Admin::ConferencesController < ApplicationController
                                        :show_timetable,
                                        :show_sponsors,
                                        :brief,
+                                       :privacy_policy,
+                                       :privacy_policy_for_speaker,
                                        links_attributes: [:id, :title, :url, :description, :_destroy],
-                                       conference_days_attributes: [:id, :date])
+                                       conference_days_attributes: [:id, :date],
+                                      )
   end
 end

--- a/app/forms/conference_form.rb
+++ b/app/forms/conference_form.rb
@@ -10,6 +10,8 @@ class ConferenceForm
   attr_accessor :show_timetable
   attr_accessor :show_sponsors
   attr_accessor :brief
+  attr_accessor :privacy_policy
+  attr_accessor :privacy_policy_for_speaker
 
   delegate :persisted?, to: :conference
 
@@ -95,7 +97,7 @@ class ConferenceForm
     return if invalid?
 
     ActiveRecord::Base.transaction do
-      conference.update!(conference_status:, cfp_result_visible:, speaker_entry:, attendee_entry:, show_timetable:, show_sponsors:, brief:)
+      conference.update!(conference_status:, cfp_result_visible:, speaker_entry:, attendee_entry:, show_timetable:, show_sponsors:, brief:, privacy_policy:, privacy_policy_for_speaker:)
     end
   rescue => e
     puts(e)
@@ -125,7 +127,9 @@ class ConferenceForm
       show_sponsors: conference.show_sponsors,
       links:,
       conference_days:,
-      brief: conference.brief
+      brief: conference.brief,
+      privacy_policy: conference.privacy_policy,
+      privacy_policy_for_speaker: conference.privacy_policy_for_speaker,
     }
   end
 end

--- a/app/forms/conference_form.rb
+++ b/app/forms/conference_form.rb
@@ -129,7 +129,7 @@ class ConferenceForm
       conference_days:,
       brief: conference.brief,
       privacy_policy: conference.privacy_policy,
-      privacy_policy_for_speaker: conference.privacy_policy_for_speaker,
+      privacy_policy_for_speaker: conference.privacy_policy_for_speaker
     }
   end
 end

--- a/app/javascript/stylesheets/_admin.scss
+++ b/app/javascript/stylesheets/_admin.scss
@@ -120,3 +120,11 @@ a:focus {
     color: #fff;
     background: #333333;
 }
+
+.admin-conference-form {
+    .privacy-policy {
+        width: 100%;
+        height: 300px;
+        font-size: small;
+    }
+}

--- a/app/views/admin/conferences/_form.html.erb
+++ b/app/views/admin/conferences/_form.html.erb
@@ -87,6 +87,22 @@
     </div>
   </div>
 
+  <h3>Privaty Policy (for attendees)</h3>
+
+  <div class="form-row form-group">
+    <div class="col-12 col-md-6">
+      <%= form.text_area :privacy_policy, {class: "privacy-policy"} %>
+    </div>
+  </div>
+
+  <h3>Privaty Policy (for speakers)</h3>
+
+  <div class="form-row form-group">
+    <div class="col-12 col-md-6">
+      <%= form.text_area :privacy_policy_for_speaker, {class: "privacy-policy"} %>
+    </div>
+  </div>
+
   <div class="form-row form-group">
     <div class="col-12 col-md-6">
       <%= form.submit class: "btn btn-primary" %>

--- a/app/views/admin/conferences/edit.html.erb
+++ b/app/views/admin/conferences/edit.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="row justify-content-md-center">
-    <div class="registration-form py-3 px-md-5 w-100">
+    <div class="registration-form py-3 px-md-5 w-100 admin-conference-form">
       <%= render 'form', conference_form: @conference_form %>
     </div>
   </div>

--- a/db/fixtures/development/00_seeds.rb
+++ b/db/fixtures/development/00_seeds.rb
@@ -120,7 +120,7 @@ EOS
     abbr: "cnsec2022",
     theme: "Go \"Green\"〜ともに目指す持続可能なセキュリティ〜",
     copyright: '© CloudNative Days (Secretariat by Impress Corporation)',
-    privacy_policy: File.read(File.join(Rails.root, 'db/fixtures/production/privacy_policy_cnsec2022.md')), #TODO: cnsec2022版プライバシーポリシー
+    privacy_policy: File.read(File.join(Rails.root, 'db/fixtures/production/privacy_policy_cnsec2022.md')),
     privacy_policy_for_speaker: File.read(File.join(Rails.root, 'db/fixtures/production/privacy_policy_for_speaker.md')),
     coc: File.read(File.join(Rails.root, 'db/fixtures/production/coc.md')),
     committee_name: "CloudNative Security Conference 2022 Committee",
@@ -163,8 +163,6 @@ EOS
     abbr: "cicd2023",
     theme: "Continuous 〜ともに回す高速なアプリケーション開発ライフサイクル〜",
     copyright: '© CloudNative Days (Secretariat by Impress Corporation)',
-    privacy_policy: File.read(File.join(Rails.root, 'db/fixtures/production/privacy_policy_cicd2023.md')),
-    privacy_policy_for_speaker: File.read(File.join(Rails.root, 'db/fixtures/production/privacy_policy_for_speaker_cndt2022.md')),
     coc: File.read(File.join(Rails.root, 'db/fixtures/production/coc.md')),
     committee_name: "CI/CD Conference 2023 Committee",
     about: <<'EOS'

--- a/db/fixtures/production/00_seeds.rb
+++ b/db/fixtures/production/00_seeds.rb
@@ -151,8 +151,6 @@ EOS
     abbr: "cicd2023",
     theme: "Continuous 〜ともに回す高速なアプリケーション開発ライフサイクル〜",
     copyright: '© CloudNative Days (Secretariat by Impress Corporation)',
-    privacy_policy: File.read(File.join(Rails.root, 'db/fixtures/production/privacy_policy_cicd2023.md')),
-    privacy_policy_for_speaker: File.read(File.join(Rails.root, 'db/fixtures/production/privacy_policy_for_speaker_cndt2022.md')),
     coc: File.read(File.join(Rails.root, 'db/fixtures/production/coc.md')),
     committee_name: "CI/CD Conference 2023 Committee",
     about: <<'EOS'


### PR DESCRIPTION
事務局からの要望で、プライバシーポリシーを管理画面で変更できるようにした。

これはスポンサーが随時追加されるについれ、プライバシーポリシーの情報提供先企業のリストを更新する必要があるため、事務局作業のセルフサービス化の一環で追加。