### PR TITLE
Offair talks having same track id and different conference_day_id

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -345,7 +345,7 @@ class Talk < ApplicationRecord
     ActiveRecord::Base.transaction do
       other_talks_in_track = conference.tracks.find_by(name: track.name).talks
                                        .accepted_and_intermission
-                                       .select { |t| t.conference_day.id == conference_day.id && t.id != id }
+                                       .select { |t| t.conference.id == conference.id && t.id != id }
       other_talks_in_track.each do |other_talk|
         other_talk.video.update!(on_air: false)
       end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -345,7 +345,7 @@ class Talk < ApplicationRecord
     ActiveRecord::Base.transaction do
       other_talks_in_track = conference.tracks.find_by(name: track.name).talks
                                        .accepted_and_intermission
-                                       .select { |t| t.conference.id == conference.id && t.id != id }
+                                       .select { |t| t.id != id }
       other_talks_in_track.each do |other_talk|
         other_talk.video.update!(on_air: false)
       end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -345,7 +345,7 @@ class Talk < ApplicationRecord
     ActiveRecord::Base.transaction do
       other_talks_in_track = conference.tracks.find_by(name: track.name).talks
                                        .accepted_and_intermission
-                                       .select { |t| t.id != id }
+                                       .reject { |t| t.id == id }
       other_talks_in_track.each do |other_talk|
         other_talk.video.update!(on_air: false)
       end

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -42,10 +42,12 @@ describe Talk, type: :model do
     before do
       create(:cndt2020)
     end
-    let!(:talk1) { create(:talk1, :accepted) }
+    let!(:talk1) { create(:talk1, :accepted, track_id: 1) }
     let!(:talk2) { create(:talk2, :accepted, :conference_day_id_1) }
+    let!(:talk3) { create(:talk3, :accepted, track_id: 1) }
     let!(:video1) { create(:video, :off_air) }
     let!(:video2) { create(:video, :on_air, :talk2) }
+    let!(:video3) { create(:video, :on_air, :talk3) }
     context 'start streaming talk1' do
       before do
         talk1.start_streaming
@@ -53,6 +55,10 @@ describe Talk, type: :model do
 
       it 'should be on_air' do
         expect(talk1.video.on_air).to(eq(true))
+      end
+
+      it "shouldn't be on_air whatever talks has different conference_day_id" do
+        expect(talk3.video.on_air).to(eq(false))
       end
 
       example 'talk in the same track and same conference_day should be off_air' do


### PR DESCRIPTION
Fix #2001

2001の修正方法として
- 既に別日でOnAirのTalkがある場合は受け付けない
- 別日でOnAirがあった場合は、そちらをオフにしてリクエスト側をオンにする

の2つのアプローチがあるが、UIは前者のアプローチでバリデーションしている。これはUIの構成上誤操作のリスクがあるので好ましい動作。

しかしAPIの利用シーン的には後者のほうが便利だし、誤操作のリスクはそれほど高くない(talk_idを明示するので曜日を誤指定することは考えづらい)
そのため、フィルタリング条件を変更して別日であっても自動的にオフになるようにした