### PR TITLE
Fix/enable cors at local dev

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -6,6 +6,16 @@ server {
     listen       80;
     server_name  localhost;
 
+    # CORS
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    add_header Access-Control-Allow-Origin "*";
+    add_header Access-Control-Allow-Methods "*";
+    add_header Access-Control-Allow-Headers "*";
+    add_header Access-Control-Allow-Credentials true;
+
     location / {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/config/default.conf
+++ b/config/default.conf
@@ -58,7 +58,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 1000M;
-        proxy_pass http://host.docker.internal:3001/$1/ui/$2;
+        proxy_pass http://host.docker.internal:3001/$1/ui/$2$is_args$args;
     }
 
     location ~ ^/(.*)/ui {
@@ -67,7 +67,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         client_max_body_size 1000M;
-        proxy_pass http://host.docker.internal:3001/$1/ui;
+        proxy_pass http://host.docker.internal:3001/$1/ui$is_args$args;
     }
 
     location ~ ^/api/v1/profile/(.*)/point(.*) {


### PR DESCRIPTION
renovateによってnextjsがversion upされたことで、yarn devでnextのdev serverを起動している際に `_next` 以外のendpointに対してもrequestを行うようになり、nginxにroutingが設定されておらずrenderingにfailする事象が出ていました。その対処です。

以前は同一ドメインじゃないとだめだったためnginxに集約していましたが、現在はcorsの設定さえすれば同一ドメインの制約はありません。同一ドメインに束ねているがゆえにnextのminor version upでlocal devができなくなる、という状況がそもそもイケてないので、corsを設定して、dev serverへのアクセスはnginxを介さなくても良いように変更しました。

また、 `/ui` およびその配下に対してのquery parameterが通らない状態になっている問題の修正も入れています。