### PR TITLE
Use released awesome_nested_set gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem 'redcarpet'
 gem "uppy-s3_multipart", "~> 1.0"
 gem "image_processing", "~> 1.12.2"
 
-gem 'awesome_nested_set', github: "collectiveidea/awesome_nested_set"
+gem 'awesome_nested_set'
 gem 'aws-sdk-rails'
 
 gem 'activerecord-nulldb-adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/collectiveidea/awesome_nested_set.git
-  revision: 3913eca5981ec60662985fe39adf988eb5c2731d
-  specs:
-    awesome_nested_set (3.5.0)
-      activerecord (>= 4.0.0, < 7.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,6 +76,8 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    awesome_nested_set (3.6.0)
+      activerecord (>= 4.0.0, < 7.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.817.0)
     aws-record (2.7.0)
@@ -684,7 +679,7 @@ DEPENDENCIES
   active_hash
   activerecord-nulldb-adapter
   annotate
-  awesome_nested_set!
+  awesome_nested_set
   aws-sdk-cloudfront
   aws-sdk-ivs
   aws-sdk-medialive


### PR DESCRIPTION
In PR #1103, awesome_nested_set gem is specified directly from GitHub to support Rails 7.
(At that time v3.5.0 had not been released yet.)
Revert to using gem from the RubyGems repository.

NOTE: awesome_nested_set v3.6.0 has been released.
https://github.com/collectiveidea/awesome_nested_set/compare/3913eca598...v3.6.0