### PR TITLE
Docker metaにトリガーを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
           images: ${{ steps.login-ecr.outputs.registry }}/dreamkast-ecs
           tags: |
             type=ref,event=branch
+            type=ref,event=tag
 
       - name: Create a New Image
         run: |


### PR DESCRIPTION
`Docker meta`がpush tagでも起動するようにトリガーを追加