### PR TITLE
Proposalに関する情報をExporterで出力できるようにする

### DIFF
--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -33,7 +33,7 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
         labels: [:conference_id, :talk_difficulty_name]
       ),
       Prometheus::Client::Gauge.new(
-        :dreamkast_select_proposal_items,
+        :dreamkast_proposal_params_count,
         docstring: 'select dreamkast proposal items',
         labels: [:conference_id, :proposal_items_label, :proposal_items_params]
       )
@@ -106,10 +106,10 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
     end
   end
 
-  def dreamkast_select_proposal_items(metrics)
-    ProposalItem.all.each do |proposal_items|
+  def dreamkast_proposal_params_count(metrics)
+    Talk.count_proposal_params.each do |proposal_items|
       metrics.set(
-        proposal_items.talk_id,
+        proposal_items.count,
         labels: { conference_id: proposal_items.conference_id, proposal_items_label: proposal_items.label, proposal_items_params: proposal_items.params }
       )
     end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -95,6 +95,6 @@ class Conference < ApplicationRecord
   end
 
   def iminonaimethod
-    p 'aaa'
+    p('aaa')
   end
 end

--- a/app/models/proposal_item.rb
+++ b/app/models/proposal_item.rb
@@ -32,11 +32,4 @@ class ProposalItem < ApplicationRecord
       params.map { |param| ProposalItemConfig.find(param.to_i) }
     end
   end
-
-  def self.select_proposal_items
-    select('talks.id AS talk_id, proposal_items.label, proposal_items.params, proposal_items.conference_id')
-      .from('proposal_items')
-      .left_joins(:talk)
-      .where(label: ['presentation_method', 'assumed_visitor', 'execution_phase', 'whether_it_can_be_published', 'session_time', 'language'])
-  end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -248,6 +248,12 @@ class Talk < ApplicationRecord
       .select('COUNT(*) AS count, talk_difficulties.name, talks.conference_id')
   end
 
+  def self.count_proposal_params
+    joins(:proposal_items)
+      .group('talks.conference_id', 'proposal_items.label', 'proposal_items.params')
+      .select('talks.conference_id, proposal_items.label, proposal_items.params, count(talks.id) as count')
+  end
+
   def category
     talk_category.present? ? talk_category.name : ''
   end


### PR DESCRIPTION
- models/proposal_item.rbのメソッドをmodels/talk.rbへ変更
- クエリ内容をselectからカウントに変更
- `rubocop -a`による修正 