### PR TITLE
Support redirect to website

### DIFF
--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -1,5 +1,6 @@
 module Secured
   extend ActiveSupport::Concern
+  WEBSITE_BASE_URL = 'https://cloudnativedays.jp'.freeze
 
   included do
     before_action :redirect_to_website
@@ -20,9 +21,9 @@ module Secured
     if set_conference.migrated?
       case [controller_name, action_name]
       in ['talks', 'show']
-        redirect_to("https://cloudnativedays.jp/#{request.fullpath}")
+        redirect_to(URI.join(WEBSITE_BASE_URL, request.fullpath).to_s)
       else
-        redirect_to("https://cloudnativedays.jp/#{params[:event]}")
+        redirect_to(URI.join(WEBSITE_BASE_URL, params[:event]).to_s)
       end
     end
   end

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -2,6 +2,7 @@ module Secured
   extend ActiveSupport::Concern
 
   included do
+    before_action :redirect_to_website
     before_action :to_preparance, :redirect_to_registration, if: :should_redirect?
     before_action :logged_in_using_omniauth?, :to_preparance, :need_order?, if: :use_secured_before_action?
     helper_method :admin?, :speaker?, :beta_user?
@@ -12,6 +13,17 @@ module Secured
       set_current_user
     else
       redirect_to('/auth/login?origin=' + request.fullpath)
+    end
+  end
+
+  def redirect_to_website
+    if set_conference.migrated?
+      case [controller_name, action_name]
+      in ['talks', 'show']
+        redirect_to("https://cloudnativedays.jp/#{request.fullpath}")
+      else
+        redirect_to("https://cloudnativedays.jp/#{params[:event]}")
+      end
     end
   end
 

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -10,7 +10,7 @@ module SecuredAdmin
     if logged_in?
       set_current_user
     else
-      redirect_to("/#{params[:event]}")
+      redirect_to('/auth/login?origin=' + request.fullpath)
     end
   end
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -28,12 +28,14 @@ class Conference < ApplicationRecord
   STATUS_OPENED = 'opened'.freeze
   STATUS_CLOSED = 'closed'.freeze
   STATUS_ARCHIVED = 'archived'.freeze
+  STATUS_MIGRATED = 'migrated'.freeze
 
   enum conference_status: {
     registered: STATUS_REGISTERED,
     opened: STATUS_OPENED,
     closed: STATUS_CLOSED,
-    archived: STATUS_ARCHIVED
+    archived: STATUS_ARCHIVED,
+    migrated: STATUS_MIGRATED
   }
   enum speaker_entry: { speaker_entry_disabled: 0, speaker_entry_enabled: 1 }
   enum attendee_entry: { attendee_entry_disabled: 0, attendee_entry_enabled: 1 }

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -64,6 +64,11 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
       speaker_entry { 0 }
     end
 
+    trait :migrated do
+      conference_status { Conference::STATUS_MIGRATED }
+      speaker_entry { 0 }
+    end
+
     trait :speaker_entry_enabled do
       speaker_entry { 1 }
     end

--- a/spec/requests/admin/speaker_announcements_spec.rb
+++ b/spec/requests/admin/speaker_announcements_spec.rb
@@ -9,11 +9,11 @@ describe Admin::SpeakerAnnouncementsController, type: :request do
   describe 'GET :event/admin/speaker_announcements#index' do
     subject { get(admin_speaker_announcements_path(event: 'cndt2020')) }
     context "user doesn't logged in" do
-      it 'redirect to event top page' do
+      it 'redirect to login page' do
         subject
         expect(response).to_not(be_successful)
         expect(response).to(have_http_status('302'))
-        expect(response).to(redirect_to('/cndt2020'))
+        expect(response).to(redirect_to('/auth/login?origin=/cndt2020/admin/speaker_announcements'))
       end
     end
 

--- a/spec/requests/admin/speakers_spec.rb
+++ b/spec/requests/admin/speakers_spec.rb
@@ -10,11 +10,11 @@ describe Admin::SpeakersController, type: :request do
 
   describe 'GET :event/admin/speakers#index' do
     context "user doesn't logged in" do
-      it 'redirect to event top page' do
+      it 'redirect to login page' do
         get admin_speakers_path(event: 'cndt2020')
         expect(response).to_not(be_successful)
         expect(response).to(have_http_status('302'))
-        expect(response).to(redirect_to('/cndt2020'))
+        expect(response).to(redirect_to('/auth/login?origin=/cndt2020/admin/speakers'))
       end
     end
 

--- a/spec/requests/admin/talks_spec.rb
+++ b/spec/requests/admin/talks_spec.rb
@@ -10,11 +10,11 @@ describe Admin::SpeakersController, type: :request do
 
   describe 'GET :event/admin/talks#index' do
     context "user doesn't logged in" do
-      it 'redirect to event top page' do
+      it 'redirect to login page' do
         get admin_talks_path(event: 'cndt2020')
         expect(response).to_not(be_successful)
         expect(response).to(have_http_status('302'))
-        expect(response).to(redirect_to('/cndt2020'))
+        expect(response).to(redirect_to('/auth/login?origin=/cndt2020/admin/talks'))
       end
     end
 

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -14,7 +14,7 @@ describe AdminController, type: :request do
         get admin_path(event: 'cndt2020')
         expect(response).to_not(be_successful)
         expect(response).to(have_http_status('302'))
-        expect(response).to(redirect_to('/cndt2020'))
+        expect(response).to(redirect_to('/auth/login?origin=/cndt2020/admin'))
       end
     end
 
@@ -68,11 +68,11 @@ describe AdminController, type: :request do
 
   describe 'GET admin#users' do
     context "user doesn't logged in" do
-      it 'redirect to event top page' do
+      it 'redirect to login page' do
         get admin_users_path(event: 'cndt2020')
         expect(response).to_not(be_successful)
         expect(response).to(have_http_status('302'))
-        expect(response).to(redirect_to('/cndt2020'))
+        expect(response).to(redirect_to('/auth/login?origin=/cndt2020/admin/users'))
       end
     end
 

--- a/spec/requests/event_spec.rb
+++ b/spec/requests/event_spec.rb
@@ -4,6 +4,17 @@ describe EventController, type: :request do
   subject(:session) { { userinfo: { info: { email: 'alice@example.com' }, extra: { raw_info: { sub: 'aaaa', 'https://cloudnativedays.jp/roles' => roles } } } } }
   let(:roles) { [] }
 
+  context 'CNDT2020 is migrated' do
+    let!(:cndt2020) { create(:cndt2020, :migrated) }
+
+    it 'redirect to website' do
+      get '/cndt2020'
+      expect(response).to_not(be_successful)
+      expect(response).to(have_http_status('302'))
+      expect(response).to(redirect_to('https://cloudnativedays.jp/cndt2020'))
+    end
+  end
+
   describe 'GET event#show' do
     before do
       create(:cndt2020)

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -5,6 +5,25 @@ describe TalksController, type: :request do
   let(:roles) { [] }
 
   describe 'GET /cndt2020/talks/:id' do
+    context 'CNDT2020 is migrated' do
+      let!(:cndt2020) { create(:cndt2020, :migrated) }
+      let!(:talk1) { create(:talk1) }
+      let!(:talk2) { create(:talk2) }
+      let!(:video) { create(:video) }
+
+      before do
+        create(:talk_category1, conference: cndt2020)
+        create(:talk_difficulties1, conference: cndt2020)
+      end
+
+      it 'redirect to website' do
+        get '/cndt2020/talks/1'
+        expect(response).to_not(be_successful)
+        expect(response).to(have_http_status('302'))
+        expect(response).to(redirect_to('https://cloudnativedays.jp/cndt2020/talks/1'))
+      end
+    end
+
     context 'CNDT2020 is registered' do
       let!(:cndt2020) { create(:cndt2020, :registered) }
       let!(:talk1) { create(:talk1) }
@@ -385,6 +404,17 @@ describe TalksController, type: :request do
 
   describe 'GET /cndt2020/talks' do
     let!(:userinfo) { { userinfo: { info: { email: 'alice@example.com' }, extra: { raw_info: { 'https://cloudnativedays.jp/roles' => 'CNDT2020-Admin', sub: '' } } } } }
+
+    context 'CNDT2020 is migrated' do
+      let!(:cndt2020) { create(:cndt2020, :migrated) }
+
+      it 'redirect to website' do
+        get '/cndt2020/talks'
+        expect(response).to_not(be_successful)
+        expect(response).to(have_http_status('302'))
+        expect(response).to(redirect_to('https://cloudnativedays.jp/cndt2020'))
+      end
+    end
 
     context 'CNDT2020 is registered' do
       before { create(:cndt2020, :registered) }


### PR DESCRIPTION
- Conferenceのstatusをmigratedに変更するとリダイレクトする
- セッションのパーマネントリンクはwebsiteの対応するパーマネントリンクにリダイレクトする
- それ以外のURLはwebsiteの各イベントトップページにリダイレクトする
- adminにアクセスした際にログインしていないとトップページにリダイレクトしていたが、ログインページにリダイレクトするように変更

https://github.com/cloudnativedaysjp/dreamkast/issues/1895