### PR TITLE
crop に失敗した画像の場合元画像を出すようにする

### DIFF
--- a/app/views/attendees/index.html.erb
+++ b/app/views/attendees/index.html.erb
@@ -21,7 +21,7 @@
           <% if public_profile.avatar_url.nil? %>
             <%= image_tag "dummy.png", :size => '40x40', class: 'card-img-top, rounded-circle' %>
           <% else %>
-            <%= image_tag public_profile.avatar_url(:small), :size => '40x40', class: 'card-img-top, rounded-circle' %>
+            <%= image_tag public_profile.avatar_url(:small) || public_profile.avatar_url, :size => '40x40', class: 'card-img-top, rounded-circle' %>
           <% end %>
         </td>
         <td>


### PR DESCRIPTION
crop できていない画像の場合 `avatar_url(:medium)` の部分で失敗してエラーになっているので追加修正