### PR TITLE
fix: cleanup script

### DIFF
--- a/lib/tasks/cleanup_profiles.rake
+++ b/lib/tasks/cleanup_profiles.rake
@@ -8,8 +8,8 @@ namespace :util do
 
     ActiveRecord::Base.transaction do
       conference = Conference.find_by(abbr:)
-      unless conference.archived?
-        raise "#{conference.abbr} is not archived yet"
+      unless conference.archived? || conference.migrated?
+        raise "#{conference.abbr} is not archived or migrated yet"
       end
       conference.profiles.each do |profile|
         AccessLog.where(profile_id: profile.id).each(&:destroy!)
@@ -21,6 +21,7 @@ namespace :util do
         CheckIn.where(profile_id: profile.id).each do |check_in|
           check_in.update!(profile_id: nil)
         end
+        PublicProfile.where(profile_id: profile.id).destroy_all
         profile.destroy!
       end
     end

--- a/spec/rake/cleanup_profiles_spec.rb
+++ b/spec/rake/cleanup_profiles_spec.rb
@@ -58,7 +58,7 @@ describe 'cleanup_profiles' do
     let!(:cndt2020) { create(:cndt2020, :registered) }
 
     it 'doesn\'t work' do
-      expect { @rake[task].invoke }.to(raise_error('cndt2020 is not archived yet'))
+      expect { @rake[task].invoke }.to(raise_error('cndt2020 is not archived or migrated yet'))
     end
   end
 
@@ -66,7 +66,7 @@ describe 'cleanup_profiles' do
     let!(:cndt2020) { create(:cndt2020, :opened) }
 
     it 'doesn\'t work' do
-      expect { @rake[task].invoke }.to(raise_error('cndt2020 is not archived yet'))
+      expect { @rake[task].invoke }.to(raise_error('cndt2020 is not archived or migrated yet'))
     end
   end
 
@@ -74,7 +74,7 @@ describe 'cleanup_profiles' do
     let!(:cndt2020) { create(:cndt2020, :closed) }
 
     it 'doesn\'t work' do
-      expect { @rake[task].invoke }.to(raise_error('cndt2020 is not archived yet'))
+      expect { @rake[task].invoke }.to(raise_error('cndt2020 is not archived or migrated yet'))
     end
   end
 end


### PR DESCRIPTION
conferenceに `migrated` ステータスを追加していたのでcleanupスクリプトでも対応する