### PR TITLE
chore: decrease rate for transaction

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,5 +6,5 @@ Sentry.init do |config|
 
   # To activate performance monitoring, set one of these options.
   # We recommend adjusting the value in production:
-  config.traces_sample_rate = 0.1
+  config.traces_sample_rate = 0.01
 end


### PR DESCRIPTION
トランザクションのサンプルレートが大きいため、キャパシティを越えてしまっている。今あまりみられていないし、1％に下げても問題ないと思う。普段だと1%は数が少なそうだが、イベント中であれば1%でもある程度パフォーマンスの測定には使えるだろう。

https://docs.sentry.io/platforms/ruby/configuration/sampling/