### PR TITLE
fix

### DIFF
--- a/app/views/event/cndf2023_show.html.erb
+++ b/app/views/event/cndf2023_show.html.erb
@@ -52,8 +52,6 @@
             <% else %>
               <%= render 'event/partial/speaker_entry_button', conference: @conference %>
               <%= render 'event/partial/attendee_entry_button', conference: @conference %>
-              <p>一般申込み開始: 6月後半</p>
-              <p></p>
               <p>観光需要の回復に伴い、宿泊施設の予約が困難になる可能性があります。<br/>現地参加を検討されている県外在住の皆様は、是非お早めの予約をお願い致します！</p>
               
             <% end %>

--- a/app/views/event/cndf2023_show.html.erb
+++ b/app/views/event/cndf2023_show.html.erb
@@ -75,13 +75,13 @@
           <div class="grid" style="--rows: 13">
             <div class="all-track" style="">
               <div class="session">
-                <h6>12:00 - 12:10</h6>
+                <h6>10:50 - 11:00</h6>
                 <h4>オープニング</h4>
               </div>
             </div>
           </div>
           <div class="grid"
-              style="--rows: <%= ((conference_day.end_time.hour - conference_day.start_time.hour) * 60) + 10 - 120 %>">
+              style="--rows: <%= ((conference_day.end_time - conference_day.start_time).to_i / 60) - 140 + 10 %>">
             <% @conference.tracks.map(&:name).each_with_index do |track_name, n| %>
                 <div class="track <%= 'even' if n.zero? || n.even? %>"
                     style="--track: <%= n %>"><%= "Track #{track_name}" %></div>
@@ -89,11 +89,18 @@
 
             <% conference_day.talks.where(show_on_timetable: true).each do |talk| %>
               <%
-                # 休み時間を除外
-                lunch_break = 10
-                each_break = 0
-                each_break = (talk.start_time.in_time_zone('Asia/Tokyo').hour - 13) * 20
-                row_start = ((talk.start_time.in_time_zone('Asia/Tokyo') - Time.zone.parse("2000-01-01 12:20")) / 60).to_i - each_break - lunch_break
+                if talk.start_time.in_time_zone('Asia/Tokyo').hour < 14
+                  lunch_break = 0
+                  each_break = 0
+                else
+                  # 14時以降のセッションについてはお昼休みとセッション間休憩を除外
+                  lunch_break = 55
+                  each_break = (talk.start_time.in_time_zone('Asia/Tokyo').hour - 14) * 20
+                end
+                
+                total_break = lunch_break + each_break
+
+                row_start = ((talk.start_time.in_time_zone('Asia/Tokyo') - Time.zone.parse("2000-01-01 10:50")) / 60).to_i - total_break
                 row_end = ((talk.end_time - talk.start_time).to_i / 60) + row_start
               %>
               <div class="talk"
@@ -126,7 +133,15 @@
       <div class="grid" style="--rows: 13">
         <div class="all-track" style="">
           <div class="session">
-            <h6>18:20 - 19:50</h6>
+            <h6>18:50 - 19:00</h6>
+            <h4>クロージング</h4>
+          </div>
+        </div>
+      </div>
+      <div class="grid" style="--rows: 13">
+        <div class="all-track" style="">
+          <div class="session">
+            <h6>19:00 - 20:00</h6>
             <h4>よるイベ</h4>
           </div>
         </div>

--- a/app/views/profile_mailer/registered.text.erb
+++ b/app/views/profile_mailer/registered.text.erb
@@ -8,9 +8,9 @@
 <%- first_day = conference_days.first -%>
 <%- day_of_the_week =  days[first_day.date.strftime("%w").to_i] -%>
 <%- if conference_days.length == 1 -%>
-<%= @conference.name %> は<%= "#{first_day.date.strftime("%-m月%d日")}(#{day_of_the_week})#{first_day.start_time.strftime("%H")}" %>時に開催されます。
+<%= @conference.name %> は<%= "#{first_day.date.strftime("%-m月%d日")}(#{day_of_the_week})#{first_day.start_time.strftime("%H:%M")}" %>に開催されます。
 <%- else -%>
-<%= @conference.name %> は<%= "#{first_day.date.strftime("%-m月%d日")}(#{day_of_the_week})#{first_day.start_time.strftime("%H")}" %>時から<%= conference_days.length %>日間にわたり開催されます。
+<%= @conference.name %> は<%= "#{first_day.date.strftime("%-m月%d日")}(#{day_of_the_week})#{first_day.start_time.strftime("%H:%M")}" %>から<%= conference_days.length %>日間にわたり開催されます。
 <%- end -%>
 時間になりましたら CloudNative Days サイトにログインしていただくと
 そのまま視聴画面に切り替わります。

--- a/lib/tasks/modify_session_time_for_keynote_cndf2023.rake
+++ b/lib/tasks/modify_session_time_for_keynote_cndf2023.rake
@@ -4,7 +4,7 @@ namespace :db do
     ActiveRecord::Base.logger = Logger.new($stdout)
     Rails.logger.level = Logger::DEBUG
 
-    keynotes = [1907, 1910, 1561, 1911, 1913]
+    keynotes = [1907, 1910, 1882, 1911, 1913]
 
     ActiveRecord::Base.transaction do
       begin

--- a/spec/mailers/profile_mailer_spec.rb
+++ b/spec/mailers/profile_mailer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe(ProfileMailer, type: :mailer) do
 
       it { expect(mail.body.encoded).to(include('こんにちは、Tester Test さん。')) }
       it { expect(mail.body.encoded).to(include('この度はOne Day Conferenceにご登録いただき、誠にありがとうございます。')) }
-      it { expect(mail.body.encoded).to(include('One Day Conference は3月11日(木)13時に開催されます')) }
+      it { expect(mail.body.encoded).to(include('One Day Conference は3月11日(木)13:00に開催されます')) }
       it { expect(mail.body.encoded).to(include('https://event.cloudnativedays.jp/oneday')) }
       it { expect(mail.body.encoded).to(include('それでは、Tester Test さんのご参加を心からお待ちしております！')) }
     end
@@ -49,7 +49,7 @@ RSpec.describe(ProfileMailer, type: :mailer) do
 
       it { expect(mail.body.encoded).to(include('こんにちは、Tester Test さん。')) }
       it { expect(mail.body.encoded).to(include('この度はTwo Day Conferenceにご登録いただき、誠にありがとうございます。')) }
-      it { expect(mail.body.encoded).to(include('Two Day Conference は3月11日(木)13時から2日間にわたり開催されます。')) }
+      it { expect(mail.body.encoded).to(include('Two Day Conference は3月11日(木)13:00から2日間にわたり開催されます。')) }
       it { expect(mail.body.encoded).to(include('https://event.cloudnativedays.jp/twoday')) }
       it { expect(mail.body.encoded).to(include('それでは、Tester Test さんのご参加を心からお待ちしております！')) }
     end


### PR DESCRIPTION
- トップページのタイムテーブルが崩れていたので修正
- メールの文面が00分以外の表記に対応していなかったので修正
- キーノートのIDが漏れていたので修正(先に手動対応済み)
- 一般申込み開始時期の文面削除