### PR TITLE
feat: add speakers api

### DIFF
--- a/app/controllers/api/v1/speakers_controller.rb
+++ b/app/controllers/api/v1/speakers_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::SpeakersController < ApplicationController
+  include SecuredPublicApi
+
+  skip_before_action :authenticate_request!, only: [:index]
+  skip_before_action :verify_authenticity_token
+
+  def index
+    conference = Conference.find_by(abbr: params[:eventAbbr])
+    @speakers = conference.speakers
+    render(:index, formats: :json, type: :jbuilder)
+  end
+end

--- a/app/views/api/v1/speakers/index.json.jbuilder
+++ b/app/views/api/v1/speakers/index.json.jbuilder
@@ -1,0 +1,10 @@
+json.array!(@speakers) do |speaker|
+  json.id(speaker.id)
+  json.name(speaker.name)
+  json.company(speaker.company)
+  json.jobTitle(speaker.job_title)
+  json.profile(speaker.profile)
+  json.githubId(speaker.github_id)
+  json.twitterId(speaker.twitter_id)
+  json.avatarUrl(speaker.avatar_url)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       get ':event/my_profile' => 'profiles#my_profile'
       resources :conferences, only: [:index, :show], path: 'events'
       resources :talks, only: [:index, :show, :update]
+      resources :speakers, only: [:index]
       resources :tracks, only: [:index, :show]
       resources :sponsors, only: [:index]
       resources :speakers, only: [:index, :show]

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -117,6 +117,30 @@ paths:
           description: Invalid params supplied
         '404':
           description: Track not found
+  /api/v1/speakers:
+    get:
+      tags:
+        - Speaker
+      parameters:
+        - name: eventAbbr
+          in: query
+          description: abbr of event (e.g. cndt2020)
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Speaker'
+        '400':
+          description: Invalid [eventAbbr] supplied
+        '404':
+          description: Event not found
   /api/v1/talks:
     get:
       tags:
@@ -1032,6 +1056,50 @@ components:
         videoPlatform: "vimeo"
         videoId: "453935827"
         channelArn: "arn:aws:ivs:us-east-1:607167088920:channel/KdizL0w0PD7i"
+      required:
+        - id
+        - name
+    Speaker:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: number
+        name:
+          type: string
+        company:
+          type: string
+          nullable: true
+        jobTitle:
+          type: string
+        profile:
+          type: string
+        githubId:
+          type: string
+          nullable: true
+        twitterId:
+          type: string
+          nullable: true
+        avatarUrl:
+          type: string
+          nullable: true
+      example:
+        - id: 1
+          name: "めちゃすごい人"
+          company: "Hoge Inc."
+          jobTitle: "Super Engineer"
+          profile: "This is profile"
+          githubId: "3aae1aa4-563b-4a8a-9116-7ef1f2b1b08c"
+          twitterId: "4639289c-b3fe-4049-8f25-58c2899c1286"
+          avatarUrl: "https://avatars.githubusercontent.com/u/107187?v=4" # r_takaishi's avatar of GitHub
+        - id: 2
+          name: "やんごとない人"
+          company: "Foo Inc."
+          jobTitle: "Great Engineer"
+          profile: "プロフィール"
+          githubId: "b677b66a-917e-4acb-b6ac-b7a09511e103"
+          twitterId: "87b72a9a-257f-4680-ab72-5edb4348124e"
+          avatarUrl: "https://avatars.githubusercontent.com/u/44778132?s=200&v=4" # cloudnativedaysjp's avatar of GitHub
       required:
         - id
         - name

--- a/spec/requests/api/v1/speaker_index_spec.rb
+++ b/spec/requests/api/v1/speaker_index_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe Api::V1::SpeakersController, type: :request do
+  describe 'GET /api/v1/speakers?eventAbbr=cndt2020' do
+    describe 'talk belongs to conference_day' do
+      before do
+        create(:cndt2020)
+        create(:speaker_alice)
+        create(:speaker_bob)
+      end
+
+      it 'confirm json schema' do
+        get '/api/v1/speakers?eventAbbr=cndt2020'
+        expect(response).to(have_http_status(:ok))
+        assert_response_schema_confirm
+        expect(response.body).to(include('Alice'))
+        expect(response.body).to(include('Bob'))
+      end
+
+      it 'successes request' do
+        get '/api/v1/speakers?eventAbbr=cndt2020'
+        expect(response.status).to(eq(200))
+      end
+    end
+  end
+end


### PR DESCRIPTION
website用にスピーカー情報を取得するためのAPIを追加する。APIで取得できるのはdk本体でパブリックな情報として見えるもののみとするので認証など不要にしているが、もし認証書けておいた方がよいのではなどコメントあればください。