### PR TITLE
Fix validation test for `company_email` to target the correct field

### DIFF
--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe(Profile, type: :model) do
   end
 
   it 'is invalid if company_email is not a valid format' do
-    profile[:email] = 'foobar'
+    profile[:company_email] = 'foobar'
     expect(profile).to(be_invalid)
   end
 


### PR DESCRIPTION
Accidentally, we were testing the `email` field instead of `company_email` (Testing `email` field validation twice).