### PR TITLE
Proposalに関する情報をExporterで出力できるようにする

### DIFF
--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -33,9 +33,9 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
         labels: [:conference_id, :talk_difficulty_name]
       ),
       Prometheus::Client::Gauge.new(
-        :dreamkast_select_proposal_items,
-        docstring: 'select dreamkast proposal items',
-        labels: [:talk_id, :conference_id, :proposal_items_label, :proposal_items_params]
+        :dreamkast_count_proposal_items,
+        docstring: 'count dreamkast proposal items',
+        labels: [:conference_id, :proposal_items_label, :proposal_items_params]
       )
     ]
     metrics.each do |metric|
@@ -106,11 +106,15 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
     end
   end
 
-  def dreamkast_select_proposal_items(metrics)
-    ProposalItem.all.each do |proposal_items|
+  def dreamkast_count_proposal_items(metrics)
+    ProposalItem.count_proposal_items.each do |proposal_item|
       metrics.set(
-        proposal_items.talk_id,
-        labels: { talk_id: proposal_items.talk_id, conference_id: proposal_items.conference_id, proposal_items_label: proposal_items.label, proposal_items_params: proposal_items.params }
+        proposal_item.count,
+        labels: {
+          conference_id: proposal_item.conference_id,
+          proposal_items_label: proposal_item.label,
+          proposal_items_params: proposal_item.value_name
+        }
       )
     end
   end

--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -35,7 +35,7 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
       Prometheus::Client::Gauge.new(
         :dreamkast_select_proposal_items,
         docstring: 'select dreamkast proposal items',
-        labels: [:conference_id, :proposal_items_label, :proposal_items_params]
+        labels: [:talk_id, :conference_id, :proposal_items_label, :proposal_items_params]
       )
     ]
     metrics.each do |metric|
@@ -110,7 +110,7 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
     ProposalItem.all.each do |proposal_items|
       metrics.set(
         proposal_items.talk_id,
-        labels: { conference_id: proposal_items.conference_id, proposal_items_label: proposal_items.label, proposal_items_params: proposal_items.params }
+        labels: { talk_id: proposal_items.talk_id, conference_id: proposal_items.conference_id, proposal_items_label: proposal_items.label, proposal_items_params: proposal_items.params }
       )
     end
   end

--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -33,9 +33,9 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
         labels: [:conference_id, :talk_difficulty_name]
       ),
       Prometheus::Client::Gauge.new(
-        :dreamkast_count_proposal_items,
-        docstring: 'count dreamkast proposal items',
-        labels: [:conference_id, :proposal_items_label, :proposal_items_params]
+        :dreamkast_select_proposal_items,
+        docstring: 'select dreamkast proposal items',
+        labels: [:talk_id, :conference_id, :proposal_items_label, :proposal_items_params]
       )
     ]
     metrics.each do |metric|
@@ -106,15 +106,11 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
     end
   end
 
-  def dreamkast_count_proposal_items(metrics)
-    ProposalItem.count_proposal_items.each do |proposal_item|
+  def dreamkast_select_proposal_items(metrics)
+    ProposalItem.all.each do |proposal_items|
       metrics.set(
-        proposal_item.count,
-        labels: {
-          conference_id: proposal_item.conference_id,
-          proposal_items_label: proposal_item.label,
-          proposal_items_params: proposal_item.value_name
-        }
+        proposal_items.talk_id,
+        labels: { talk_id: proposal_items.talk_id, conference_id: proposal_items.conference_id, proposal_items_label: proposal_items.label, proposal_items_params: proposal_items.params }
       )
     end
   end

--- a/app/models/proposal_item.rb
+++ b/app/models/proposal_item.rb
@@ -33,10 +33,10 @@ class ProposalItem < ApplicationRecord
     end
   end
 
-  def self.count_proposal_items
-    select('proposal_items.label, proposal_item_configs.params as value_name, proposal_items.conference_id, COUNT(*) as count')
-      .joins('LEFT JOIN proposal_item_configs ON proposal_item_configs.id = proposal_items.params')
+  def self.select_proposal_items
+    select('talks.id AS talk_id, proposal_items.label, proposal_items.params, proposal_items.conference_id')
+      .from('proposal_items')
+      .left_joins(:talk)
       .where(label: ['presentation_method', 'assumed_visitor', 'execution_phase', 'whether_it_can_be_published', 'session_time', 'language'])
-      .group('proposal_items.label, proposal_item_configs.params,proposal_items.conference_id')
   end
 end

--- a/app/models/proposal_item.rb
+++ b/app/models/proposal_item.rb
@@ -35,6 +35,6 @@ class ProposalItem < ApplicationRecord
 
   def self.select_proposal_items
     ProposalItem.joins(:talk)
-                 .select(:talks.id AS talk_id, :label, :params, :conference_id)
+                .select(:talks.id(AS(talk_id)), :label, :params, :conference_id)
   end
 end

--- a/app/models/proposal_item.rb
+++ b/app/models/proposal_item.rb
@@ -33,10 +33,10 @@ class ProposalItem < ApplicationRecord
     end
   end
 
-  def self.select_proposal_items
-    select('talks.id AS talk_id, proposal_items.label, proposal_items.params, proposal_items.conference_id')
-      .from('proposal_items')
-      .left_joins(:talk)
+  def self.count_proposal_items
+    select('proposal_items.label, proposal_item_configs.params as value_name, proposal_items.conference_id, COUNT(*) as count')
+      .joins('LEFT JOIN proposal_item_configs ON proposal_item_configs.id = proposal_items.params')
       .where(label: ['presentation_method', 'assumed_visitor', 'execution_phase', 'whether_it_can_be_published', 'session_time', 'language'])
+      .group('proposal_items.label, proposal_item_configs.params,proposal_items.conference_id')
   end
 end

--- a/app/models/proposal_item.rb
+++ b/app/models/proposal_item.rb
@@ -34,9 +34,7 @@ class ProposalItem < ApplicationRecord
   end
 
   def self.select_proposal_items
-    select('talks.id AS talk_id, proposal_items.label, proposal_items.params, proposal_items.conference_id')
-      .from('proposal_items')
-      .left_joins(:talk)
-      .where(label: ['presentation_method', 'assumed_visitor', 'execution_phase', 'whether_it_can_be_published', 'session_time', 'language'])
+    ProposalItem.joins(:talk)
+                 .select(:talks.id AS talk_id, :label, :params, :conference_id)
   end
 end


### PR DESCRIPTION
#2059　の修正版。
メトリクス`dreamkast_select_proposal_items`のlabelsにtalk_idを追加することで正しく件数を取得する。