### PR TITLE
env_nameの条件にS3バケット名を使っていて、バケットを変えたので正しくenv_nameが出なくなった問題を修正

### DIFF
--- a/app/helpers/env_helper.rb
+++ b/app/helpers/env_helper.rb
@@ -2,9 +2,9 @@ module EnvHelper
   def env_name
     if ENV['REVIEW_APP'] == 'true'
       'review_app'
-    elsif ENV['S3_BUCKET'] == 'dk-us-stg-bucket'
+    elsif ENV['S3_BUCKET'] == 'dreamkast-stg-bucket'
       'staging'
-    elsif ENV['S3_BUCKET'] == 'dreamkast-prd-bucket'
+    elsif ENV['S3_BUCKET'] == 'dreamkast-prod-bucket'
       'production'
     else
       'others'


### PR DESCRIPTION
環境変数でprod/stagingなど識別できるようにした方がいいが、それは別途やります