### PR TITLE
ナビゲーション改善 & レビュー反映

### DIFF
--- a/app/views/event/partial/_information.html.erb
+++ b/app/views/event/partial/_information.html.erb
@@ -16,7 +16,7 @@
       <h5 class="text-white mt-0">想定来場者</h5>
       <p class="text-white-75 mb-4 text-center">インフラエンジニア, SRE, アプリエンジニアなど8割以上が開発者, その他 CTO/CIO, システムインテグレーターなど</p>
       <h5 class="text-white mt-0">キーワード</h5>
-      <p class="text-white-75 mb-4 text-center">Observability, Monitoring, CloudNative, Kubernetes, Container, Microservices, DevOps</p>
+      <p class="text-white-75 mb-4 text-center">CloudNative, Kubernetes, Container, SRE, Platform Engineering, Microservices, CI/CD, DevOps, Observability, </p>
     </div>
   </div>
 </div>

--- a/app/views/event/partial/_speaker_entry_button.html.erb
+++ b/app/views/event/partial/_speaker_entry_button.html.erb
@@ -4,5 +4,6 @@
     登壇者募集中!
     <% end %>
   </p>
-  <%= link_to speaker_entry_button_name, speaker_entry_button_path, {method: :get, class: "btn btn-entry btn-xl  m-2" } %>
+  <%= link_to speaker_entry_button_name, speaker_entry_button_path, {method: :get, class: "btn btn-entry btn-xl  m-2" } %><br/>
+  <%= link_to 'プロポーザル一覧を見る', talks_path, {method: :get, class: "btn btn-secondary btn-xl  m-2" } %>
 <% end %>

--- a/app/views/event/preparation.html.erb
+++ b/app/views/event/preparation.html.erb
@@ -5,7 +5,7 @@
       <h3 >一般参加申込みはまだ開始しておりません。</h3>
       <br>
       <h4>応募されているセッション一覧をご覧になりたい場合は</h4>
-      <h4>一度<a href="https://staging.dev.cloudnativedays.jp/logout">ログアウト</a>してからご利用ください</h4>
+      <h4>一度<a href="/logout">ログアウト</a>してからご利用ください</h4>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -26,7 +26,7 @@
               <li class="nav-item"><%= link_to "プロポーザル一覧", talks_path, class: "nav-link js-scroll-trigger" %></li>
             <% elsif %>
               <li class="nav-item dropdown">
-                <% if @conference.show_timetable_enabled? %>
+                <% if @conference.present? &&  @conference.show_timetable_enabled? %>
                 <li class="nav-item"><%= link_to "タイムテーブル", timetables_path, class: "nav-link js-scroll-trigger" %></li>
                 <% end %>
                 <li class="nav-item"><%= link_to "セッション一覧", talks_path, class: "nav-link js-scroll-trigger" %></li>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -22,15 +22,13 @@
             <% end %>
           <% end %>
           <% unless controller_name == "profiles" && (action_name == "new" || action_name == "create") %>
-            <% if @conference.present? && @conference.opened? %>
-              <li class="nav-item"><%= link_to "Booths", booths_path, class: "nav-link js-scroll-trigger" %></li>
-            <% end %>
-
             <% if @conference.present? && @conference.speaker_entry_enabled? %>
               <li class="nav-item"><%= link_to "プロポーザル一覧", talks_path, class: "nav-link js-scroll-trigger" %></li>
             <% elsif %>
               <li class="nav-item dropdown">
+                <% if @conference.show_timetable_enabled? %>
                 <li class="nav-item"><%= link_to "タイムテーブル", timetables_path, class: "nav-link js-scroll-trigger" %></li>
+                <% end %>
                 <li class="nav-item"><%= link_to "セッション一覧", talks_path, class: "nav-link js-scroll-trigger" %></li>
                 <li class="nav-item"><%= link_to "Grafana", o11y_path, class: "nav-link js-scroll-trigger" %></li>
               </li>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -26,7 +26,7 @@
               <li class="nav-item"><%= link_to "Booths", booths_path, class: "nav-link js-scroll-trigger" %></li>
             <% end %>
 
-            <% if @conference.speaker_entry_enabled? %>
+            <% if @conference.present? && @conference.speaker_entry_enabled? %>
               <li class="nav-item"><%= link_to "プロポーザル一覧", talks_path, class: "nav-link js-scroll-trigger" %></li>
             <% elsif %>
               <li class="nav-item dropdown">

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -26,17 +26,15 @@
               <li class="nav-item"><%= link_to "Booths", booths_path, class: "nav-link js-scroll-trigger" %></li>
             <% end %>
 
-            <li class="nav-item dropdown">
-              <%= link_to "SessionList", '#', id: "navbarDropdown", class: 'nav-link', role: "button", 'data-toggle': "dropdown", 'aria-haspopup': "true", 'aria-expanded': "false" %>
-              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                <% if @conference.present? && @conference.show_timetable_enabled? %>
-                  <%= link_to 'Timetable', timetables_path, class: "dropdown-item", data: {"turbolinks" => false} %>
-                  <div class="dropdown-divider"></div>
-                <% end %>
-                <%= link_to 'セッションリスト', talks_path, class: "dropdown-item", data: {"turbolinks" => false} %>
-              </div>
-            </li>
-            <li class="nav-item"><%= link_to "Grafana", o11y_path, class: "nav-link js-scroll-trigger" %></li>
+            <% if @conference.speaker_entry_enabled? %>
+              <li class="nav-item"><%= link_to "プロポーザル一覧", talks_path, class: "nav-link js-scroll-trigger" %></li>
+            <% elsif %>
+              <li class="nav-item dropdown">
+                <li class="nav-item"><%= link_to "タイムテーブル", timetables_path, class: "nav-link js-scroll-trigger" %></li>
+                <li class="nav-item"><%= link_to "セッション一覧", talks_path, class: "nav-link js-scroll-trigger" %></li>
+                <li class="nav-item"><%= link_to "Grafana", o11y_path, class: "nav-link js-scroll-trigger" %></li>
+              </li>
+            <% end %>
 
             <% case event_name %>
             <% when 'cndt2020' %>

--- a/app/views/speaker_dashboard/speakers/_form.html.erb
+++ b/app/views/speaker_dashboard/speakers/_form.html.erb
@@ -69,7 +69,7 @@
   <section class="speaker-information py-3">
     <a id="sessions"><h3 class="py-3">セッション情報</h3></a>
     <p class="alert alert-info">
-      <%= link_to 'CFP要項を確認する', speakers_guidance_path %>
+      <%= link_to 'CFP要項を確認する', speakers_guidance_path, {target: :_blank, style: 'text-decoration: underline'} %>
     </p>
 
 

--- a/app/views/speaker_dashboard/speakers/_form.html.erb
+++ b/app/views/speaker_dashboard/speakers/_form.html.erb
@@ -35,7 +35,7 @@
     </div>
 
     <div class="field pb-3">
-      <%= form.label :twitter_id, 'Twitter ID' %>
+      <%= form.label :twitter_id, 'X(Twitter) ID' %>
       <%= form.text_field :twitter_id, class: "form-control", placeholder: 'cloudnativedays'  %>
     </div>
 

--- a/app/views/speaker_dashboard/speakers/_speaker_info.html.erb
+++ b/app/views/speaker_dashboard/speakers/_speaker_info.html.erb
@@ -20,7 +20,7 @@
     <h5 class="card-title">過去の登壇実績が分かるスライド等</h5>
     <div class="card-text"><%= simple_format speaker.additional_documents %></div>
 
-    <h5 class="card-title">Twitter ID</h5>
+    <h5 class="card-title">X(Twitter) ID</h5>
     <div class="card-text"><%= speaker.twitter_id %></div>
 
     <h5 class="card-title">GitHub ID</h5>

--- a/app/views/speaker_dashboard/speakers/edit.html.erb
+++ b/app/views/speaker_dashboard/speakers/edit.html.erb
@@ -3,7 +3,7 @@
     <div class="col-12 col-lg-8">
       <%= render 'form', speaker: @speaker %>
 
-      <%= link_to 'Back', speaker_dashboard_path %>
+      <%= link_to 'Back', speaker_dashboard_path, {class: "btn btn-secondary"} %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- SessionListだと視認性が悪かったので、CFP期間は「プロポーザル一覧」 それ以外は「セッション一覧」「タイムテーブル」と切り替わるようにした
- SessionListの中にさらにプルダウンだったのを、平置きのリンクに変えた
- 登壇者登録の下にプロポーザル一覧ボタンを設置
- TwitterをX(Twitter)表記に
- ボタンのスタイルをあてた
- 開催概要のキーワードがo11yのままだった
