### PR TITLE
Update redcarpet gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
     rbs_rails (0.11.0)
       parser
       rbs (>= 1)
-    redcarpet (3.5.1)
+    redcarpet (3.6.0)
     redis (4.8.0)
     redis-actionpack (5.3.0)
       actionpack (>= 5, < 8)


### PR DESCRIPTION
Fix following warning:

> /Users/onaka/src/github.com/cloudnativedaysjp/dreamkast/app/helpers/application_helper.rb:94: \
> warning: undefining the allocator of T_DATA class Redcarpet::Markdown

From Ruby 3.2, warnings are displayed when C extensions undefine or redefine the alloc functions for `T_DATA` objects. https://bugs.ruby-lang.org/issues/18007

* https://github.com/vmg/redcarpet/blob/v3.6.0/CHANGELOG.md
* https://github.com/vmg/redcarpet/compare/v3.5.1...v3.6.0