### PR TITLE
(2) MediaPackageリソースをStreamingの管理下に移行する

### DIFF
--- a/app/helpers/media_package_helper.rb
+++ b/app/helpers/media_package_helper.rb
@@ -22,4 +22,15 @@ module MediaPackageHelper
 
     channels.select { |channel| channel_ids.include?(channel.id) }
   end
+
+  def resource_name
+    conference = streaming.conference
+    track = streaming.track
+
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}_track#{track.name}"
+    else
+      "#{env_name}_#{conference.abbr}_track#{track.name}"
+    end
+  end
 end

--- a/app/jobs/create_media_package_job.rb
+++ b/app/jobs/create_media_package_job.rb
@@ -10,11 +10,11 @@ class CreateMediaPackageJob < ApplicationJob
 
     channel = MediaPackageChannel.new(conference:, track:)
     logger.error("Failed to create MediaPackageChannel: #{channel.errors}") unless channel.save
-    channel.create_media_package_resources
+    channel.create_aws_resource
 
     endpoint = MediaPackageOriginEndpoint.new(conference:, media_package_channel: channel)
     logger.error("Failed to create MediaPackageChannel: #{endpoint.errors}") unless endpoint.save
-    endpoint.create_media_package_resources
+    endpoint.create_aws_resource
   rescue => e
     logger.error(e.message)
   end

--- a/app/jobs/create_streaming_aws_resources_job.rb
+++ b/app/jobs/create_streaming_aws_resources_job.rb
@@ -18,6 +18,7 @@ class CreateStreamingAwsResourcesJob < ApplicationJob
     @track = @streaming.track
 
     create_media_package_v2_resources
+    create_media_package_resources
 
     @streaming.update!(status: 'created')
   rescue => e
@@ -41,5 +42,21 @@ class CreateStreamingAwsResourcesJob < ApplicationJob
     origin_endpoint = MediaPackageV2OriginEndpoint.find_or_create_by(streaming_id: @streaming.id, media_package_v2_channel_id: channel.id, name: origin_endpoint_name)
     logger.info("origin endpoint: #{origin_endpoint}")
     origin_endpoint.create_aws_resource
+  end
+
+  def create_media_package_resources
+    logger.info('Perform CreateMediaPackageJob')
+
+    channel = MediaPackageChannel.find_or_create_by(streaming_id: @streaming.id)
+    logger.info("channel: #{channel}")
+    channel.create_aws_resource
+
+    parameter = MediaPackageParameter.find_or_create_by(streaming_id: @streaming.id, media_package_channel_id: channel.id)
+    logger.info("parameter: #{parameter}")
+    parameter.create_aws_resources
+
+    endpoint = MediaPackageOriginEndpoint.find_or_create_by(streaming_id: @streaming.id, media_package_channel_id: channel.id)
+    logger.info("endpoint: #{endpoint}")
+    endpoint.create_aws_resource
   end
 end

--- a/app/jobs/delete_media_package_job.rb
+++ b/app/jobs/delete_media_package_job.rb
@@ -7,8 +7,12 @@ class DeleteMediaPackageJob < ApplicationJob
   def perform(*args)
     logger.info('Perform DeleteMediaPackageJob')
     channel = args[0]
-    channel.media_package_origin_endpoints.each(&:destroy)
+    channel.media_package_origin_endpoints.each do |oe|
+      oe.delete_aws_resource
+      oe.destroy
+    end
     channel.media_package_harvest_jobs.each(&:destroy)
+    channel.delete_aws_resource
     channel.destroy
   rescue => e
     logger.error(e.message)

--- a/app/jobs/delete_streaming_aws_resources_job.rb
+++ b/app/jobs/delete_streaming_aws_resources_job.rb
@@ -43,21 +43,10 @@ class DeleteStreamingAwsResourcesJob < ApplicationJob
   def delete_media_package_resources
     logger.info('Deleting MediaPackage resources...')
 
-    if @streaming.media_package_origin_endpoint
-      @streaming.media_package_origin_endpoint.delete_aws_resource
-      @streaming.media_package_origin_endpoint.destroy!
-    end
-
-    if @streaming.media_package_parameter
-      @streaming.media_package_parameter.delete_aws_resource
-      @streaming.media_package_parameter.destroy!
-    end
-
-    if @streaming.media_package_channel
-      @streaming.media_package_channel.media_package_harvest_jobs&.each(&:destroy)
-      @streaming.media_package_channel.delete_aws_resource
-      @streaming.media_package_channel.destroy!
-    end
+    @streaming.media_package_origin_endpoint&.destroy!
+    @streaming.media_package_parameter&.destroy!
+    @streaming.media_package_channel&.media_package_harvest_jobs&.each(&:destroy)
+    @streaming.media_package_channel&.destroy!
 
     logger.info('Deleted MediaPackage resources...')
   end

--- a/app/jobs/delete_streaming_aws_resources_job.rb
+++ b/app/jobs/delete_streaming_aws_resources_job.rb
@@ -11,6 +11,7 @@ class DeleteStreamingAwsResourcesJob < ApplicationJob
     @streaming = args[0]
 
     delete_media_package_v2_resources
+    delete_media_package_resources
 
     @streaming.update!(status: 'deleted')
   rescue => e
@@ -37,5 +38,27 @@ class DeleteStreamingAwsResourcesJob < ApplicationJob
     end
 
     logger.info('Deleted MediaPackageV2 resources...')
+  end
+
+  def delete_media_package_resources
+    logger.info('Deleting MediaPackage resources...')
+
+    if @streaming.media_package_origin_endpoint
+      @streaming.media_package_origin_endpoint.delete_aws_resource
+      @streaming.media_package_origin_endpoint.destroy!
+    end
+
+    if @streaming.media_package_parameter
+      @streaming.media_package_parameter.delete_aws_resource
+      @streaming.media_package_parameter.destroy!
+    end
+
+    if @streaming.media_package_channel
+      @streaming.media_package_channel.media_package_harvest_jobs&.each(&:destroy)
+      @streaming.media_package_channel.delete_aws_resource
+      @streaming.media_package_channel.destroy!
+    end
+
+    logger.info('Deleted MediaPackage resources...')
   end
 end

--- a/app/models/media_package_channel.rb
+++ b/app/models/media_package_channel.rb
@@ -20,9 +20,7 @@ class MediaPackageChannel < ApplicationRecord
   include MediaPackageHelper
   include EnvHelper
 
-  before_destroy do
-    delete_aws_resource
-  end
+  before_destroy :delete_aws_resource
 
   belongs_to :streaming
   has_many :media_package_origin_endpoints

--- a/app/models/media_package_channel.rb
+++ b/app/models/media_package_channel.rb
@@ -26,8 +26,6 @@ class MediaPackageChannel < ApplicationRecord
 
   def channel
     @channel = media_package_client.describe_channel(id: channel_id)
-  rescue => e
-    logger.error(e.message.to_s)
   end
 
   def ingest_endpoints

--- a/app/models/media_package_channel.rb
+++ b/app/models/media_package_channel.rb
@@ -20,6 +20,10 @@ class MediaPackageChannel < ApplicationRecord
   include MediaPackageHelper
   include EnvHelper
 
+  before_destroy do
+    delete_aws_resource
+  end
+
   belongs_to :streaming
   has_many :media_package_origin_endpoints
   has_many :media_package_harvest_jobs

--- a/app/models/media_package_channel.rb
+++ b/app/models/media_package_channel.rb
@@ -64,7 +64,7 @@ class MediaPackageChannel < ApplicationRecord
   end
 
   def delete_aws_resource
-    media_package_client.delete_channel(id: channel_id)
+    media_package_client.delete_channel(id: channel_id) if exists_aws_resource?
   end
 
   private

--- a/app/models/media_package_origin_endpoint.rb
+++ b/app/models/media_package_origin_endpoint.rb
@@ -28,8 +28,6 @@ class MediaPackageOriginEndpoint < ApplicationRecord
 
   def origin_endpoint
     @origin_endpoint = media_package_client.describe_origin_endpoint(id: endpoint_id)
-  rescue => e
-    logger.error(e.message.to_s)
   end
 
   def create_aws_resource

--- a/app/models/media_package_origin_endpoint.rb
+++ b/app/models/media_package_origin_endpoint.rb
@@ -3,50 +3,52 @@
 # Table name: media_package_origin_endpoints
 #
 #  id                       :bigint           not null, primary key
-#  conference_id            :bigint           not null
 #  endpoint_id              :string(255)
 #  media_package_channel_id :bigint           not null
+#  streaming_id             :string(255)
 #
 # Indexes
 #
-#  index_media_package_origin_endpoints_on_conference_id             (conference_id)
 #  index_media_package_origin_endpoints_on_media_package_channel_id  (media_package_channel_id)
+#  index_media_package_origin_endpoints_on_streaming_id              (streaming_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (conference_id => conferences.id)
 #  fk_rails_...  (media_package_channel_id => media_package_channels.id)
+#  fk_rails_...  (streaming_id => streamings.id)
 #
 
 class MediaPackageOriginEndpoint < ApplicationRecord
   include MediaPackageHelper
   include EnvHelper
 
-  belongs_to :conference
   belongs_to :media_package_channel
+  belongs_to :streaming
 
-  before_destroy do
-    delete_media_package_resources
-  end
 
   def origin_endpoint
-    @origin_endpoint ||= media_package_client.describe_origin_endpoint(id: endpoint_id)
+    @origin_endpoint = media_package_client.describe_origin_endpoint(id: endpoint_id)
   rescue => e
     logger.error(e.message.to_s)
   end
 
-  def create_media_package_resources
+  def create_aws_resource
     resp = media_package_client.create_origin_endpoint(create_params)
     update!(endpoint_id: resp.id)
-  rescue => e
-    logger.error(e.message)
-    delete_media_package_resources
   end
 
-  def delete_media_package_resources
-    media_package_client.delete_origin_endpoint(id: endpoint_id)
+  def exists_aws_resource?
+    media_package_client.describe_origin_endpoint(id: endpoint_id)
+    true
+  rescue Aws::MediaPackage::Errors::NotFoundException
+    false
   rescue => e
     logger.error(e.message.to_s)
+    false
+  end
+
+  def delete_aws_resource
+    media_package_client.delete_origin_endpoint(id: endpoint_id)
   end
 
   private
@@ -83,13 +85,5 @@ class MediaPackageOriginEndpoint < ApplicationRecord
     tags = { 'Environment' => env_name }
     tags['ReviewAppNumber'] = review_app_number.to_s if ENV['DREAMKAST_NAMESPACE']
     tags
-  end
-
-  def resource_name
-    if review_app?
-      "review_app_#{review_app_number}_#{conference.abbr}_track#{media_package_channel.track.name}"
-    else
-      "#{env_name}_#{conference.abbr}_track#{media_package_channel.track.name}"
-    end
   end
 end

--- a/app/models/media_package_origin_endpoint.rb
+++ b/app/models/media_package_origin_endpoint.rb
@@ -22,6 +22,10 @@ class MediaPackageOriginEndpoint < ApplicationRecord
   include MediaPackageHelper
   include EnvHelper
 
+  before_destroy do
+    delete_aws_resource
+  end
+
   belongs_to :media_package_channel
   belongs_to :streaming
 

--- a/app/models/media_package_origin_endpoint.rb
+++ b/app/models/media_package_origin_endpoint.rb
@@ -48,7 +48,7 @@ class MediaPackageOriginEndpoint < ApplicationRecord
   end
 
   def delete_aws_resource
-    media_package_client.delete_origin_endpoint(id: endpoint_id)
+    media_package_client.delete_origin_endpoint(id: endpoint_id) if exists_aws_resource?
   end
 
   private

--- a/app/models/media_package_origin_endpoint.rb
+++ b/app/models/media_package_origin_endpoint.rb
@@ -22,9 +22,7 @@ class MediaPackageOriginEndpoint < ApplicationRecord
   include MediaPackageHelper
   include EnvHelper
 
-  before_destroy do
-    delete_aws_resource
-  end
+  before_destroy :delete_aws_resource
 
   belongs_to :media_package_channel
   belongs_to :streaming

--- a/app/models/media_package_parameter.rb
+++ b/app/models/media_package_parameter.rb
@@ -48,7 +48,7 @@ class MediaPackageParameter < ApplicationRecord
   end
 
   def delete_aws_resource
-    delete_parameter("/medialive/#{resource_name}")
+    delete_parameter("/medialive/#{resource_name}") if exists_aws_resource?
   rescue => e
     logger.error(e.message.to_s)
   end

--- a/app/models/media_package_parameter.rb
+++ b/app/models/media_package_parameter.rb
@@ -36,8 +36,6 @@ class MediaPackageParameter < ApplicationRecord
       create_parameter("/medialive/#{resource_name}", media_package_channel.ingest_endpoint_password)
       update!(name: "/medialive/#{resource_name}")
     end
-  rescue => e
-    logger.error(e.message)
   end
 
   def exists_aws_resource?
@@ -49,8 +47,6 @@ class MediaPackageParameter < ApplicationRecord
 
   def delete_aws_resource
     delete_parameter("/medialive/#{resource_name}") if exists_aws_resource?
-  rescue => e
-    logger.error(e.message.to_s)
   end
 
   private

--- a/app/models/media_package_parameter.rb
+++ b/app/models/media_package_parameter.rb
@@ -26,9 +26,7 @@ class MediaPackageParameter < ApplicationRecord
   include SsmHelper
   include EnvHelper
 
-  before_destroy do
-    delete_aws_resource
-  end
+  before_destroy :delete_aws_resource
 
   before_create :set_uuid
 

--- a/app/models/media_package_parameter.rb
+++ b/app/models/media_package_parameter.rb
@@ -1,0 +1,65 @@
+# == Schema Information
+#
+# Table name: media_package_parameters
+#
+#  id                       :string(255)      not null, primary key
+#  name                     :string(255)
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  media_package_channel_id :bigint           not null
+#  streaming_id             :string(255)      not null
+#
+# Indexes
+#
+#  index_media_package_parameters_on_media_package_channel_id  (media_package_channel_id)
+#  index_media_package_parameters_on_streaming_id              (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (media_package_channel_id => media_package_channels.id)
+#  fk_rails_...  (streaming_id => streamings.id)
+#
+require 'aws-sdk-medialive'
+
+class MediaPackageParameter < ApplicationRecord
+  include MediaLiveHelper
+  include SsmHelper
+  include EnvHelper
+
+  before_create :set_uuid
+
+  belongs_to :streaming
+  belongs_to :media_package_channel
+
+  def create_aws_resources
+    unless exists_aws_resource?
+      create_parameter("/medialive/#{resource_name}", media_package_channel.ingest_endpoint_password)
+      update!(name: "/medialive/#{resource_name}")
+    end
+  rescue => e
+    logger.error(e.message)
+  end
+
+  def exists_aws_resource?
+    ssm_client.describe_parameters(filters: [{ key: 'Name', values: ["/medialive/#{resource_name}"] }]).parameters.any?
+  rescue => e
+    logger.error(e.message)
+    false
+  end
+
+  def delete_aws_resource
+    delete_parameter("/medialive/#{resource_name}")
+  rescue => e
+    logger.error(e.message.to_s)
+  end
+
+  private
+
+  def resource_name
+    if review_app?
+      "review_app_#{review_app_number}_#{conference.abbr}_track#{track.name}"
+    else
+      "#{env_name}_#{conference.abbr}_track#{track.name}"
+    end
+  end
+end

--- a/app/models/media_package_parameter.rb
+++ b/app/models/media_package_parameter.rb
@@ -26,6 +26,10 @@ class MediaPackageParameter < ApplicationRecord
   include SsmHelper
   include EnvHelper
 
+  before_destroy do
+    delete_aws_resource
+  end
+
   before_create :set_uuid
 
   belongs_to :streaming

--- a/app/models/streaming.rb
+++ b/app/models/streaming.rb
@@ -29,6 +29,9 @@ class Streaming < ApplicationRecord
   has_one :media_package_v2_channel_group
   has_one :media_package_v2_channel
   has_one :media_package_v2_origin_endpoint
+  has_one :media_package_channel
+  has_one :media_package_origin_endpoint
+  has_one :media_package_parameter
 
   STATUS_CREATING = 'creating'.freeze
   STATUS_CRTEATED = 'created'.freeze

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -21,7 +21,6 @@ class Track < ApplicationRecord
   has_many :talks
   has_one :live_stream_ivs
   has_one :live_stream_media_live
-  has_one :media_package_channel
   has_one :streaming
 
   belongs_to :room, optional: true

--- a/app/views/admin/streamings/index.html.erb
+++ b/app/views/admin/streamings/index.html.erb
@@ -101,6 +101,9 @@
           <tr>
             <td>MediaPackage V2 ChannelGroup</td><td><%= track.streaming&.media_package_v2_channel_group&.name %></td>
           </tr>
+          <tr>
+            <td>MediaPackage Channel</td><td><%= track.streaming&.media_package_channel&.channel_id %></td>
+          </tr>
           </tbody>
         </table>
       </div>

--- a/db/migrate/20230909035236_add_streaming_id_columns_to_media_package_tables.rb
+++ b/db/migrate/20230909035236_add_streaming_id_columns_to_media_package_tables.rb
@@ -1,0 +1,31 @@
+class AddStreamingIdColumnsToMediaPackageTables < ActiveRecord::Migration[7.0]
+  def up
+    create_table :media_package_parameters, id: :string do |t|
+      t.belongs_to :streaming, null: false, foreign_key: true, type: :string
+      t.belongs_to :media_package_channel, null: false, foreign_key: true, type: :bigint
+
+      t.string :name, null: true
+      t.timestamps
+    end unless ActiveRecord::Base.connection.table_exists?(:media_package_parameters)
+
+    add_belongs_to :media_package_channels, :streaming, null: true, foreign_key: true, type: :string
+    add_belongs_to :media_package_origin_endpoints, :streaming, null: true, foreign_key: true, type: :string
+
+    remove_belongs_to :media_package_channels, :conference
+    remove_belongs_to :media_package_channels, :track
+
+    remove_belongs_to :media_package_origin_endpoints, :conference
+  end
+
+  def down
+    add_belongs_to :media_package_origin_endpoints, :conference, null: false, foreign_key: true, type: :bigint
+
+    add_belongs_to :media_package_channels, :track, null: false, foreign_key: true, type: :bigint
+    add_belongs_to :media_package_channels, :conference, null: false, foreign_key: true, type: :bigint
+
+    remove_belongs_to :media_package_channels, :streaming
+    remove_belongs_to :media_package_origin_endpoints, :streaming
+
+    drop_table :media_package_parameters
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_132249) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_09_035236) do
   create_table "access_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "sub"
@@ -163,12 +163,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_132249) do
   end
 
   create_table "media_package_channels", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "conference_id", null: false
-    t.bigint "track_id", null: false
     t.string "channel_id", default: ""
+    t.string "streaming_id"
     t.index ["channel_id"], name: "index_media_package_channels_on_channel_id"
-    t.index ["conference_id"], name: "index_media_package_channels_on_conference_id"
-    t.index ["track_id"], name: "index_media_package_channels_on_track_id"
+    t.index ["streaming_id"], name: "index_media_package_channels_on_streaming_id"
   end
 
   create_table "media_package_harvest_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -185,11 +183,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_132249) do
   end
 
   create_table "media_package_origin_endpoints", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "conference_id", null: false
     t.bigint "media_package_channel_id", null: false
     t.string "endpoint_id"
-    t.index ["conference_id"], name: "index_media_package_origin_endpoints_on_conference_id"
+    t.string "streaming_id"
     t.index ["media_package_channel_id"], name: "index_media_package_origin_endpoints_on_media_package_channel_id"
+    t.index ["streaming_id"], name: "index_media_package_origin_endpoints_on_streaming_id"
+  end
+
+  create_table "media_package_parameters", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "streaming_id", null: false
+    t.bigint "media_package_channel_id", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["media_package_channel_id"], name: "index_media_package_parameters_on_media_package_channel_id"
+    t.index ["streaming_id"], name: "index_media_package_parameters_on_streaming_id"
   end
 
   create_table "media_package_v2_channel_groups", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -577,13 +585,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_132249) do
   add_foreign_key "links", "conferences"
   add_foreign_key "live_streams", "conferences"
   add_foreign_key "live_streams", "tracks"
-  add_foreign_key "media_package_channels", "conferences"
-  add_foreign_key "media_package_channels", "tracks"
+  add_foreign_key "media_package_channels", "streamings"
   add_foreign_key "media_package_harvest_jobs", "conferences"
   add_foreign_key "media_package_harvest_jobs", "media_package_channels"
   add_foreign_key "media_package_harvest_jobs", "talks"
-  add_foreign_key "media_package_origin_endpoints", "conferences"
   add_foreign_key "media_package_origin_endpoints", "media_package_channels"
+  add_foreign_key "media_package_origin_endpoints", "streamings"
+  add_foreign_key "media_package_parameters", "media_package_channels"
+  add_foreign_key "media_package_parameters", "streamings"
   add_foreign_key "media_package_v2_channel_groups", "streamings"
   add_foreign_key "media_package_v2_channels", "streamings"
   add_foreign_key "media_package_v2_origin_endpoints", "streamings"


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/2020 の後続PR。

このPRでは既存のMediaPackage系リソースをStreamingリソースの管理下に移行します。また、MediaLiveからMediaPackageに送るために必要なパラメータを扱うためのテーブルも追加しています。