### PR TITLE
Fetch conference days in single query to improve performance

### DIFF
--- a/app/controllers/api/v1/conferences_controller.rb
+++ b/app/controllers/api/v1/conferences_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ConferencesController < ApplicationController
   def index
-    @conferences = Conference.all
+    @conferences = Conference.includes([:conference_days]).all
     render(:index, formats: :json, type: :jbuilder)
   end
 


### PR DESCRIPTION
`/api/v1/events` 呼び出し時にconference_daysの取得クエリがイベントの数だけ呼ばれていて非効率なのを修正