### PR TITLE
CICD2023以降ではsponsor logoの持ち方が変わっていたのでAPIをそれに対応させる

### DIFF
--- a/app/views/api/v1/sponsors/index.json.jbuilder
+++ b/app/views/api/v1/sponsors/index.json.jbuilder
@@ -4,7 +4,7 @@ json.array!(@sponsors) do |sponsor|
   json.name(sponsor.name)
   json.abbr(sponsor.abbr)
   json.url(sponsor.url)
-  json.logo_url(image_url(sponsor.sponsor_attachment_logo_image.url))
+  json.logo_url(sponsor.sponsor_attachment_logo_image.file_data.present? ? sponsor.sponsor_attachment_logo_image.file_url : image_url(sponsor.sponsor_attachment_logo_image.url))
   json.sponsorType(sponsor.sponsor_types.map { |type| type.name })
   json.booth(sponsor.booth.present? ? sponsor.booth_info : {})
 end


### PR DESCRIPTION
CICD2023でadminからスポンサー情報を登録できるようにしたのだが、その際ロゴの情報を持たせるフィールドが `url` から `file_data` に変えていた（S3にアップロードするので変更が必要だった）。そのため、sponsor apiがCICD2023のスポンサー一覧を返そうとした際にurlがnilのためエラーになっていた。

```
irb(main):020:0> Conference.find_by(abbr: 'cndt2022').sponsors.map{|sponsor| [sponsor.name, sponsor.sponsor_attachment_logo_image.url]}
=>
[["CircleCI合同会社", "sponsors/cndt2022/circleci.png"],
 ["LINE株式会社", "sponsors/cndt2022/line.png"],
 ["Snyk株式会社", "sponsors/cndt2022/snyk.png"],
 ["テクマトリックス株式会社", "sponsors/cndt2022/techmatrix.png"],
 ["GMOインターネットグループ株式会社", "sponsors/cndt2022/gmo.png"],
 ["PingCAP株式会社", "sponsors/cndt2022/pingcap.png"],
 ["PagerDuty株式会社", "sponsors/cndt2022/pagerduty.png"],
 ["Aiven Japan合同会社", "sponsors/cndt2022/aiven.png"],
 ["グーグル・クラウド・ジャパン合同会社", "sponsors/cndt2022/google.png"],
 ["クリエーションライン株式会社", "sponsors/cndt2022/creationline.png"],
 ["Sysdig Japan合同会社", "sponsors/cndt2022/sysdig.png"],
 ["freee株式会社", "sponsors/cndt2022/freee.png"],
 ["株式会社カサレアル", "sponsors/cndt2022/casareal.png"],
 ["トレンドマイクロ株式会社", "sponsors/cndt2022/trendmicro.png"],
 ["Datadog Japan合同会社", "sponsors/cndt2022/datadog.png"],
 ["日本アイ・ビー・エム株式会社", "sponsors/cndt2022/ibm.jpg"],
 ["F5ネットワークスジャパン合同会社", "sponsors/cndt2022/nginx.png"],
 ["GitLab合同会社", "sponsors/cndt2022/gitlab.png"],
 ["株式会社NTTデータ", "sponsors/cndt2022/nttdata.png"],
 ["Plaid", "sponsors/cndt2022/plaid.png"],
 ["さくらインターネット株式会社", "sponsors/cndt2022/sakura.png"],
 ["New Relic", "sponsors/cndt2022/newrelic.png"],
 ["Dynatrace合同会社", "sponsors/cndt2022/dynatrace.png"],
 ["Elastic", "sponsors/cndt2022/elastic.png"],
 ["レッドハット株式会社", "sponsors/cndt2022/redhat.png"],
 ["アクイアジャパン合同会社", "sponsors/cndt2022/acquia.png"],
 ["東京エレクトロンデバイス株式会社", "sponsors/cndt2022/teldevice.png"],
 ["日本マイクロソフト株式会社", "sponsors/cndt2022/microsoft.png"],
 ["ヴィーム・ソフトウェア株式会社", "sponsors/cndt2022/veeam.png"],
 ["パロアルトネットワークス株式会社", "sponsors/cndt2022/paloalto.png"],
 ["Splunk Services Japan合同会社", "sponsors/cndt2022/splunk.png"],
 ["HashiCorp Japan株式会社", "sponsors/cndt2022/hashicorp.png"],
 ["ミロ・ジャパン合同会社", "sponsors/cndt2022/miro.png"]]
irb(main):021:0> Conference.find_by(abbr: 'cicd2023').sponsors.map{|sponsor| [sponsor.name, sponsor.sponsor_attachment_logo_image.url]}
=> [["GitLab合同会社", nil], ["株式会社スリーシェイク", nil], ["Snyk株式会社", nil], ["F5ネットワークスジャパン合同会社", nil], ["mabl株式会社", nil], ["パイオニア株式会社", nil], ["SUSEソフトウエアソリューションズジャパン株式会社", nil], ["株式会社ハイヤールー", nil]]
```