### PR TITLE
(1) MediaPackageV2リソースを扱えるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,7 @@ gem 'psych', '< 6'
 gem "aws-sdk-ivs"
 gem "aws-sdk-medialive"
 gem "aws-sdk-mediapackage"
+gem "aws-sdk-mediapackagev2"
 gem "aws-sdk-ssm"
 
 gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,13 +84,13 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.628.0)
+    aws-partitions (1.817.0)
     aws-record (2.7.0)
       aws-sdk-dynamodb (~> 1.18)
-    aws-sdk-core (3.144.0)
+    aws-sdk-core (3.181.0)
       aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.525.0)
-      aws-sigv4 (~> 1.1)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
     aws-sdk-dynamodb (1.76.0)
       aws-sdk-core (~> 3, >= 3.127.0)
@@ -106,6 +106,9 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sdk-mediapackage (1.56.0)
       aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-mediapackagev2 (1.5.0)
+      aws-sdk-core (~> 3, >= 3.177.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-rails (3.6.3)
       aws-record (~> 2)
@@ -702,6 +705,7 @@ DEPENDENCIES
   aws-sdk-ivs
   aws-sdk-medialive
   aws-sdk-mediapackage
+  aws-sdk-mediapackagev2
   aws-sdk-rails
   aws-sdk-s3 (~> 1.14)
   aws-sdk-ssm

--- a/app/helpers/media_package_v2_helper.rb
+++ b/app/helpers/media_package_v2_helper.rb
@@ -1,0 +1,44 @@
+require 'aws-sdk-mediapackagev2'
+
+module MediaPackageV2Helper
+  def media_package_v2_client
+    creds = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
+    @client ||= if creds.set?
+                  Aws::MediaPackageV2::Client.new(region: AWS_LIVE_STREAM_REGION, credentials: creds)
+                else
+                  Aws::MediaPackageV2::Client.new(region: AWS_LIVE_STREAM_REGION)
+                end
+  end
+
+  def channel_group_name
+    conference = streaming.conference
+
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}"
+    else
+      "#{env_name}_#{conference.abbr}"
+    end
+  end
+
+  def channel_name
+    conference = streaming.conference
+    track = streaming.track
+
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}_track#{track.name}"
+    else
+      "#{env_name}_#{conference.abbr}_track#{track.name}"
+    end
+  end
+
+  def origin_endpoint_name
+    conference = streaming.conference
+    track = streaming.track
+
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}_track#{track.name}"
+    else
+      "#{env_name}_#{conference.abbr}_track#{track.name}"
+    end
+  end
+end

--- a/app/jobs/create_streaming_aws_resources_job.rb
+++ b/app/jobs/create_streaming_aws_resources_job.rb
@@ -1,19 +1,45 @@
 class CreateStreamingAwsResourcesJob < ApplicationJob
   include EnvHelper
+  include MediaPackageV2Helper
   include LogoutHelper
 
   # queue_as :default
   self.queue_adapter = :async
 
+  attr_reader :conference
+  attr_reader :track
+  attr_reader :streaming
+
   def perform(*args)
     # Rails.logger.level = Logger::DEBUG
     logger.info('Perform CreateMediaPackageV2Job')
     @streaming = args[0]
+    @conference = @streaming.conference
+    @track = @streaming.track
+
+    create_media_package_v2_resources
 
     @streaming.update!(status: 'created')
   rescue => e
     @streaming.update!(status: 'error')
     logger.error(e.message)
     logger.error(e.backtrace.join("\n"))
+  end
+
+  def create_media_package_v2_resources
+    logger.info('Perform CreateMediaPackageV2Job')
+
+
+    channel_group = MediaPackageV2ChannelGroup.find_or_create_by(streaming_id: @streaming.id, name: channel_group_name)
+    logger.info("channel group: #{channel_group}")
+    channel_group.create_aws_resource
+
+    channel = MediaPackageV2Channel.find_or_create_by(streaming_id: @streaming.id, media_package_v2_channel_group_id: channel_group.id, name: channel_name)
+    logger.info("channel: #{channel}")
+    channel.create_aws_resource
+
+    origin_endpoint = MediaPackageV2OriginEndpoint.find_or_create_by(streaming_id: @streaming.id, media_package_v2_channel_id: channel.id, name: origin_endpoint_name)
+    logger.info("origin endpoint: #{origin_endpoint}")
+    origin_endpoint.create_aws_resource
   end
 end

--- a/app/jobs/delete_streaming_aws_resources_job.rb
+++ b/app/jobs/delete_streaming_aws_resources_job.rb
@@ -21,20 +21,9 @@ class DeleteStreamingAwsResourcesJob < ApplicationJob
   def delete_media_package_v2_resources
     logger.info('Deleting MediaPackageV2 resources...')
 
-    if @streaming.media_package_v2_origin_endpoint
-      @streaming.media_package_v2_origin_endpoint.delete_aws_resource
-      @streaming.media_package_v2_origin_endpoint.destroy!
-    end
-
-    if @streaming.media_package_v2_channel
-      @streaming.media_package_v2_channel.delete_aws_resource
-      @streaming.media_package_v2_channel.destroy!
-    end
-
-    if @streaming.media_package_v2_channel_group
-      @streaming.media_package_v2_channel_group.delete_aws_resource
-      @streaming.media_package_v2_channel_group.destroy!
-    end
+    @streaming.media_package_v2_origin_endpoint&.destroy!
+    @streaming.media_package_v2_channel&.destroy!
+    @streaming.media_package_v2_channel_group&.destroy!
 
     logger.info('Deleted MediaPackageV2 resources...')
   end

--- a/app/jobs/delete_streaming_aws_resources_job.rb
+++ b/app/jobs/delete_streaming_aws_resources_job.rb
@@ -10,9 +10,32 @@ class DeleteStreamingAwsResourcesJob < ApplicationJob
     logger.info('Perform DeleteStreamingAwsResourcesJob')
     @streaming = args[0]
 
+    delete_media_package_v2_resources
+
     @streaming.update!(status: 'deleted')
   rescue => e
     logger.error(e.message)
     logger.error(e.backtrace.join("\n"))
+  end
+
+  def delete_media_package_v2_resources
+    logger.info('Deleting MediaPackageV2 resources...')
+
+    if @streaming.media_package_v2_origin_endpoint
+      @streaming.media_package_v2_origin_endpoint.delete_aws_resource
+      @streaming.media_package_v2_origin_endpoint.destroy!
+    end
+
+    if @streaming.media_package_v2_channel
+      @streaming.media_package_v2_channel.delete_aws_resource
+      @streaming.media_package_v2_channel.destroy!
+    end
+
+    if @streaming.media_package_v2_channel_group
+      @streaming.media_package_v2_channel_group.delete_aws_resource
+      @streaming.media_package_v2_channel_group.destroy!
+    end
+
+    logger.info('Deleted MediaPackageV2 resources...')
   end
 end

--- a/app/models/media_package_v2_channel.rb
+++ b/app/models/media_package_v2_channel.rb
@@ -57,8 +57,6 @@ class MediaPackageV2Channel < ApplicationRecord
 
   def channel
     @channel ||= media_package_v2_client.get_channel(channel_group_name:, channel_name:)
-  rescue => e
-    logger.error(e.message.to_s)
   end
 
   def ingest_endpoint_url

--- a/app/models/media_package_v2_channel.rb
+++ b/app/models/media_package_v2_channel.rb
@@ -1,0 +1,77 @@
+# == Schema Information
+#
+# Table name: media_package_v2_channels
+#
+#  id                                :string(255)      not null, primary key
+#  name                              :string(255)
+#  media_package_v2_channel_group_id :string(255)
+#  streaming_id                      :string(255)      not null
+#
+# Indexes
+#
+#  index_channels_on_channel_group_id               (media_package_v2_channel_group_id)
+#  index_media_package_v2_channels_on_name          (name) UNIQUE
+#  index_media_package_v2_channels_on_streaming_id  (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (streaming_id => streamings.id)
+#
+
+require 'aws-sdk-mediapackagev2'
+
+class MediaPackageV2Channel < ApplicationRecord
+  include EnvHelper
+  include MediaPackageV2Helper
+
+  before_create :set_uuid
+
+  belongs_to :streaming
+  belongs_to :channel_group, class_name: 'MediaPackageV2ChannelGroup', foreign_key: :media_package_v2_channel_group_id
+  has_one :origin_endpoint, class_name: 'MediaPackageV2OriginEndpoint'
+
+  def create_aws_resource
+    unless exists_aws_resource?
+      resp = media_package_v2_client.create_channel(channel_group_name:, channel_name:)
+      update!(name: resp.channel_name)
+    end
+  end
+
+  def delete_aws_resource
+    media_package_v2_client.delete_channel(channel_group_name:, channel_name:) if exists_aws_resource?
+    loop do
+      break unless exists_aws_resource?
+    end
+    update!(name: '')
+  end
+
+  def exists_aws_resource?
+    media_package_v2_client.get_channel(channel_group_name:, channel_name:)
+    true
+  rescue Aws::MediaPackageV2::Errors::NotFoundException
+    false
+  rescue => e
+    logger.error(e.message)
+    false
+  end
+
+  def channel
+    @channel ||= media_package_v2_client.get_channel(channel_group_name:, channel_name:)
+  rescue => e
+    logger.error(e.message.to_s)
+  end
+
+  def ingest_endpoint_url
+    channel.ingest_endpoints[0].url
+  end
+
+  private
+
+  def conference
+    streaming.conference
+  end
+
+  def track
+    streaming.track
+  end
+end

--- a/app/models/media_package_v2_channel.rb
+++ b/app/models/media_package_v2_channel.rb
@@ -25,6 +25,7 @@ class MediaPackageV2Channel < ApplicationRecord
   include MediaPackageV2Helper
 
   before_create :set_uuid
+  before_destroy :delete_aws_resource
 
   belongs_to :streaming
   belongs_to :channel_group, class_name: 'MediaPackageV2ChannelGroup', foreign_key: :media_package_v2_channel_group_id
@@ -38,11 +39,13 @@ class MediaPackageV2Channel < ApplicationRecord
   end
 
   def delete_aws_resource
-    media_package_v2_client.delete_channel(channel_group_name:, channel_name:) if exists_aws_resource?
-    loop do
-      break unless exists_aws_resource?
+    if exists_aws_resource?
+      media_package_v2_client.delete_channel(channel_group_name:, channel_name:)
+      loop do
+        break unless exists_aws_resource?
+      end
+      update!(name: '')
     end
-    update!(name: '')
   end
 
   def exists_aws_resource?

--- a/app/models/media_package_v2_channel_group.rb
+++ b/app/models/media_package_v2_channel_group.rb
@@ -22,6 +22,7 @@ class MediaPackageV2ChannelGroup < ApplicationRecord
   include MediaPackageV2Helper
 
   before_create :set_uuid
+  before_destroy :delete_aws_resource
 
   belongs_to :streaming
   has_one :channel, class_name: 'MediaPackageV2Channel'
@@ -34,11 +35,13 @@ class MediaPackageV2ChannelGroup < ApplicationRecord
   end
 
   def delete_aws_resource
-    media_package_v2_client.delete_channel_group(channel_group_name:) if exists_aws_resource?
-    loop do
-      break unless exists_aws_resource?
+    if exists_aws_resource?
+      media_package_v2_client.delete_channel_group(channel_group_name:)
+      loop do
+        break unless exists_aws_resource?
+      end
+      update!(name: '')
     end
-    update!(name: '')
   end
 
   def exists_aws_resource?

--- a/app/models/media_package_v2_channel_group.rb
+++ b/app/models/media_package_v2_channel_group.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: media_package_v2_channel_groups
+#
+#  id           :string(255)      not null, primary key
+#  name         :string(255)
+#  streaming_id :string(255)      not null
+#
+# Indexes
+#
+#  index_media_package_v2_channel_groups_on_name          (name) UNIQUE
+#  index_media_package_v2_channel_groups_on_streaming_id  (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (streaming_id => streamings.id)
+#
+require 'aws-sdk-mediapackagev2'
+
+class MediaPackageV2ChannelGroup < ApplicationRecord
+  include EnvHelper
+  include MediaPackageV2Helper
+
+  before_create :set_uuid
+
+  belongs_to :streaming
+  has_one :channel, class_name: 'MediaPackageV2Channel'
+
+  def create_aws_resource
+    unless exists_aws_resource?
+      resp = media_package_v2_client.create_channel_group(channel_group_name:)
+      update!(name: resp.channel_group_name)
+    end
+  end
+
+  def delete_aws_resource
+    media_package_v2_client.delete_channel_group(channel_group_name:) if exists_aws_resource?
+    loop do
+      break unless exists_aws_resource?
+    end
+    update!(name: '')
+  end
+
+  def exists_aws_resource?
+    media_package_v2_client.get_channel_group(channel_group_name:)
+    true
+  rescue Aws::MediaPackageV2::Errors::NotFoundException
+    false
+  rescue => e
+    logger.error(e.message)
+    false
+  end
+end

--- a/app/models/media_package_v2_origin_endpoint.rb
+++ b/app/models/media_package_v2_origin_endpoint.rb
@@ -1,0 +1,109 @@
+# == Schema Information
+#
+# Table name: media_package_v2_origin_endpoints
+#
+#  id                          :string(255)      not null, primary key
+#  name                        :string(255)
+#  media_package_v2_channel_id :string(255)
+#  streaming_id                :string(255)      not null
+#
+# Indexes
+#
+#  index_media_package_v2_origin_endpoints_on_name          (name) UNIQUE
+#  index_media_package_v2_origin_endpoints_on_streaming_id  (streaming_id)
+#  index_origin_endpoints_on_channel_id                     (media_package_v2_channel_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (streaming_id => streamings.id)
+#
+require 'aws-sdk-mediapackagev2'
+
+class MediaPackageV2OriginEndpoint < ApplicationRecord
+  include EnvHelper
+  include MediaPackageV2Helper
+
+  before_create :set_uuid
+
+  belongs_to :streaming
+  belongs_to :channel, class_name: 'MediaPackageV2Channel', foreign_key: :media_package_v2_channel_id
+
+  def create_aws_resource
+    unless exists_aws_resource?
+      resp = media_package_v2_client.create_origin_endpoint(
+        {
+          channel_group_name:,
+          channel_name:,
+          origin_endpoint_name:,
+          container_type: 'TS',
+          segment: {
+            segment_duration_seconds: 1,
+            segment_name: 'segment',
+            ts_use_audio_rendition_group: false,
+            include_iframe_only_streams: false,
+            ts_include_dvb_subtitles: false
+          },
+          startover_window_seconds: 60,
+          low_latency_hls_manifests: [
+            {
+              manifest_name: 'll-hls-index',
+              manifest_window_seconds: 30,
+              program_date_time_interval_seconds: 1
+            }
+          ]
+        }
+      )
+      media_package_v2_client.put_origin_endpoint_policy(
+        {
+          channel_group_name:,
+          channel_name:,
+          origin_endpoint_name:,
+          policy: <<~EOS
+            {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AllowUser",
+                  "Effect": "Allow",
+                  "Principal": "*",
+                  "Action": "mediapackagev2:GetObject",
+                  "Resource": "arn:aws:mediapackagev2:us-east-1:607167088920:channelGroup/#{channel_group_name}/channel/#{channel_name}/originEndpoint/#{origin_endpoint_name}"
+                }
+              ]
+            }
+          EOS
+        }
+      )
+      update!(name: resp.origin_endpoint_name)
+    end
+  end
+
+  def exists_aws_resource?
+    media_package_v2_client.get_origin_endpoint(channel_group_name:, channel_name:, origin_endpoint_name:)
+    true
+  rescue Aws::MediaPackageV2::Errors::NotFoundException
+    false
+  rescue => e
+    logger.error(e.message)
+    false
+  end
+
+  def delete_aws_resource
+    media_package_v2_client.delete_origin_endpoint_policy(channel_group_name:, channel_name:, origin_endpoint_name:)
+    media_package_v2_client.delete_origin_endpoint(channel_group_name:, channel_name:, origin_endpoint_name:)
+    loop do
+      break unless exists_aws_resource?
+    end
+    update!(name: '')
+  end
+
+  def aws_resource
+    @aws_resource = media_package_v2_client.get_origin_endpoint(channel_group_name:, channel_name:, origin_endpoint_name:)
+  end
+
+  def playback_url
+    aws_resource&.low_latency_hls_manifests&.first&.url
+  rescue Aws::MediaPackageV2::Errors::NotFoundException
+    ''
+  end
+end

--- a/app/models/media_package_v2_origin_endpoint.rb
+++ b/app/models/media_package_v2_origin_endpoint.rb
@@ -24,6 +24,7 @@ class MediaPackageV2OriginEndpoint < ApplicationRecord
   include MediaPackageV2Helper
 
   before_create :set_uuid
+  before_destroy :delete_aws_resource
 
   belongs_to :streaming
   belongs_to :channel, class_name: 'MediaPackageV2Channel', foreign_key: :media_package_v2_channel_id
@@ -89,10 +90,12 @@ class MediaPackageV2OriginEndpoint < ApplicationRecord
   end
 
   def delete_aws_resource
-    media_package_v2_client.delete_origin_endpoint_policy(channel_group_name:, channel_name:, origin_endpoint_name:)
-    media_package_v2_client.delete_origin_endpoint(channel_group_name:, channel_name:, origin_endpoint_name:)
-    loop do
-      break unless exists_aws_resource?
+    if exists_aws_resource?
+      media_package_v2_client.delete_origin_endpoint_policy(channel_group_name:, channel_name:, origin_endpoint_name:)
+      media_package_v2_client.delete_origin_endpoint(channel_group_name:, channel_name:, origin_endpoint_name:)
+      loop do
+        break unless exists_aws_resource?
+      end
     end
     update!(name: '')
   end

--- a/app/views/admin/streamings/index.html.erb
+++ b/app/views/admin/streamings/index.html.erb
@@ -56,4 +56,54 @@
       </table>
     </div>
   </div>
+
+  <div class="row">
+    <div class="col-10">
+      <h3>配信用URL一覧</h3>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
+      <table class="table table-striped" >
+        <thead>
+        <tr>
+          <th scope="col">Track Name (ID)</th>
+          <th scope="col">Playback URL</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% @tracks.each do |track| %>
+          <tr>
+            <td><%= track.name %> (<%= track.id %>)</td>
+            <td><%= track.streaming&.playback_url %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <% @tracks.each do |track| %>
+    <div class="row">
+      <div class="col-10">
+        <h3>Track <%= track.name %>: リソース詳細</h3>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col">
+        <table class="table table-striped" >
+          <tbody>
+          <tr>
+            <td>Track ID</td><td><%= track.id %></td>
+          </tr>
+          <tr>
+            <td>MediaPackage V2 ChannelGroup</td><td><%= track.streaming&.media_package_v2_channel_group&.name %></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/db/migrate/20230906132249_create_media_package_v2.rb
+++ b/db/migrate/20230906132249_create_media_package_v2.rb
@@ -1,0 +1,30 @@
+class CreateMediaPackageV2 < ActiveRecord::Migration[7.0]
+  def up
+    create_table :media_package_v2_channel_groups, id: :string do |t|
+      t.belongs_to :streaming, null: false, foreign_key: true, type: :string
+      t.string :name, null: true
+      t.index :name, unique: true
+    end unless ActiveRecord::Base.connection.table_exists?(:media_package_v2_channel_groups)
+
+    create_table :media_package_v2_channels, id: :string do |t|
+      t.belongs_to :streaming, null: false, foreign_key: true, type: :string
+      t.belongs_to :media_package_v2_channel_group, null: true, type: :string, index: {name: 'index_channels_on_channel_group_id'}
+
+      t.string :name, null: true
+      t.index :name, unique: true
+    end unless ActiveRecord::Base.connection.table_exists?(:media_package_v2_channels)
+
+    create_table :media_package_v2_origin_endpoints, id: :string do |t|
+      t.belongs_to :streaming, null: false, foreign_key: true, type: :string
+      t.belongs_to :media_package_v2_channel, null: true, type: :string, index: {name: 'index_origin_endpoints_on_channel_id'}
+      t.string :name, null: true
+      t.index :name, unique: true
+    end unless ActiveRecord::Base.connection.table_exists?(:media_package_v2_origin_endpoints)
+  end
+
+  def down
+    drop_table :media_package_v2_origin_endpoints
+    drop_table :media_package_v2_channels
+    drop_table :media_package_v2_channel_groups
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_27_103419) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_132249) do
   create_table "access_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "sub"
@@ -190,6 +190,31 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_103419) do
     t.string "endpoint_id"
     t.index ["conference_id"], name: "index_media_package_origin_endpoints_on_conference_id"
     t.index ["media_package_channel_id"], name: "index_media_package_origin_endpoints_on_media_package_channel_id"
+  end
+
+  create_table "media_package_v2_channel_groups", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "streaming_id", null: false
+    t.string "name"
+    t.index ["name"], name: "index_media_package_v2_channel_groups_on_name", unique: true
+    t.index ["streaming_id"], name: "index_media_package_v2_channel_groups_on_streaming_id"
+  end
+
+  create_table "media_package_v2_channels", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "streaming_id", null: false
+    t.string "media_package_v2_channel_group_id"
+    t.string "name"
+    t.index ["media_package_v2_channel_group_id"], name: "index_channels_on_channel_group_id"
+    t.index ["name"], name: "index_media_package_v2_channels_on_name", unique: true
+    t.index ["streaming_id"], name: "index_media_package_v2_channels_on_streaming_id"
+  end
+
+  create_table "media_package_v2_origin_endpoints", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "streaming_id", null: false
+    t.string "media_package_v2_channel_id"
+    t.string "name"
+    t.index ["media_package_v2_channel_id"], name: "index_origin_endpoints_on_channel_id"
+    t.index ["name"], name: "index_media_package_v2_origin_endpoints_on_name", unique: true
+    t.index ["streaming_id"], name: "index_media_package_v2_origin_endpoints_on_streaming_id"
   end
 
   create_table "messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -559,6 +584,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_103419) do
   add_foreign_key "media_package_harvest_jobs", "talks"
   add_foreign_key "media_package_origin_endpoints", "conferences"
   add_foreign_key "media_package_origin_endpoints", "media_package_channels"
+  add_foreign_key "media_package_v2_channel_groups", "streamings"
+  add_foreign_key "media_package_v2_channels", "streamings"
+  add_foreign_key "media_package_v2_origin_endpoints", "streamings"
   add_foreign_key "orders", "profiles"
   add_foreign_key "orders_tickets", "orders"
   add_foreign_key "orders_tickets", "tickets"

--- a/spec/factories/media_package_v2_channel.rb
+++ b/spec/factories/media_package_v2_channel.rb
@@ -21,21 +21,6 @@
 #  fk_rails_...  (track_id => tracks.id)
 #
 
-class Streaming < ApplicationRecord
-  before_create :set_uuid
-
-  belongs_to :conference
-  belongs_to :track
-  has_one :media_package_v2_channel_group
-  has_one :media_package_v2_channel
-  has_one :media_package_v2_origin_endpoint
-
-  STATUS_CREATING = 'creating'.freeze
-  STATUS_CRTEATED = 'created'.freeze
-  STATUS_DELETING = 'deleting'.freeze
-  STATUS_DELETED  = 'deleted'.freeze
-
-  def playback_url
-    media_package_v2_origin_endpoint&.playback_url
-  end
+FactoryBot.define do
+  factory :media_package_v2_channel, class: MediaPackageV2Channel
 end

--- a/spec/factories/media_package_v2_channel_group.rb
+++ b/spec/factories/media_package_v2_channel_group.rb
@@ -21,21 +21,6 @@
 #  fk_rails_...  (track_id => tracks.id)
 #
 
-class Streaming < ApplicationRecord
-  before_create :set_uuid
-
-  belongs_to :conference
-  belongs_to :track
-  has_one :media_package_v2_channel_group
-  has_one :media_package_v2_channel
-  has_one :media_package_v2_origin_endpoint
-
-  STATUS_CREATING = 'creating'.freeze
-  STATUS_CRTEATED = 'created'.freeze
-  STATUS_DELETING = 'deleting'.freeze
-  STATUS_DELETED  = 'deleted'.freeze
-
-  def playback_url
-    media_package_v2_origin_endpoint&.playback_url
-  end
+FactoryBot.define do
+  factory :media_package_v2_channel_group, class: MediaPackageV2ChannelGroup
 end

--- a/spec/factories/media_package_v2_origin_endpoint.rb
+++ b/spec/factories/media_package_v2_origin_endpoint.rb
@@ -21,21 +21,6 @@
 #  fk_rails_...  (track_id => tracks.id)
 #
 
-class Streaming < ApplicationRecord
-  before_create :set_uuid
-
-  belongs_to :conference
-  belongs_to :track
-  has_one :media_package_v2_channel_group
-  has_one :media_package_v2_channel
-  has_one :media_package_v2_origin_endpoint
-
-  STATUS_CREATING = 'creating'.freeze
-  STATUS_CRTEATED = 'created'.freeze
-  STATUS_DELETING = 'deleting'.freeze
-  STATUS_DELETED  = 'deleted'.freeze
-
-  def playback_url
-    media_package_v2_origin_endpoint&.playback_url
-  end
+FactoryBot.define do
+  factory :media_package_v2_origin_endpoint, class: MediaPackageV2OriginEndpoint
 end


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/2019 の後続PR。

このPRではMediaPackageV2リソースを扱えるようにする。 `/admin/streamings` でStreamingレコードを作ると非同期にMediaPackageV2のChannelGroup, Channel, OriginEndpointが作られる。これらのリソースはTrack毎にそれぞれ作成される。

なお、このPRでは細かいパラメータのチューニングは行わない。