### PR TITLE
checkbox と radio_button をラベルリンクする

### DIFF
--- a/app/views/speaker_dashboard/speakers/_presentation_method.html.erb
+++ b/app/views/speaker_dashboard/speakers/_presentation_method.html.erb
@@ -1,6 +1,6 @@
 <% if f.object.proposal && f.object.proposal.accepted? %>
   <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, disabled: 'disabled'} %>
 <% else %>
-  <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params} %>
+  <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, id: "#{label}_#{item.params}"} %>
 <% end %>
 <%= label label, item.params, {class: 'form-check-label'} %><br>

--- a/app/views/speaker_dashboard/speakers/_session_times.html.erb
+++ b/app/views/speaker_dashboard/speakers/_session_times.html.erb
@@ -2,6 +2,6 @@
 <% if (label == :session_times && item.key.to_i == SessionTime::TWENTY_MINUTES) || (f.object.proposal && f.object.proposal.accepted?)  %>
   <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, disabled: 'disabled'} %>
 <% else %>
-  <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params} %>
+  <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, id: "#{label}_#{item.params}"} %>
 <% end %>
 <%= label label, item.params, {class: 'form-check-label'} %><br>

--- a/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
+++ b/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
@@ -54,7 +54,7 @@
           <% @conference.proposal_item_configs.where(item_number: item_number).each do |item|%>
             <% label = item.label.pluralize.to_sym %>
             <% checked = existing_items ? existing_items.include?(item.id.to_s) : false%>
-            <%= check_box_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}][]", item.id, checked, {id: "speaker_talks_attributes_#{f.options[:child_index]}_#{label}", class: 'form-check-input'} %>
+            <%= check_box_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}][]", item.id, checked, {id: "speaker_talks_attributes_#{f.options[:child_index]}_#{label}", class: 'form-check-input', id: "#{label}_#{item.params}"} %>
             <%= label label, item.params, {class: 'form-check-label'} %><br>
           <% end %>
         </div>
@@ -73,7 +73,7 @@
           <% when 'session_time' then %>
             <%= render 'speaker_dashboard/speakers/session_times', f: f, existing_items: existing_items, first_item: first_item, item: item, classes: classes, label: label, checked: checked %>
           <% else %>
-            <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params} %>
+            <%= radio_button_tag "speaker[talks_attributes][#{f.options[:child_index]}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, id: "#{label}_#{item.params}"} %>
             <%= label label, item.params, {class: 'form-check-label'} %><br>
           <% end %>
         <% end %>


### PR DESCRIPTION
CFP のフォームでチェックボックスとラジオボタンが input のみに入力判定があり、ラベルの文字列をクリックしても反応しない状態だったのでラベルでも入力できるようにしました。