### PR TITLE
fix: Update swagger to the one used at dreamkast-ui

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -1454,6 +1454,8 @@ components:
                 type: "number"
               timestamp:
                 type: "number"
+              desc:
+                type: "string"
             additionalProperties: false
       additionalProperties: false
     ProfilePoint:


### PR DESCRIPTION
CNDT2022の最後の追い込みで、apigatewayから出力したswagger.ymlをdkを通している時間が惜しかったのでdreamkast-uiに直接渡していました。結果dkとdk-uiのswagger.ymlが不一致な状態なので、それを解消するPRです。

もう少しあるかと思っていましたが、差分は2行だけでした。

これをmergeしてgithub actionが走っても、dk-ui側のRTK query clientの更新PRは作成されないはずです（変更点がないので）