### PR TITLE
Add committee configuration to silence deprecation warning

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,6 +70,7 @@ RSpec.configure do |config|
   config.add_setting(:committee_options)
   config.committee_options = {
     schema_path: Rails.root.join('schemas', 'swagger.yml').to_s,
+    strict_reference_validation: true,
   }
   include Committee::Rails::Test::Methods
   config.include(ActiveJob::TestHelper)


### PR DESCRIPTION
Committee gem v5.0.0 outputs the following deprecation warning:

> [DEPRECATION] openapi_parser will default to strict reference validation from next version. Pass config `strict_reference_validation: true` (or false, if you must) to quiet this warning.

Since strict validation is acceptable, I added the configuration to silence the warning.