### PR TITLE
Suppress committee warning

### DIFF
--- a/spec/requests/api/v1/chat_message_index_spec.rb
+++ b/spec/requests/api/v1/chat_message_index_spec.rb
@@ -37,7 +37,7 @@ describe Api::V1::ChatMessagesController, type: :request do
 
     it 'confirm json schema' do
       get '/api/v1/chat_messages?eventAbbr=cndt2020&roomId=1&roomType=talk'
-      assert_response_schema_confirm
+      assert_response_schema_confirm(200)
     end
   end
 end

--- a/spec/requests/api/v1/chat_message_update_spec.rb
+++ b/spec/requests/api/v1/chat_message_update_spec.rb
@@ -30,7 +30,6 @@ describe Api::V1::ChatMessagesController, type: :request do
 
       it 'confirm json schema' do
         put '/api/v1/chat_messages/1', params: { eventAbbr: 'cndt2020', body: 'hogehoge' }
-        expect(response).to(have_http_status(:no_content))
         assert_response_schema_confirm(204)
       end
 
@@ -53,7 +52,6 @@ describe Api::V1::ChatMessagesController, type: :request do
 
     it 'confirm json schema' do
       put "/api/v1/chat_messages/#{msg.id}", params: { eventAbbr: 'cndt2020', body: 'hogehoge' }
-      expect(response).to(have_http_status(:forbidden))
       assert_response_schema_confirm(403)
     end
 

--- a/spec/requests/api/v1/chat_message_update_spec.rb
+++ b/spec/requests/api/v1/chat_message_update_spec.rb
@@ -31,7 +31,7 @@ describe Api::V1::ChatMessagesController, type: :request do
       it 'confirm json schema' do
         put '/api/v1/chat_messages/1', params: { eventAbbr: 'cndt2020', body: 'hogehoge' }
         expect(response).to(have_http_status(:no_content))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(204)
       end
 
       it 'succeed request' do
@@ -54,7 +54,7 @@ describe Api::V1::ChatMessagesController, type: :request do
     it 'confirm json schema' do
       put "/api/v1/chat_messages/#{msg.id}", params: { eventAbbr: 'cndt2020', body: 'hogehoge' }
       expect(response).to(have_http_status(:forbidden))
-      assert_response_schema_confirm
+      assert_response_schema_confirm(403)
     end
 
     it 'succeed request' do

--- a/spec/requests/api/v1/conference_index_spec.rb
+++ b/spec/requests/api/v1/conference_index_spec.rb
@@ -10,7 +10,6 @@ describe Api::V1::ConferencesController, type: :request do
 
       it 'confirm json schema' do
         get '/api/v1/events'
-        expect(response).to(have_http_status(:ok))
         expect(response.body).to(include('cndt2020'))
         expect(response.body).to(include('cndo2021'))
         assert_response_schema_confirm(200)

--- a/spec/requests/api/v1/conference_index_spec.rb
+++ b/spec/requests/api/v1/conference_index_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::ConferencesController, type: :request do
         expect(response).to(have_http_status(:ok))
         expect(response.body).to(include('cndt2020'))
         expect(response.body).to(include('cndo2021'))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
       end
     end
   end

--- a/spec/requests/api/v1/conference_show_spec.rb
+++ b/spec/requests/api/v1/conference_show_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::ConferencesController, type: :request do
         expect(response).to(have_http_status(:ok))
         expect(response.body).to(include('cndt2020'))
         expect(response.body).not_to(include('cndo2021'))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
       end
     end
   end

--- a/spec/requests/api/v1/conference_show_spec.rb
+++ b/spec/requests/api/v1/conference_show_spec.rb
@@ -10,7 +10,6 @@ describe Api::V1::ConferencesController, type: :request do
 
       it 'should have valid conference' do
         get '/api/v1/events/cndt2020'
-        expect(response).to(have_http_status(:ok))
         expect(response.body).to(include('cndt2020'))
         expect(response.body).not_to(include('cndo2021'))
         assert_response_schema_confirm(200)

--- a/spec/requests/api/v1/event_show_spec.rb
+++ b/spec/requests/api/v1/event_show_spec.rb
@@ -8,7 +8,6 @@ describe EventController, type: :request do
 
     it 'confirm json schema' do
       get '/api/v1/events/cndt2020'
-      expect(response).to(have_http_status(:ok))
       assert_response_schema_confirm(200)
     end
 

--- a/spec/requests/api/v1/event_show_spec.rb
+++ b/spec/requests/api/v1/event_show_spec.rb
@@ -9,7 +9,7 @@ describe EventController, type: :request do
     it 'confirm json schema' do
       get '/api/v1/events/cndt2020'
       expect(response).to(have_http_status(:ok))
-      assert_response_schema_confirm
+      assert_response_schema_confirm(200)
     end
 
     it 'successed request' do

--- a/spec/requests/api/v1/proposal_index_spec.rb
+++ b/spec/requests/api/v1/proposal_index_spec.rb
@@ -9,7 +9,6 @@ describe Api::V1::ProposalsController, type: :request do
 
     it 'confirm json schema' do
       get '/api/v1/proposals?eventAbbr=cndt2020'
-      expect(response).to(have_http_status(:ok))
       assert_response_schema_confirm(200)
     end
 

--- a/spec/requests/api/v1/proposal_index_spec.rb
+++ b/spec/requests/api/v1/proposal_index_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::ProposalsController, type: :request do
     it 'confirm json schema' do
       get '/api/v1/proposals?eventAbbr=cndt2020'
       expect(response).to(have_http_status(:ok))
-      assert_response_schema_confirm
+      assert_response_schema_confirm(200)
     end
 
     it 'succeed request' do

--- a/spec/requests/api/v1/speaker_index_spec.rb
+++ b/spec/requests/api/v1/speaker_index_spec.rb
@@ -12,7 +12,7 @@ describe Api::V1::SpeakersController, type: :request do
       it 'confirm json schema' do
         get '/api/v1/speakers?eventAbbr=cndt2020'
         expect(response).to(have_http_status(:ok))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
         expect(response.body).to(include('Alice'))
         expect(response.body).to(include('Bob'))
       end

--- a/spec/requests/api/v1/speaker_index_spec.rb
+++ b/spec/requests/api/v1/speaker_index_spec.rb
@@ -11,7 +11,6 @@ describe Api::V1::SpeakersController, type: :request do
 
       it 'confirm json schema' do
         get '/api/v1/speakers?eventAbbr=cndt2020'
-        expect(response).to(have_http_status(:ok))
         assert_response_schema_confirm(200)
         expect(response.body).to(include('Alice'))
         expect(response.body).to(include('Bob'))

--- a/spec/requests/api/v1/sponsor_index_spec.rb
+++ b/spec/requests/api/v1/sponsor_index_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::SponsorsController, type: :request do
     it 'confirm json schema' do
       get '/api/v1/sponsors?eventAbbr=cndt2020'
       expect(response).to(have_http_status(:ok))
-      assert_response_schema_confirm
+      assert_response_schema_confirm(200)
     end
 
     it 'successed request' do

--- a/spec/requests/api/v1/sponsor_index_spec.rb
+++ b/spec/requests/api/v1/sponsor_index_spec.rb
@@ -12,7 +12,6 @@ describe Api::V1::SponsorsController, type: :request do
 
     it 'confirm json schema' do
       get '/api/v1/sponsors?eventAbbr=cndt2020'
-      expect(response).to(have_http_status(:ok))
       assert_response_schema_confirm(200)
     end
 

--- a/spec/requests/api/v1/talk_index_spec.rb
+++ b/spec/requests/api/v1/talk_index_spec.rb
@@ -12,7 +12,6 @@ describe TalksController, type: :request do
 
       it 'confirm json schema' do
         get '/api/v1/talks?eventAbbr=cndt2020'
-        expect(response).to(have_http_status(:ok))
         assert_response_schema_confirm(200)
         expect(response.body).to(include('talk1'))
         expect(response.body).to(include('talk3'))
@@ -44,7 +43,6 @@ describe TalksController, type: :request do
 
       it 'confirm json schema' do
         get '/api/v1/talks?eventAbbr=cndt2020'
-        expect(response).to(have_http_status(:ok))
         assert_response_schema_confirm(200)
 
         expect(response.body).to(include('talk1'))

--- a/spec/requests/api/v1/talk_index_spec.rb
+++ b/spec/requests/api/v1/talk_index_spec.rb
@@ -13,7 +13,7 @@ describe TalksController, type: :request do
       it 'confirm json schema' do
         get '/api/v1/talks?eventAbbr=cndt2020'
         expect(response).to(have_http_status(:ok))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
         expect(response.body).to(include('talk1'))
         expect(response.body).to(include('talk3'))
       end
@@ -45,7 +45,7 @@ describe TalksController, type: :request do
       it 'confirm json schema' do
         get '/api/v1/talks?eventAbbr=cndt2020'
         expect(response).to(have_http_status(:ok))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
 
         expect(response.body).to(include('talk1'))
         expect(response.body).to(include('"conferenceDayId":null'))

--- a/spec/requests/api/v1/talk_show_spec.rb
+++ b/spec/requests/api/v1/talk_show_spec.rb
@@ -12,7 +12,7 @@ describe TalksController, type: :request do
       it 'confirm json schema' do
         get '/api/v1/talks/1'
         expect(response).to(have_http_status(:ok))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
       end
 
       it 'successed request' do
@@ -30,7 +30,7 @@ describe TalksController, type: :request do
       it 'confirm json schema' do
         get '/api/v1/talks/1'
         expect(response).to(have_http_status(:ok))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
 
         expect(response.body).to(include('talk1'))
         expect(response.body).to(include('"conferenceDayId":null'))

--- a/spec/requests/api/v1/talk_show_spec.rb
+++ b/spec/requests/api/v1/talk_show_spec.rb
@@ -11,7 +11,6 @@ describe TalksController, type: :request do
 
       it 'confirm json schema' do
         get '/api/v1/talks/1'
-        expect(response).to(have_http_status(:ok))
         assert_response_schema_confirm(200)
       end
 
@@ -29,7 +28,6 @@ describe TalksController, type: :request do
 
       it 'confirm json schema' do
         get '/api/v1/talks/1'
-        expect(response).to(have_http_status(:ok))
         assert_response_schema_confirm(200)
 
         expect(response.body).to(include('talk1'))

--- a/spec/requests/api/v1/track_index_spec.rb
+++ b/spec/requests/api/v1/track_index_spec.rb
@@ -10,7 +10,6 @@ describe TalksController, type: :request do
 
     it 'confirm json schema' do
       get '/api/v1/tracks?eventAbbr=cndt2020'
-      expect(response).to(have_http_status(:ok))
       assert_response_schema_confirm(200)
     end
 

--- a/spec/requests/api/v1/track_index_spec.rb
+++ b/spec/requests/api/v1/track_index_spec.rb
@@ -11,7 +11,7 @@ describe TalksController, type: :request do
     it 'confirm json schema' do
       get '/api/v1/tracks?eventAbbr=cndt2020'
       expect(response).to(have_http_status(:ok))
-      assert_response_schema_confirm
+      assert_response_schema_confirm(200)
     end
 
     it 'succeed request' do

--- a/spec/requests/api/v1/track_show_spec.rb
+++ b/spec/requests/api/v1/track_show_spec.rb
@@ -11,7 +11,7 @@ describe TalksController, type: :request do
     it 'confirm json schema' do
       get '/api/v1/tracks/1'
       expect(response).to(have_http_status(:ok))
-      assert_response_schema_confirm
+      assert_response_schema_confirm(200)
     end
 
     it 'successed request' do

--- a/spec/requests/api/v1/track_show_spec.rb
+++ b/spec/requests/api/v1/track_show_spec.rb
@@ -10,7 +10,6 @@ describe TalksController, type: :request do
 
     it 'confirm json schema' do
       get '/api/v1/tracks/1'
-      expect(response).to(have_http_status(:ok))
       assert_response_schema_confirm(200)
     end
 

--- a/spec/requests/api/v1/video_registration_spec.rb
+++ b/spec/requests/api/v1/video_registration_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::Talks::VideoRegistrationController, type: :request do
       it 'confirm json schema' do
         get('/api/v1/talks/1/video_registration', headers:)
         expect(response).to(have_http_status(:ok))
-        assert_response_schema_confirm
+        assert_response_schema_confirm(200)
       end
     end
 

--- a/spec/requests/api/v1/video_registration_spec.rb
+++ b/spec/requests/api/v1/video_registration_spec.rb
@@ -12,7 +12,6 @@ describe Api::V1::Talks::VideoRegistrationController, type: :request do
 
       it 'confirm json schema' do
         get('/api/v1/talks/1/video_registration', headers:)
-        expect(response).to(have_http_status(:ok))
         assert_response_schema_confirm(200)
       end
     end


### PR DESCRIPTION
Since committee gem v4.4.0, `assert_response_schema_confirm` requires HTTP status code explictly.
Been seeing this message a lot in the logs, so fix that up.

> Pass expected response status code to check it against the corresponding schema explicitly.

Also, since we're now testing response status code with `assert_response_schema_confirm(200)`,
so we no longer need our own test `expect(response).to(have_http_status(:ok))`.
