### PR TITLE
add permission to comment PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   run-test:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     if: github.event.pusher.name != 'dreamkast-cloudnativedays'
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- フォークされたリポジトリからのPRについて、CI内のSimplecov Reportがコケる
  - secrets.GITHUB_TOKENに権限がないため https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
- そのため、permissionsでpull-requests: write権限を追加する
  -  フォークされたリポジトリからのPR のようなoutside collaboratorからのPRについて、CIはcontributorのapprovalがないと動かないのでセキュリティ的にも問題はなさそう
