### PR TITLE
Speakers のスタイルを修正

### DIFF
--- a/app/views/event/cndt2023_show.html.erb
+++ b/app/views/event/cndt2023_show.html.erb
@@ -96,7 +96,7 @@
                   lunch_break = 80
                   each_break = (talk.start_time.in_time_zone('Asia/Tokyo').hour - 13) * 20
                 end
-                
+
                 total_break = lunch_break + each_break
 
                 row_start = ((talk.start_time.in_time_zone('Asia/Tokyo') - Time.zone.parse("2000-01-01 09:50")) / 60).to_i - total_break
@@ -164,8 +164,10 @@
               <% @talks.each do |talk| %>
                 <% talk.speakers.each do |speaker| %>
                   <li>
-                    <%= image_tag speaker.avatar_or_dummy_url(:medium), :size => '100x100', class: "rounded-circle" %><br/>
-                    <%= speaker&.name %>
+                    <div style="width: min-content">
+                      <%= image_tag speaker.avatar_or_dummy_url(:medium), :size => '100x100', class: "rounded-circle" %><br/>
+                      <%= speaker&.name %>
+                    </div>
                   </li>
                 <% end %>
               <% end %>


### PR DESCRIPTION
Speakers のスタイルが名前の長さで伸び縮みしていたので `width: min-content` で文字溢れを修正しました.
その分縦幅が不ぞろいになりますが, 登壇者の名前を (...) で省略するのも良くないかなと思い, 横幅のずれよりは気になりにくいだろうということで縦に伸ばしています. 
下記はとりあえず本番で CSS を書き換えてみた例です.
![image](https://github.com/cloudnativedaysjp/dreamkast/assets/40717789/1a071c4d-7e96-447e-93bd-2d5ed115b12e)
