### PR TITLE
GithubActionにtimeoutを設定

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,9 @@ jobs:
       matrix:
         runs-on:
           - "ubuntu-latest"
-          - "buildjet-2vcpu-ubuntu-2204-arm"
+          - "buildjet-4vcpu-ubuntu-2204-arm"
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 10
     if: github.event.pusher.name != 'dreamkast-cloudnativedays'
     steps:
       - name: Checkout code
@@ -66,6 +67,7 @@ jobs:
 
   merge-images:
     runs-on: "ubuntu-latest"
+    timeout-minutes: 10
     needs: ["build"]
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/actions/runs/6098184501
buildjet によるbuildに2時間かかっているケース↑があるため以下の対策を実施。

### 対策
- githubactionのworkflowにtimeout(10分)を設定
  - timeoutした場合、手動で再実行、もしくは実行時間を変えて再実行していただく。
- 2vcpu→4vcpuに変更
  - timeoutと合わせて設定することで過剰な課金は防止できる。

### 検証結果
 - buildに10分かかった時点でtimeoutで停止すること
   - https://github.com/cloudnativedaysjp/dreamkast/actions/runs/6111269796
  - 10分以内の場合は正常終了すること
    - https://github.com/cloudnativedaysjp/dreamkast/actions/runs/6111477998