### PR TITLE
Remove DEPRECATED /docker-entrypoint-initaws.d

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -97,7 +97,6 @@ services:
       - DEFAULT_REGION=ap-northeast-1
       - DATA_DIR=/var/lib/localstack/data
     volumes:
-      - ./localstack/docker-entrypoint-initaws.d:/docker-entrypoint-initaws.d:ro
       - ./localstack/init:/etc/localstack/init:ro
       - ./localstack:/var/lib/localstack
     ports:

--- a/localstack/docker-entrypoint-initaws.d/README.md
+++ b/localstack/docker-entrypoint-initaws.d/README.md
@@ -1,2 +1,0 @@
-DEPRECATED: docker-entrypoint-initaws.d is no longer supported by the latest localstack, use /etc/localstack/init entrypoints.
-ref: https://docs.localstack.cloud/references/init-hooks/

--- a/localstack/docker-entrypoint-initaws.d/create_queue.sh
+++ b/localstack/docker-entrypoint-initaws.d/create_queue.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-awslocal sqs create-queue --queue-name default


### PR DESCRIPTION
The new method for initializing localstack using `/etc/localhost/init/<stage>.d` was introduced in [v1.1.0](https://github.com/localstack/localstack/releases/tag/v1.1.0) (2022-09-03). It's been more than a year since this update was released. Time to clean up deprecated code.

See: PR #1886