### PR TITLE
タイムテーブルを非表示にしていてもセッション個別ページに表示されてしまっている

### DIFF
--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -73,9 +73,11 @@
         <%= link_to "このイベントに参加申し込み <br/> (参加無料)".html_safe, registration_path, {method: :get, class: "btn btn-focus btn-xl inline" } %>
       </div>
       <% end %>
-      <div class="col-12 text-center my-4">
-        <%= button_to 'タイムテーブル', timetables_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
-      </div>
+      <% if @conference.present? && @conference.show_timetable_enabled? %>
+        <div class="col-12 text-center my-4">
+          <%= button_to 'タイムテーブル', timetables_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -82,6 +82,14 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
       speaker_entry { 0 }
     end
 
+    trait :show_timetable do
+      show_timetable { 1 }
+    end
+
+    trait :hide_timetable do
+      show_timetable { 0 }
+    end
+
     trait :cfp_result_visible do
       cfp_result_visible { true }
     end

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -5,6 +5,28 @@ describe TalksController, type: :request do
   let(:roles) { [] }
 
   describe 'GET /cndt2020/talks/:id' do
+    context 'show timetable' do
+      let!(:cndt2020) { create(:cndt2020, :registered, :speaker_entry_enabled, :show_timetable) }
+      let!(:talk1) { create(:talk1) }
+
+      it 'includes timetable button' do
+        get '/cndt2020/talks/1'
+        expect(response).to(be_successful)
+        expect(response.body).to(include('タイムテーブル'))
+      end
+    end
+
+    context 'hide timetable' do
+      let!(:cndt2020) { create(:cndt2020, :registered, :speaker_entry_enabled, :hide_timetable) }
+      let!(:talk1) { create(:talk1) }
+
+      it 'does not includes timetable button' do
+        get '/cndt2020/talks/1'
+        expect(response).to(be_successful)
+        expect(response.body).not_to(include('タイムテーブル'))
+      end
+    end
+
     context 'CNDT2020 is migrated' do
       let!(:cndt2020) { create(:cndt2020, :migrated) }
       let!(:talk1) { create(:talk1) }


### PR DESCRIPTION
close https://github.com/cloudnativedaysjp/dreamkast/issues/1911