### PR TITLE
イベント開催中にダッシュボードを閲覧できない問題を解消する

### DIFF
--- a/app/controllers/attendee_dashboards_controller.rb
+++ b/app/controllers/attendee_dashboards_controller.rb
@@ -5,9 +5,6 @@ class AttendeeDashboardsController < ApplicationController
 
   def show
     @conference = Conference.includes(:talks).find_by(abbr: event_name)
-    if @conference.opened?
-      redirect_to(tracks_path)
-    end
 
     @announcements = @conference.announcements.published
     @speaker_announcements = @conference.speaker_announcements.find_by_speaker(@speaker.id) unless @speaker.nil?

--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -10,8 +10,9 @@ class EventController < ApplicationController
                   .includes(sponsor_types: [{ sponsors: :sponsor_attachment_logo_image }, :sponsors_sponsor_types])
                   .order('sponsor_types.order ASC')
                   .find_by(abbr: event_name)
-    if !@conference.speaker_entry_enabled? and logged_in? and (@conference.registered? || @conference.opened?)
-      redirect_to("/#{@conference.abbr}/dashboard")
+    if !@conference.speaker_entry_enabled? and logged_in?
+      redirect_to("/#{@conference.abbr}/dashboard") if @conference.registered?
+      redirect_to("/#{@conference.abbr}/ui") if @conference.opened?
     else
       @talks = @conference.talks.accepted.includes(:talks_speakers, :speakers)
 

--- a/app/views/attendee_dashboards/show.html.erb
+++ b/app/views/attendee_dashboards/show.html.erb
@@ -17,8 +17,31 @@
 
   <div class="row">
     <section id="main-pane card-group" class="col-12 col-md-8">
-      <div class="mt-3">
+      <% if @conference.opened? %>
+        <div class="mt-3">
+          <div class="card">
+            <div class="card-header">
+              <b><%= @conference.abbr.upcase %> 開催中！</b>
+            </div>
+
+            <div class="card-body">
+              <div class="card-text">
+                <div class="py-3 text-center">
+                  <div>
+                    <%= button_to '配信はこちらから！', "/#{@conference.abbr}/ui/", {method: :get, class: "btn btn-primary btn-xl" } %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="mt-3" id="project-list">
         <div class="card">
+          <div class="card-header">
+            <b>企画一覧</b>
+          </div>
           <div class="card-body" id="exhibition">
             <a href="https://eventregist.com/e/cndt2023_party">
               <div class="project">

--- a/spec/requests/tracks_spec.rb
+++ b/spec/requests/tracks_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe(TracksController, type: :request) do
           get '/cndt2020'
           expect(response).to_not(be_successful)
           expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('/cndt2020/dashboard'))
+          expect(response).to(redirect_to('/cndt2020/ui'))
         end
       end
     end


### PR DESCRIPTION
- conferenceがopenedの時でも `/dashboard` を見えるようにする
- conferenceがopenedの時、 `/dashboard` からUIへの導線を追加
- `/cndt2023` アクセス時、conferenceがopenedの時はUIにリダイレクトする。

UIからダッシュボードへの導線は https://github.com/cloudnativedaysjp/dreamkast-ui/pull/477 で追加します。