### PR TITLE
Disable SQL log in test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,10 +54,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
-  config.log_formatter = ::Logger::Formatter.new
-  logger           = ActiveSupport::Logger.new($stdout)
-  logger.formatter = config.log_formatter
-  config.logger    = ActiveSupport::TaggedLogging.new(logger)
+
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 end

--- a/lib/tasks/cleanup_profiles.rake
+++ b/lib/tasks/cleanup_profiles.rake
@@ -1,8 +1,10 @@
 namespace :util do
   desc 'cleanup_profiles'
   task cleanup_profiles: :environment do
-    ActiveRecord::Base.logger = Logger.new($stdout)
-    Rails.logger.level = Logger::DEBUG
+    unless Rails.env.test?
+      ActiveRecord::Base.logger = Logger.new($stdout)
+      Rails.logger.level = Logger::DEBUG
+    end
 
     abbr = ENV.fetch('EVENT_ABBR')
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,9 +31,6 @@ rescue ActiveRecord::PendingMigrationError => e
   exit(1)
 end
 
-Rails.logger = Logger.new(STDOUT) # Rails.loggerを出す
-ActiveRecord::Base.logger = Logger.new(STDOUT) # SQLログ出す
-
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Changing log level during testing generates a large amount of unnecessary log messages.
This change ensures the use of the default logging configuration in tests, thereby simplifying the focus on test results.