### PR TITLE
Proposal APIにKeynoteやスポンサーセッションが含まれてしまっている問題の修正

### DIFF
--- a/app/controllers/api/v1/proposals_controller.rb
+++ b/app/controllers/api/v1/proposals_controller.rb
@@ -7,7 +7,10 @@ class Api::V1::ProposalsController < ApplicationController
   def index
     @conference = Conference.find_by(abbr: params[:eventAbbr])
     query = { conference_id: @conference.id }
-    @proposals = Proposal.where(query)
+    @proposals = Proposal
+        .includes(:talk)
+        .where(query)
+        .where(talk: { type: "Session" })
     render(:index, formats: :json, type: :jbuilder)
   end
 end

--- a/app/controllers/api/v1/proposals_controller.rb
+++ b/app/controllers/api/v1/proposals_controller.rb
@@ -8,9 +8,9 @@ class Api::V1::ProposalsController < ApplicationController
     @conference = Conference.find_by(abbr: params[:eventAbbr])
     query = { conference_id: @conference.id }
     @proposals = Proposal
-        .includes(:talk)
-        .where(query)
-        .where(talk: { type: "Session" })
+                 .includes(:talk)
+                 .where(query)
+                 .where(talk: { type: 'Session' })
     render(:index, formats: :json, type: :jbuilder)
   end
 end

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -20,7 +20,7 @@
         <th scope="col">Speakers</th>
         <th scope="col">Title / Abstract</th>
         <th scope="col">Status</th>
-        <th scope="col">SponsorSession?</th>
+        <th scope="col">Type</th>
       </tr>
       </thead>
       <tbody>
@@ -40,7 +40,7 @@
             </td>
 
             <td>
-              <%= proposal.talk.sponsor.present? ? proposal.talk.sponsor.name : '' %>
+              <%= proposal.talk.type %>
             </td>
           </tr>
         <% end %>

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -220,6 +220,12 @@ FactoryBot.define do
     show_on_timetable { true }
     video_published { true }
     document_url { 'http://' }
+
+    trait :accepted do
+      after(:build) do |talk|
+        create(:proposal, talk:, status: 1, conference_id: talk.conference_id)
+      end
+    end
   end
 
   factory :has_no_conference_days, class: Talk do
@@ -249,5 +255,25 @@ FactoryBot.define do
     track_id { 1 }
     show_on_timetable { false }
     video_published { true }
+  end
+
+  factory :keynote_session, class: Talk do
+    title { 'keynote_session' }
+    type { 'KeynoteSession' }
+    start_time { '12:30' }
+    end_time { '12:40' }
+    conference_id { 1 }
+    conference_day_id { 1 }
+    talk_difficulty_id { 1 }
+    track_id { 1 }
+    show_on_timetable { true }
+    video_published { true }
+    document_url { 'http://' }
+
+    trait :accepted do
+      after(:build) do |talk|
+        create(:proposal, talk:, status: 1, conference_id: talk.conference_id)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/proposal_index_spec.rb
+++ b/spec/requests/api/v1/proposal_index_spec.rb
@@ -17,5 +17,19 @@ describe Api::V1::ProposalsController, type: :request do
       get '/api/v1/proposals?eventAbbr=cndt2020'
       expect(response.status).to(eq(200))
     end
+
+    context 'return only Session type' do
+      before do
+        create(:talk2, :accepted)
+        create(:sponsor_session, :accepted)
+        create(:keynote_session, :accepted)
+      end
+
+      it 'return only session talk' do
+        get '/api/v1/proposals?eventAbbr=cndt2020'
+        expect(response).to(have_http_status(:ok))
+        expect(response.parsed_body.length).to(eq 2)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/proposal_index_spec.rb
+++ b/spec/requests/api/v1/proposal_index_spec.rb
@@ -28,7 +28,7 @@ describe Api::V1::ProposalsController, type: :request do
       it 'return only session talk' do
         get '/api/v1/proposals?eventAbbr=cndt2020'
         expect(response).to(have_http_status(:ok))
-        expect(response.parsed_body.length).to(eq 2)
+        expect(response.parsed_body.length).to(eq(2))
       end
     end
   end


### PR DESCRIPTION
#2076 

Session type の Talk だけを表示するように修正しました。

また、Session type カラムが追加された変更に合わせて管理画面のプロポーザルリストのカラムを SponserSession? から Type に変更しました（Keynote？を追加するよりは Type で一覧表示した方がよいかなという判断でした）。