### PR TITLE
fix: make dk-ui work when started by docker-compose

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -83,9 +83,16 @@ services:
     ports:
     - 8080:80
   ui:
-    image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui:main
+    image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui:latest
     ports:
     - 3001:3001
+    environment:
+      - NEXT_PUBLIC_AUTH0_DOMAIN=dreamkast.us.auth0.com
+      - NEXT_PUBLIC_AUTH0_CLIENT_ID=0cWWdpGt4CpWjHJ9QIHtPm5GrJLS25lz
+      - NEXT_PUBLIC_AUTH0_AUDIENCE=https://event.cloudnativedays.jp/
+      - NEXT_PUBLIC_BASE_PATH=/cndt2022/ui
+      - NEXT_PUBLIC_API_BASE_URL=http://localhost:8080/
+      - NEXT_PUBLIC_EVENT_SALT=cndt2022
   localstack:
     image: localstack/localstack:latest
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,18 +81,25 @@ services:
     ports:
     - 8080:80
   ui:
-    image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui:main
+    image: 607167088920.dkr.ecr.ap-northeast-1.amazonaws.com/dreamkast-ui:latest
     ports:
     - 3001:3001
+    environment:
+      - NEXT_PUBLIC_AUTH0_DOMAIN=dreamkast.us.auth0.com
+      - NEXT_PUBLIC_AUTH0_CLIENT_ID=0cWWdpGt4CpWjHJ9QIHtPm5GrJLS25lz
+      - NEXT_PUBLIC_AUTH0_AUDIENCE=https://event.cloudnativedays.jp/
+      - NEXT_PUBLIC_BASE_PATH=/cndt2022/ui
+      - NEXT_PUBLIC_API_BASE_URL=http://localhost:8080/
+      - NEXT_PUBLIC_EVENT_SALT=cndt2022
   localstack:
     image: localstack/localstack:latest
     environment:
       - SERVICES=sqs
       - DEFAULT_REGION=ap-northeast-1
-      - DATA_DIR=/tmp/localstack/data
+      - DATA_DIR=/var/lib/localstack/data
     volumes:
       - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
-      - ./localstack:/tmp/localstack
+      - ./localstack:/var/lib/localstack
     ports:
       - 4566:4566
     healthcheck:


### PR DESCRIPTION
docker-composeで起動するdk-uiが古く、かつ環境変数がアタッチされておらず動かない状態だったので、動くように修正しました。
dk-uiは、main mergeされるとそのrevisionで生成されたdocker imageにlatestタグが付くように修正しています。

https://github.com/cloudnativedaysjp/dreamkast-ui/pull/368
