### PR TITLE
AWS上の配信用リソースを管理するためのstreamingsテーブルとStreamingモデルを追加する

### DIFF
--- a/app/controllers/admin/streamings_controller.rb
+++ b/app/controllers/admin/streamings_controller.rb
@@ -1,0 +1,41 @@
+class Admin::StreamingsController < ApplicationController
+  include SecuredAdmin
+
+
+  def index
+    @tracks = @conference.tracks
+  end
+
+  def create
+    @streaming = Streaming.new(streaming_params.merge(conference_id: @conference.id))
+
+    respond_to do |format|
+      if @streaming.save && create_aws_resources
+        format.html { redirect_to(admin_streamings_path, notice: 'Streaming AWS Resources is creating...') }
+        format.json { render(:show, status: :ok, location: @job) }
+      else
+        format.html { redirect_to(admin_streaming_path, flash: { error: @job.errors.messages }) }
+        format.json { render(json: @job.errors, status: :unprocessable_entity) }
+      end
+    end
+  end
+
+  def create_aws_resources
+    @streaming ||= Streaming.find(params[:id])
+    CreateStreamingAwsResourcesJob.perform_later(@streaming)
+  end
+
+  def delete_aws_resources
+    @streaming ||= Streaming.find(params[:id])
+    DeleteStreamingAwsResourcesJob.perform_later(@streaming)
+    @streaming.update!(status: 'deleting')
+    respond_to do |format|
+      format.html { redirect_to(admin_streamings_path, notice: 'Streaming AWS Resources is deleting...') }
+      format.json { head(:no_content) }
+    end
+  end
+
+  def streaming_params
+    params.require(:streaming).permit(:id, :conference_id, :track_id, :status)
+  end
+end

--- a/app/controllers/admin/streamings_controller.rb
+++ b/app/controllers/admin/streamings_controller.rb
@@ -30,7 +30,7 @@ class Admin::StreamingsController < ApplicationController
     DeleteStreamingAwsResourcesJob.perform_later(@streaming)
     @streaming.update!(status: 'deleting')
     respond_to do |format|
-      format.html { redirect_to(admin_streamings_path, notice: 'Streaming AWS Resources is deleting...') }
+      format.html { redirect_to(admin_streamings_path, notice: 'Deleting AWS streaming resources...') }
       format.json { head(:no_content) }
     end
   end

--- a/app/controllers/admin/streamings_controller.rb
+++ b/app/controllers/admin/streamings_controller.rb
@@ -11,7 +11,7 @@ class Admin::StreamingsController < ApplicationController
 
     respond_to do |format|
       if @streaming.save && create_aws_resources
-        format.html { redirect_to(admin_streamings_path, notice: 'Streaming AWS Resources is creating...') }
+        format.html { redirect_to(admin_streamings_path, notice: 'Creating AWS streaming resources. Please wait few minutes') }
         format.json { render(:show, status: :ok, location: @job) }
       else
         format.html { redirect_to(admin_streaming_path, flash: { error: @job.errors.messages }) }

--- a/app/controllers/api/v1/streamings_controller.rb
+++ b/app/controllers/api/v1/streamings_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::StreamingsController < ApplicationController
+  include SecuredPublicApi
+
+  def index
+    @conference ||= Conference.find_by(abbr: params[:eventAbbr])
+    @streamings = @conference.streamings
+  end
+end

--- a/app/jobs/create_streaming_aws_resources_job.rb
+++ b/app/jobs/create_streaming_aws_resources_job.rb
@@ -1,0 +1,19 @@
+class CreateStreamingAwsResourcesJob < ApplicationJob
+  include EnvHelper
+  include LogoutHelper
+
+  # queue_as :default
+  self.queue_adapter = :async
+
+  def perform(*args)
+    # Rails.logger.level = Logger::DEBUG
+    logger.info('Perform CreateMediaPackageV2Job')
+    @streaming = args[0]
+
+    @streaming.update!(status: 'created')
+  rescue => e
+    @streaming.update!(status: 'error')
+    logger.error(e.message)
+    logger.error(e.backtrace.join("\n"))
+  end
+end

--- a/app/jobs/delete_streaming_aws_resources_job.rb
+++ b/app/jobs/delete_streaming_aws_resources_job.rb
@@ -1,0 +1,18 @@
+class DeleteStreamingAwsResourcesJob < ApplicationJob
+  include EnvHelper
+  include LogoutHelper
+
+  # queue_as :default
+  self.queue_adapter = :async
+
+  def perform(*args)
+    # Rails.logger.level = Logger::DEBUG
+    logger.info('Perform DeleteStreamingAwsResourcesJob')
+    @streaming = args[0]
+
+    @streaming.update!(status: 'deleted')
+  rescue => e
+    logger.error(e.message)
+    logger.error(e.backtrace.join("\n"))
+  end
+end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -58,6 +58,7 @@ class Conference < ApplicationRecord
   has_many :talk_times
   has_many :talk_categories
   has_many :talk_difficulties
+  has_many :streamings
   has_many :speakers
   has_many :announcements
   has_many :speaker_announcements

--- a/app/models/streaming.rb
+++ b/app/models/streaming.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: streamings
+#
+#  id            :string(255)      not null, primary key
+#  status        :string(255)      not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  conference_id :bigint           not null
+#  track_id      :bigint           not null
+#
+# Indexes
+#
+#  index_streamings_on_conference_id               (conference_id)
+#  index_streamings_on_conference_id_and_track_id  (conference_id,track_id) UNIQUE
+#  index_streamings_on_track_id                    (track_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#  fk_rails_...  (track_id => tracks.id)
+#
+
+class Streaming < ApplicationRecord
+  before_create :set_uuid
+
+  belongs_to :conference
+  belongs_to :track
+
+  STATUS_CREATING = 'creating'.freeze
+  STATUS_CRTEATED = 'created'.freeze
+  STATUS_DELETING = 'deleting'.freeze
+  STATUS_DELETED  = 'deleted'.freeze
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -22,6 +22,8 @@ class Track < ApplicationRecord
   has_one :live_stream_ivs
   has_one :live_stream_media_live
   has_one :media_package_channel
+  has_one :streaming
+
   belongs_to :room, optional: true
 
   def on_air_talk

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -17,6 +17,7 @@
     <%= render 'admin/nav_item', name: 'TimeTable', path: admin_timetables_path, active: controller_name == 'timetables' %>
     <%= render 'admin/nav_item', name: 'Tracks', path: admin_tracks_path, active: controller_name == 'tracks'%>
     <%= render 'admin/nav_item', name: 'IVS', path: admin_live_stream_ivs_path, active: action_name == 'live_stream_ivs' %>
+    <%= render 'admin/nav_item', name: 'Streaming AWS Resources', path: admin_streamings_path, active: action_name == 'streaming' %>
     <%= render 'admin/nav_item', name: 'HarvestJobs', path: admin_harvest_jobs_path, active: action_name == 'media_package_harvest_job' %>
     <%= render 'admin/nav_item', name: 'Statistics', path: admin_statistics_path, active: action_name == 'statistics' %>
     <%= render 'admin/nav_item', name: 'Sponsors', path: admin_sponsors_path, active: controller_name == 'sponsors' || action_name == 'show_sponsor' %>

--- a/app/views/admin/streamings/index.html.erb
+++ b/app/views/admin/streamings/index.html.erb
@@ -1,0 +1,59 @@
+<%= render 'admin/layout' do %>
+  <div class="row mb-2">
+    <div class="col-10 d-flex align-items-center">
+      <h2>配信用AWSリソース管理</h2>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-10">
+      <h3>Track毎の配信用リソース一覧</h3>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
+      <table class="table table-striped talks_table" >
+        <thead>
+        <tr>
+          <th scope="col">Track</th>
+          <th scope="col">リソース</th>
+          <th scope="col">一括作成</th>
+          <th scope="col">一括削除</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% @tracks.each do |track| %>
+          <tr>
+            <td>
+              <%= track.name %>
+            </td>
+            <td>
+              <% if track.streaming %>
+                <%= track.streaming.status %>
+              <% end %>
+            </td>
+            <td>
+              <% if track.streaming && %w(deleted error).include?(track.streaming.status) %>
+                <%= button_to("配信用リソースを一括作成", admin_create_aws_resources_path(id: track.streaming.id), {method: :post, class: "btn btn-primary"}) %>
+              <% elsif track.streaming.nil? || track.streaming.status == 'deleted' %>
+                <%= form_with(url: admin_streamings_path, model: Streaming.new, method: :post, local: true) do |form| %>
+                  <%= form.hidden_field :conference_id, value: @conference.id %>
+                  <%= form.hidden_field :track_id, value: track.id %>
+                  <%= form.hidden_field :status, value: 'creating' %>
+                  <%= form.submit "配信用リソースを一括作成", class: "btn btn-primary" %>
+                <% end %>
+              <% end %>
+            </td>
+            <td>
+              <% if track.streaming && track.streaming.status != 'deleted' %>
+                <%= button_to("配信用リソースを一括削除", admin_delete_aws_resources_path(id: track.streaming.id), {method: :post, class: "btn btn-primary"}) %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/api/v1/streamings/index.json.jbuilder
+++ b/app/views/api/v1/streamings/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@streamings) do |streaming|
+  json.id(streaming.id)
+  json.status(streaming.status)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       resources :proposals, only: [:index]
       resources :speakers, only: [:index]
       resources :tracks, only: [:index, :show]
+      resources :streamings, only: [:index]
       resources :sponsors, only: [:index]
       resources :speakers, only: [:index, :show]
       resources :chat_messages, only: [:index, :create, :update]
@@ -61,6 +62,10 @@ Rails.application.routes.draw do
       resource :timetable, only: [:update]
       resources :announcements
       resources :speaker_announcements
+      resources :streamings
+      post 'create_aws_resources' => 'streamings#create_aws_resources'
+      post 'delete_aws_resources' => 'streamings#delete_aws_resources'
+
       post 'publish_timetable' => 'timetables#publish'
       post 'close_timetable' => 'timetables#close'
       get 'preview_timetable' => 'timetables#preview'

--- a/db/migrate/20230627103419_create_streamings_table.rb
+++ b/db/migrate/20230627103419_create_streamings_table.rb
@@ -1,0 +1,16 @@
+class CreateStreamingsTable < ActiveRecord::Migration[7.0]
+  def up
+    create_table :streamings, id: :string do |t|
+      t.belongs_to :conference, null: false, foreign_key: true, type: :bigint
+      t.belongs_to :track, null: false, foreign_key: true, type: :bigint
+      t.string :status, null: false
+
+      t.timestamps
+      t.index  [:conference_id, :track_id], unique: true
+    end unless ActiveRecord::Base.connection.table_exists?(:streamings)
+  end
+
+  def down
+    drop_table :streamings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_18_045613) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_27_103419) do
   create_table "access_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "sub"
@@ -410,6 +410,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_18_045613) do
     t.index ["conference_id"], name: "index_stats_of_registrants_on_conference_id"
   end
 
+  create_table "streamings", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.bigint "track_id", null: false
+    t.string "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["conference_id", "track_id"], name: "index_streamings_on_conference_id_and_track_id", unique: true
+    t.index ["conference_id"], name: "index_streamings_on_conference_id"
+    t.index ["track_id"], name: "index_streamings_on_track_id"
+  end
+
   create_table "talk_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -563,6 +574,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_18_045613) do
   add_foreign_key "sponsor_profiles", "conferences"
   add_foreign_key "sponsor_types", "conferences"
   add_foreign_key "sponsors", "conferences"
+  add_foreign_key "streamings", "conferences"
+  add_foreign_key "streamings", "tracks"
   add_foreign_key "talk_times", "conferences"
   add_foreign_key "tickets", "conferences"
   add_foreign_key "video_registrations", "talks"

--- a/spec/factories/streamings.rb
+++ b/spec/factories/streamings.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: streamings
+#
+#  id            :string(255)      not null, primary key
+#  status        :string(255)      not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  conference_id :bigint           not null
+#  track_id      :bigint           not null
+#
+# Indexes
+#
+#  index_streamings_on_conference_id               (conference_id)
+#  index_streamings_on_conference_id_and_track_id  (conference_id,track_id) UNIQUE
+#  index_streamings_on_track_id                    (track_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#  fk_rails_...  (track_id => tracks.id)
+#
+
+FactoryBot.define do
+  factory :streaming, class: Streaming
+end

--- a/spec/requests/admin/streamss_spec.rb
+++ b/spec/requests/admin/streamss_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Admin::SpeakersController, type: :request do
+  subject(:session) { { userinfo: { info: { email: 'alice@example.com', extra: { sub: 'alice' } }, extra: { raw_info: { sub: 'alice', 'https://cloudnativedays.jp/roles' => roles } } } } }
+  let(:roles) { ['CNDT2020-Admin'] }
+
+  before do
+    conference = create(:cndt2020)
+    create(:streaming, status: 'created', conference:, track: conference.tracks.first)
+  end
+
+  context 'user logged in' do
+    before do
+      ActionDispatch::Request::Session.define_method(:original, ActionDispatch::Request::Session.instance_method(:[]))
+      allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]) do |*arg|
+        if arg[1] == :userinfo
+          session[:userinfo]
+        else
+          arg[0].send(:original, arg[1])
+        end
+      end)
+    end
+
+    describe 'GET :event/admin/streamings#index' do
+      it 'returns a success response' do
+        get admin_streamings_path(event: 'cndt2020')
+        expect(response).to(be_successful)
+        expect(response).to(have_http_status('200'))
+      end
+
+      it 'returns a success response with streams' do
+        get admin_streamings_path(event: 'cndt2020')
+        expect(response).to(be_successful)
+        expect(response).to(have_http_status('200'))
+
+        expect(response.body).to(include('created'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
MediaLiveやMediaPackage, MediaPackageV2などのリソースをまとめて管理するためのテーブルとモデルを作成します。
Streamingオブジェクトを作成し、`create_aws_resources` や `delete_aws_resources` メソッドを呼ぶことで非同期で必要なリソースを作成する予定です。

管理画面に `/admin/streamings` を追加しており、今後はこの画面からAWSリソースを作成します。このPRの時点では以下の操作のみ可能です。

- Streamingレコードを作成
- 作成したStreamingレコード経由でAWSリソース作成メソッドを呼び出す（現時点では何もしない）
- 作成したStreamingレコード経由でAWSリソース削除メソッドを呼び出す（現時点では何もしない）

Streamingレコード自体は削除する必要はないので削除用処理は未実装です。