### PR TITLE
サムネイルサイズの指定の誤りを修正

### DIFF
--- a/app/views/admin/speakers/_form.html.erb
+++ b/app/views/admin/speakers/_form.html.erb
@@ -39,7 +39,7 @@
     <% if speaker.avatar_url.nil? %>
       <div class="avatar">Avatar: <%= image_tag 'dummy.png', :size => '80x80'  %></div>
     <% else %>
-      <div class="avatar">Avatar: <%= image_tag speaker.avatar_url, :size => '80x80'  %></div>
+      <div class="avatar">Avatar: <%= image_tag speaker.avatar_url(:small) || avatar_url, :size => '80x80'  %></div>
     <% end %>
   </div>
 

--- a/app/views/attendees/index.html.erb
+++ b/app/views/attendees/index.html.erb
@@ -21,7 +21,7 @@
           <% if public_profile.avatar_url.nil? %>
             <%= image_tag "dummy.png", :size => '40x40', class: 'card-img-top, rounded-circle' %>
           <% else %>
-            <%= image_tag public_profile.avatar_url, :size => '40x40', class: 'card-img-top, rounded-circle' %>
+            <%= image_tag public_profile.avatar_url(:medium), :size => '40x40', class: 'card-img-top, rounded-circle' %>
           <% end %>
         </td>
         <td>

--- a/app/views/attendees/index.html.erb
+++ b/app/views/attendees/index.html.erb
@@ -21,7 +21,7 @@
           <% if public_profile.avatar_url.nil? %>
             <%= image_tag "dummy.png", :size => '40x40', class: 'card-img-top, rounded-circle' %>
           <% else %>
-            <%= image_tag public_profile.avatar_url(:medium), :size => '40x40', class: 'card-img-top, rounded-circle' %>
+            <%= image_tag public_profile.avatar_url(:small), :size => '40x40', class: 'card-img-top, rounded-circle' %>
           <% end %>
         </td>
         <td>

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -9,7 +9,7 @@
             <% if speaker.avatar_url.nil? %>
                 <%= image_tag 'dummy.png', :size => '80x80'  %>
             <% else %>
-                <%= image_tag speaker.avatar_url, :size => '80x80'  %>
+                <%= image_tag speaker.avatar_url(:small) || speaker.avatar_url, :size => '80x80'  %>
             <% end %>
             </div>
             <div class="card-body">

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -7,7 +7,7 @@
       <% if @speaker.avatar_url.nil? %>
         <%= image_tag "dummy.png", :size => '90x90'  %>
       <% else %>
-        <%= image_tag @speaker.avatar_url, :size => '90x90'  %>
+        <%= image_tag @speaker.avatar_url(:small) || @speaker.avatar_url, :size => '90x90'  %>
       <% end %>
       <% if @speaker.profile != "" %>
         <p class="card-text">Profile: <%= @speaker.profile %></p>


### PR DESCRIPTION
数か所でサイズ指定のないサムネイル表示があり、元画像を表示していたためサイズ指定に修正