### PR TITLE
chore: Move localstack init script to catch up to the latest init process

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,6 +99,7 @@ services:
       - DATA_DIR=/var/lib/localstack/data
     volumes:
       - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
+      - ./localstack/init:/etc/localstack/init:ro
       - ./localstack:/var/lib/localstack
     ports:
       - 4566:4566

--- a/localstack/docker-entrypoint-initaws.d/README.md
+++ b/localstack/docker-entrypoint-initaws.d/README.md
@@ -1,0 +1,2 @@
+DEPRECATED: docker-entrypoint-initaws.d is no longer supported by the latest localstack, use /etc/localstack/init entrypoints.
+ref: https://docs.localstack.cloud/references/init-hooks/

--- a/localstack/init/ready.d/create_queue.sh
+++ b/localstack/init/ready.d/create_queue.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+awslocal sqs create-queue --queue-name default


### PR DESCRIPTION
### Problem
- localstack:latestをimage pullしてdocker-composeで起動すると、sqs queueが作られずhealthcheckが通りませんでした。

### Solution
- 新しいlocalstackは起動時のinterceptの仕方が変わったようなので、新しいimageにも対応できるようにmount pointを追加しました。
  - ref: https://docs.localstack.cloud/references/init-hooks/
- mount先を増やすだけでも良かったのですが、新しい方式の方がhookできるポイントが増えていて柔軟性が高そう & ディレクトリ構成がわかりやすいので、そちらに揃えました。
- 後方互換のため、古い方も残しています

