### PR TITLE
Change preparation message

### DIFF
--- a/app/javascript/stylesheets/cndt2023/_cndt2023.scss
+++ b/app/javascript/stylesheets/cndt2023/_cndt2023.scss
@@ -257,5 +257,14 @@
         top: 0px;
         display: block;
         background-color: $white;
+        @media (max-width: 576px) {
+            width: 90px;
+            height: 120px;
+        }
     }
+    
+}
+
+.talk-page {
+    margin-top: 80px;
 }

--- a/app/views/event/preparation.html.erb
+++ b/app/views/event/preparation.html.erb
@@ -2,10 +2,10 @@
   <div class="row justify-content-lg-center">
     <div class="col-12 col-lg-8 registration-form py-4" style="text-align:center">
       <h2 class="mb-4" style="text-align:center">準備中...</h2>
-      <h3 >現在一般参加機能を鋭意準備中です</h3>
+      <h3 >一般参加申込みはまだ開始しておりません。</h3>
       <br>
-      <h4>本サイトを利用する場合</h4>
-      <h4>ログアウトしてからご利用ください</h4>
+      <h4>応募されているセッション一覧をご覧になりたい場合は</h4>
+      <h4>一度<a href="https://staging.dev.cloudnativedays.jp/logout">ログアウト</a>してからご利用ください</h4>
     </div>
   </div>
 </div>

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 <% provide(:title, @talk.title) %>
 
-<div class="container white_background">
+<div class="container white_background talk-page">
   <div class="row my-3">
 
     <div class="col-12 col-lg-8 main-pane">


### PR DESCRIPTION
- ログアウトしないとCFP一覧が見れないので、その旨が分かりやすいように文言を修正
- ロゴが被って個別セッションのタイトルが隠れていたのを修正
- スマホだとロゴがデカすぎるので調整