### PR TITLE
現地参加判定の修正

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -166,7 +166,7 @@ class Profile < ApplicationRecord
 
   def attend_offline?
     if active_order.present?
-      active_order.tickets.first.title == 'オフライン参加'
+      active_order.tickets.first.title == '現地参加'
     else
       false
     end

--- a/app/views/tracks/waiting.html.erb
+++ b/app/views/tracks/waiting.html.erb
@@ -119,8 +119,7 @@
           <div class="card-body">
             <div class="card-text">
               <ul>
-                <li><%= link_to "参加者ガイド", "https://sites.google.com/view/cndt2022-guide/", target: :_blank, rel: "noopener noreferrer" %>
-</li>
+                <li><%= link_to "参加者ガイド", "https://sites.google.com/view/cndt2022-guide/", target: :_blank, rel: "noopener noreferrer" %></li>
                 <li><%= link_to '参加方法変更', new_cancel_order_path(order_id: @profile.active_order.id) %></li>
                 <li><%= link_to "オンラインホワイトボード", 'https://miro.com/app/board/uXjVPWsauOI=/', target: :_blank, rel: "noopener noreferrer" %></li>
                 <li><%= link_to "CNDT2022 Blog記事一覧", "https://cloudnativedays.medium.com/list/cndt2022-2200d91cd1b6", target: :_blank, rel: "noopener noreferrer" %>
@@ -136,13 +135,11 @@
       </div>
     </section>
   </div>
-  <div class="row">
-    <% if @conference.show_sponsors %>
-    <section class="page-section" id="sponsors">
-      <%= render 'event/partial/sponsors', conference: @conference %>
-    </section>
-    <% end %>
-  </div>
+  <% if @conference.show_sponsors %>
+  <section class="page-section" id="sponsors">
+    <%= render 'event/partial/sponsors', conference: @conference %>
+  </section>
+  <% end %>
 
 </div>
 <script>

--- a/db/fixtures/development/00_seeds.rb
+++ b/db/fixtures/development/00_seeds.rb
@@ -533,6 +533,6 @@ EOS
 Ticket.seed(
   {id: "7b02e975-8418-4b40-a01d-f8011cc705e3", title: "オフライン参加", description: "aaaa", price: 0, stock: 454, conference_id: 7 },
   {id: "15ac6d96-5083-496d-9fd1-327f320a2f7b", title: "オンライン参加", description: "aaaa", price: 0, stock: 3500, conference_id: 7 },
-  {id: "f4d09974-c6af-4fab-bb60-d394058e9eb8", title: "現地参加(日比谷会場)", description: "aaaa", price: 0, stock: 500, conference_id: 8 },
+  {id: "f4d09974-c6af-4fab-bb60-d394058e9eb8", title: "現地参加", description: "aaaa", price: 0, stock: 500, conference_id: 8 },
   {id: "5b31c315-5b70-4238-bf62-ed193480e9fd", title: "オンライン参加", description: "aaaa", price: 0, stock: 3500, conference_id: 8 },
 )

--- a/db/fixtures/production/00_seeds.rb
+++ b/db/fixtures/production/00_seeds.rb
@@ -421,6 +421,6 @@ end
 Ticket.seed(
   {id: "7b02e975-8418-4b40-a01d-f8011cc705e3", title: "オフライン参加", description: "aaaa", price: 0, stock: 454, conference_id: 7 },
   {id: "15ac6d96-5083-496d-9fd1-327f320a2f7b", title: "オンライン参加", description: "aaaa", price: 0, stock: 3500, conference_id: 7 },
-  {id: "f4d09974-c6af-4fab-bb60-d394058e9eb8", title: "現地参加(日比谷会場)", description: "aaaa", price: 0, stock: 500, conference_id: 8 },
+  {id: "f4d09974-c6af-4fab-bb60-d394058e9eb8", title: "現地参加", description: "aaaa", price: 0, stock: 500, conference_id: 8 },
   {id: "5b31c315-5b70-4238-bf62-ed193480e9fd", title: "オンライン参加", description: "aaaa", price: 0, stock: 3500, conference_id: 8 },
 )

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
     end
 
     trait :offline do
-      title { 'オフライン参加' }
+      title { '現地参加' }
       description { 'offline' }
       price { 0 }
       stock { 2000 }

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe(Profile, type: :model) do
       expect(profile.attend_offline?).to(be_truthy)
     end
 
-    it 'should return オフライン参加' do
-      expect(profile.way_to_attend).to(eq('オフライン参加'))
+    it 'should return 現地参加' do
+      expect(profile.way_to_attend).to(eq('現地参加'))
     end
   end
 end


### PR DESCRIPTION
『オフライン参加』と『オンライン参加』の視認性が悪いため、オフライン参加を『現地参加(日比谷会場)』としていたが、これのおかげでフラグ判定にマッチしなくなり、座席数管理が正しく動いていなかった。

日比谷会場と入れてしまうとイベントの度に修正が必要なので、現地参加という記載に変更した。

ついでにDashboardのロゴがズレていたので修正