### PR TITLE
Fix pundit deprecation warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class NotFound < ActionController::ActionControllerError; end
 
 class ApplicationController < ActionController::Base
   include EnvHelper
-  include Pundit
+  include Pundit::Authorization
 
   before_action :set_sentry_context, :event_exists?
 


### PR DESCRIPTION
pundit gem v2.2.0 outputs the following deprecation warning:

> 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.
>  (called from Module#include at /Users/onaka/src/github.com/cloudnativedaysjp/dreamkast/app/controllers/application_controller.rb:7)

https://github.com/varvet/pundit/blob/v2.2.0/CHANGELOG.md

When a top-level module is included, many side effects occur, such as the creation of the `VERSION` constant.
As a result, `Pundit::Authorization` module has been separated.