### PR TITLE
remove e2e gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,12 +63,6 @@ group :development do
 end
 
 group :test do
-  # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '>= 2.15'
-  gem 'selenium-webdriver'
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
-
   gem 'rexml', '~> 3.2', '>= 3.2.4'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,16 +140,6 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    capybara (3.37.1)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-    childprocess (4.1.0)
     coderay (1.1.3)
     committee (5.0.0)
       json_schema (~> 0.14, >= 0.14.3)
@@ -235,7 +225,6 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    matrix (0.4.2)
     method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
@@ -594,7 +583,6 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -611,11 +599,6 @@ GEM
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
-    selenium-webdriver (4.4.0)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
     semantic_range (3.0.0)
     sentry-opentelemetry (5.9.0)
       opentelemetry-sdk (~> 1.0)
@@ -692,21 +675,14 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -726,7 +702,6 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   bullet
   byebug
-  capybara (>= 2.15)
   committee
   committee-rails
   execjs
@@ -765,7 +740,6 @@ DEPENDENCIES
   rubocop-rspec (>= 2.0.0)
   sass-rails (>= 6)
   seed-fu
-  selenium-webdriver
   sentry-opentelemetry
   sentry-rails
   sentry-ruby
@@ -780,7 +754,6 @@ DEPENDENCIES
   tzinfo-data
   uppy-s3_multipart (~> 1.0)
   web-console (>= 3.3.0)
-  webdrivers
   webpacker (~> 5.0)
 
 RUBY VERSION


### PR DESCRIPTION
Capybara を始め E2E 関連の Gem がいくつか renovate されていたが、現状 E2E テスト（実際に UI を描画して動かすテスト）は実施しておらず、また直近導入予定もないので削除しておきたい。
また、bundle install 時に rubyzip がバージョン警告を出しているがこれは Capybara の依存関係としてしか取り込まれていない。