### PR TITLE
cfp投票先をdk-weaverに切り替え

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,7 +105,7 @@ module ApplicationHelper
 
   def vote_api_url
     [
-      ENV.fetch('DREAMKAST_WEAVER_ADDR', 'http://localhost:8080'), 'query'
+      ENV['DREAMKAST_WEAVER_ADDR'], 'query'
     ].join('/')
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,7 +103,9 @@ module ApplicationHelper
     end
   end
 
-  def vote_api_url(id)
-    File.join(ENV['DREAMKAST_API_ADDR'], 'api/v1/talks', id, 'vote')
+  def vote_api_url
+    [
+      ENV.fetch('DREAMKAST_WEAVER_ADDR', 'http://localhost:8080'), 'query'
+    ].join('/')
   end
 end

--- a/app/javascript/packs/vote_cfp.js
+++ b/app/javascript/packs/vote_cfp.js
@@ -21,6 +21,9 @@ toggleVoted = function() {
 }
 
 document.getElementById('vote').addEventListener('click', function() {
+    function print_vote_alert () {
+        alert("投票を受け付けられませんでした。\nしばらく時間をおいてから再度の投票をお願いします。");
+    }
     const voteUrl = document.getElementById('vote').getAttribute('vote_url');
 
     const eventAbbr = document.getElementById('vote').getAttribute('event_name');
@@ -35,16 +38,26 @@ document.getElementById('vote').addEventListener('click', function() {
     const body = JSON.stringify({ query });
     const headers = { 'Content-Type': 'application/json' };
 
-    fetch(voteUrl,{ method, headers, body})
-        .then(r => r.json())
-        .then(data => {
-          if (data.hasOwnProperty('errors')) {
-              alert("投票を受け付けられませんでした。\nしばらく時間をおいてから再度の投票をお願いします。");
-          } else {
-              setVotedId(talkId);
-              toggleVoted();
-          }
-        })
+    try {
+        fetch(voteUrl,{ method, headers, body})
+            .then(r=> {
+              if (!r.ok) {
+                  throw new Error();
+              }
+              data = r.json();
+              if (data.hasOwnProperty('errors')) {
+                  throw new Error();
+              } else {
+                  setVotedId(talkId);
+                  toggleVoted();
+              }
+            })
+            .catch(e => {
+                  print_vote_alert();
+            })
+    } catch(e) {
+        print_vote_alert();
+    }
     return false;
 });
 

--- a/app/javascript/packs/vote_cfp.js
+++ b/app/javascript/packs/vote_cfp.js
@@ -24,13 +24,27 @@ document.getElementById('vote').addEventListener('click', function() {
     const voteUrl = document.getElementById('vote').getAttribute('vote_url');
 
     const eventAbbr = document.getElementById('vote').getAttribute('event_name');
+    const talkId = parseInt(document.getElementById('vote').getAttribute('talk_id'));
     const method = 'POST'
-    const body = JSON.stringify({'eventAbbr': eventAbbr});
-    const headers = {'Content-Type': 'application/json'};
+    const query = `mutation {
+          vote(input: {
+            confName: ${eventAbbr}
+            talkId: ${talkId}
+        })
+    }`;
+    const body = JSON.stringify({ query });
+    const headers = { 'Content-Type': 'application/json' };
 
-    fetch(voteUrl,{ method, headers, body});
-    setVotedId(parseInt(document.getElementById('vote').getAttribute('talk_id')));
-    toggleVoted();
+    fetch(voteUrl,{ method, headers, body})
+        .then(r => r.json())
+        .then(data => {
+          if (data.hasOwnProperty('errors')) {
+              alert("投票を受け付けられませんでした。\nしばらく時間をおいてから再度の投票をお願いします。");
+          } else {
+              setVotedId(talkId);
+              toggleVoted();
+          }
+        })
     return false;
 });
 

--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -8,17 +8,17 @@
         <%= render 'talks/partial_show/facebook_share_button', url: request.original_url %>
       </h3>
       <h4>
-        <% if talk.start_time.present? && 
+        <% if talk.start_time.present? &&
               talk.end_time.present? &&
               talk.conference_day.present? %>
-          Track <%= talk.track.name %> 
-          <%= talk.conference_day.date.strftime("%Y/%m/%d") %> 
+          Track <%= talk.track.name %>
+          <%= talk.conference_day.date.strftime("%Y/%m/%d") %>
           <%= talk.start_time.strftime("%H:%M") %>-<%= talk.end_time.strftime("%H:%M") %>
         <% elsif talk.proposal.present? && !talk.sponsor_session? %>
-          Proposal 
+          Proposal
           <% case talk.proposal.status %>
           <% when "registered" %>
-          (採択待ち) 
+          (採択待ち)
           <% when "accepted" %>
           (採択)
           <% when "rejected" %>
@@ -38,7 +38,7 @@
       <div class="row py-3">
         <div class="col-auto col-md-auto">
           <% if talk.proposal.present? && talk.proposal.status == 'registered' %>
-            <button class="btn btn-primary inline" id="vote" vote_url="<%= vote_api_url(talk.id.to_s) %>" event_name="<%= @conference.abbr %>" talk_id="<%= talk.id %>" type="button">👍投票する</button>
+            <button class="btn btn-primary inline" id="vote" vote_url="<%= vote_api_url %>" event_name="<%= @conference.abbr %>" talk_id="<%= talk.id %>" type="button">👍投票する</button>
           <% end %>
         </div>
       </div>

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -31,6 +31,7 @@ services:
       SQS_FIFO_QUEUE_URL: http://localstack:4566/000000000000/default
       REVIEW_APP: "true"
       DREAMKAST_NAMESPACE: "localhost"
+      DREAMKAST_WEAVER_ADDR: "localhost:8080"
     tty: true
     stdin_open: true
     tmpfs:


### PR DESCRIPTION
fix: #1896 
CFP の投票先を dk-weaver に切り替えました。
GraphQL のクエリは #1896 に準拠しつつ、コミットが進んだ分を追従しています。

環境変数から URL を取得していましたが、キー名を `DREAMKAST_API_ADDR` から `DREAMKAST_WEAVER_ADDR` に変更していますので、そちらにも対応が必要になりますが、こちらはまだ確定していないとのことなので現段階では未対応です。

WEAVER へのリクエストが失敗した場合にはアラートで対応するように仕様を変更していますが、こちらサーバーレスポンスが失敗した場合（500エラーなど）にはアクションが何も起こらない状態です。
この変更については検討の余地ありだと思いますので、（エラーハンドリングの場合分けを追加する/エラーは無視して投票済みへの切り替えを行う等）、ご意見をお伺いしたいところです。

![スクリーンショット 2023-05-01 221844](https://user-images.githubusercontent.com/40717789/235458814-0dcd065f-1351-4330-a5bf-cc6ad2c7a4b1.png)
