### PR TITLE
fix: validation when start_on_air

### DIFF
--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -27,7 +27,7 @@ class Admin::TalksController < ApplicationController
     talk = Talk.find(params[:talk][:id])
 
     respond_to do |format|
-      on_air_talks_of_other_days = talk.track.talks.accepted.reject { |t| t.conference_day.id == talk.conference_day.id }.select { |t| t.video.on_air? }
+      on_air_talks_of_other_days = talk.track.talks.accepted_and_intermission.reject { |t| t.conference_day.id == talk.conference_day.id }.select { |t| t.video.on_air? }
       if on_air_talks_of_other_days.size.positive?
         format.turbo_stream {
           update_variables_for_tracks(talk)

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -29,7 +29,7 @@ class Admin::TalksController < ApplicationController
     talk = Talk.find(params[:talk][:id])
 
     respond_to do |format|
-      on_air_talks_of_other_days = talk.track.talks.accepted_and_intermission.reject { |t| t.conference_day.id == talk.conference_day.id }.select { |t| t.video.on_air? }
+      on_air_talks_of_other_days = talk.track.talks.includes([:conference_day, :video]).accepted_and_intermission.reject { |t| t.conference_day.id == talk.conference_day.id }.select { |t| t.video.on_air? }
       if on_air_talks_of_other_days.size.positive?
         format.html {
           update_variables_for_tracks(talk)

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -35,20 +35,20 @@ class Admin::TalksController < ApplicationController
           update_variables_for_tracks(talk)
           redirect_to(admin_tracks_path(date:, track_name:), alert: "Talk id=#{on_air_talks_of_other_days.map(&:id).join(',')} are already on_air.")
         }
-        format.turbo_stream {
-          update_variables_for_tracks(talk)
-          flash[:alert] = "Talk id=#{on_air_talks_of_other_days.map(&:id).join(',')} are already on_air."
-        }
+        # format.turbo_stream {
+        #   update_variables_for_tracks(talk)
+        #   flash[:alert] = "Talk id=#{on_air_talks_of_other_days.map(&:id).join(',')} are already on_air."
+        # }
       else
         talk.start_streaming
         format.html {
           update_variables_for_tracks(talk)
           redirect_to(admin_tracks_path(date:, track_name:), notice: "OnAirに切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}")
         }
-        format.turbo_stream {
-          update_variables_for_tracks(talk)
-          flash[:notice] = "OnAirに切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
-        }
+        # format.turbo_stream {
+        #   update_variables_for_tracks(talk)
+        #   flash[:notice] = "OnAirに切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
+        # }
       end
     end
   end
@@ -69,9 +69,9 @@ class Admin::TalksController < ApplicationController
       format.html {
         redirect_to(admin_tracks_path(date:, track_name:), notice: "Waiting に切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}")
       }
-      format.turbo_stream {
-        flash[:notice] = "Waiting に切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
-      }
+      # format.turbo_stream {
+      #   flash[:notice] = "Waiting に切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
+      # }
     end
   end
 

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -218,4 +218,18 @@ FactoryBot.define do
     document_url { 'http://' }
     created_at { Time.new(2022, 9, 1, 10) }
   end
+
+  factory :intermission, class: Talk do
+    title { '開始までしばらくお待ちください' }
+    start_time { '10:00' }
+    end_time { '11:00' }
+    conference_id { 1 }
+    conference_day_id { 3 }
+    abstract { 'intermission' }
+    talk_difficulty_id { 1 }
+    talk_category_id { 1 }
+    track_id { 1 }
+    show_on_timetable { false }
+    video_published { true }
+  end
 end

--- a/spec/requests/admin/talks_spec.rb
+++ b/spec/requests/admin/talks_spec.rb
@@ -90,9 +90,11 @@ describe Admin::SpeakersController, type: :request do
         let!(:video2) { create(:video, talk: talk2, on_air: false) }
 
         it 'success to change to start on air' do
-          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: talk2.id }, format: 'turbo_stream' }
-          expect(response).to(be_successful)
+          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: talk2.id } }
+          expect(response).to_not(be_successful)
+          expect(response).to(have_http_status('302'))
           expect(Video.find(talk2.video.id).on_air).to(be_truthy)
+          expect(response).to(redirect_to('http://www.example.com/cndt2020/admin/tracks'))
         end
       end
 
@@ -101,10 +103,12 @@ describe Admin::SpeakersController, type: :request do
         let!(:video2) { create(:video, talk: talk2, on_air: false) }
 
         it 'can not to change to start on air' do
-          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: talk2.id }, format: 'turbo_stream' }.to_json, headers: { "Content-Type": 'application/json' }
-          expect(response).to(be_successful)
+          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: talk2.id } }.to_json, headers: { "Content-Type": 'application/json' }
+          expect(response).to_not(be_successful)
+          expect(response).to(have_http_status('302'))
           expect(Video.find(talk2.video.id).on_air).to(be_falsey)
-          expect(response.body).to(include("Talk id=#{talk1.id} are already on_air."))
+          expect(response).to(redirect_to('http://www.example.com/cndt2020/admin/tracks'))
+          expect(flash[:alert]).to(include("Talk id=#{talk1.id} are already on_air."))
         end
       end
     end
@@ -118,8 +122,10 @@ describe Admin::SpeakersController, type: :request do
         let!(:video2) { create(:video, talk: intermission2, on_air: false) }
 
         it 'can not to change to start on air' do
-          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: intermission2.id }, format: 'turbo_stream' }.to_json, headers: { "Content-Type": 'application/json' }
-          expect(response).to(be_successful)
+          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: intermission2.id } }.to_json, headers: { "Content-Type": 'application/json' }
+          expect(response).to_not(be_successful)
+          expect(response).to(have_http_status('302'))
+          expect(response).to(redirect_to('http://www.example.com/cndt2020/admin/tracks'))
           expect(Video.find(intermission2.video.id).on_air).to(be_truthy)
         end
       end
@@ -129,10 +135,12 @@ describe Admin::SpeakersController, type: :request do
         let!(:video2) { create(:video, talk: intermission2, on_air: false) }
 
         it 'can not to change to start on air' do
-          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: intermission2.id }, format: 'turbo_stream' }.to_json, headers: { "Content-Type": 'application/json' }
-          expect(response).to(be_successful)
+          post admin_start_on_air_path(event: 'cndt2020'), params: { talk: { id: intermission2.id } }.to_json, headers: { "Content-Type": 'application/json' }
+          expect(response).to_not(be_successful)
+          expect(response).to(have_http_status('302'))
+          expect(response).to(redirect_to('http://www.example.com/cndt2020/admin/tracks'))
           expect(Video.find(intermission2.video.id).on_air).to(be_falsey)
-          expect(response.body).to(include("Talk id=#{intermission1.id} are already on_air."))
+          expect(flash[:alert]).to(include("Talk id=#{intermission1.id} are already on_air."))
         end
       end
     end


### PR DESCRIPTION
fix https://github.com/cloudnativedaysjp/dreamkast/issues/1852

- 別日にオンエア状態のTalkがある時のバリデーションが一部動いていなかった問題を修正
- Start/Stop後にメッセージ表示されなくなっていた問題を修正
- パフォーマンス修正