### PR TITLE
add rule for PR by renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,5 +33,6 @@
     "github-actions",
     "npm",
   ],
+  "prHeader": "✅ マイナーチェンジ以上のアップデートは動作確認をしてからマージすること",
   "reviewers": ["team:dk-rails"]
 }


### PR DESCRIPTION
renovateが作るPRについてのルールをヘッダとして追加します。PRのテンプレートは設定で変えられる模様。

https://docs.renovatebot.com/configuration-options/#prheader

close https://github.com/cloudnativedaysjp/dreamkast/issues/1878