### PR TITLE
セッション毎の登録者数をadmin/statisticsに表示する

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -25,6 +25,7 @@ class AdminController < ApplicationController
   end
 
   def statistics
+    @talks = @conference.talks.accepted_and_intermission.order('conference_day_id ASC, start_time ASC, track_id ASC')
   end
 
   def export_statistics

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -25,7 +25,7 @@ class AdminController < ApplicationController
   end
 
   def statistics
-    @talks = @conference.talks.accepted_and_intermission.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference.talks.accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
   end
 
   def export_statistics

--- a/app/views/admin/statistics.erb
+++ b/app/views/admin/statistics.erb
@@ -7,5 +7,28 @@
       <h3>Export to CSV</h3>
       <%= button_to 'エクスポート', admin_export_statistics_path, {method: :get } %>
     </div>
+
+
+    <div class="col-12">
+      <h2>Talks</h2>
+      <table class="table table-striped talks_table" >
+        <thead>
+        <tr>
+          <th scope="col">ID</th>
+          <th scope="col">Title</th>
+          <th scope="col">登録者数</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% @talks.each do |talk| %>
+          <tr>
+            <td><%= talk.id %></td>
+            <td><%= talk.title %></td>
+            <td><%= talk.registered_talks.size %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
現地参加・オンライン参加の人数表示はどうやるか検討中なので、一旦セッション毎の登録者数のみadminで見えるようにする

close https://github.com/cloudnativedaysjp/dreamkast/issues/1857