### PR TITLE
workflowにBuildjetを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Create a New Image
         run: |
           image_tag_sha="${{ steps.login-ecr.outputs.registry }}/dreamkast-ecs:${{ github.sha }}"
-          image_tag_ref="${{ steps.login-ecr.outputs.registry }}${{ steps.meta.outputs.tags }}"
+          image_tag_ref="${{ steps.meta.outputs.tags }}"
 
 
           docker buildx imagetools create \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,22 +64,23 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-
-
   merge-images:
     runs-on: "ubuntu-latest"
     needs: ["build"]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
       - name: Docker meta
         id: meta
@@ -89,9 +90,6 @@ jobs:
           tags: |
             type=ref,event=branch
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
       - name: Create a New Image
         run: |
           image_tag_sha="${{ steps.login-ecr.outputs.registry }}/dreamkast-ecs:${{ github.sha }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,16 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runs-on:
+          - "ubuntu-latest"
+          - "buildjet-2vcpu-ubuntu-2204-arm"
+    runs-on: ${{ matrix.runs-on }}
     if: github.event.pusher.name != 'dreamkast-cloudnativedays'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         id: buildx
@@ -33,19 +39,69 @@ jobs:
             type=sha,prefix=,format=long
             type=ref,event=branch
 
+      - name: Prepare-tag
+        id: tags
+        run: |
+          arch=""
+          # https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
+          case "${{ runner.arch }}" in
+            "X64" ) arch="amd64" ;;
+            "ARM64" ) arch="arm64" ;;
+          esac
+
+          echo "tag=${{ github.sha }}-${arch}" >> $GITHUB_OUTPUT
+
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v4
         with:
           context: ./
           file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
           push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/dreamkast-ecs:${{ steps.tags.outputs.tag }}
           provenance: false
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+
+
+  merge-images:
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/dreamkast-ecs
+          tags: |
+            type=ref,event=branch
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Create a New Image
+        run: |
+          image_tag_sha="${{ steps.login-ecr.outputs.registry }}/dreamkast-ecs:${{ github.sha }}"
+          image_tag_ref="${{ steps.login-ecr.outputs.registry }}${{ steps.meta.outputs.tags }}"
+
+
+          docker buildx imagetools create \
+            --tag ${image_tag_ref} --tag ${image_tag_sha}\
+            ${image_tag_sha}-arm64 \
+            ${image_tag_sha}-amd64
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
Graviton対応に向けて、ARM対応イメージをビルドするBuildjetを追加する。

懸念事項
1. 実行する時間帯によってbuildjetによるビルドがいつまでも終わらないケースがある。
    - 通常約8分で終わるところ、17分以上かかっても終わらない
      - 正常終了したworkflow
        - https://github.com/cloudnativedaysjp/dreamkast/actions/runs/5914172251
      - 終了しないworkflow
        - https://github.com/cloudnativedaysjp/dreamkast/actions/runs/5912169199
    - 22時以降に実施すると終わらない場合が多い。
    - 朝、日中に実施した場合は問題なし。
    - buildjet側のstatusにパフォーマンス低下の通知が来ているがリアルタイムには分からない
      - https://status.buildjet.com/