### PR TITLE
Align CSV export path to ./tmp/ directory

### DIFF
--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -11,8 +11,8 @@ class Admin::ProposalsController < ApplicationController
 
         @talks = @conference.talks.order('conference_day_id ASC, start_time ASC, track_id ASC')
         filename = Talk.export_csv(@conference, @talks)
-        stat = File.stat("./tmp/#{filename}.csv")
-        send_file("./tmp/#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+        stat = File.stat("./tmp/#{filename}")
+        send_file("./tmp/#{filename}", filename: filename, length: stat.size)
       end
     end
   end

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -10,9 +10,9 @@ class Admin::ProposalsController < ApplicationController
         head(:no_content)
 
         @talks = @conference.talks.order('conference_day_id ASC, start_time ASC, track_id ASC')
-        filename = Talk.export_csv(@conference, @talks)
-        stat = File.stat("./tmp/#{filename}")
-        send_file("./tmp/#{filename}", filename: filename, length: stat.size)
+        filepath = Talk.export_csv(@conference, @talks)
+        stat = File.stat(filepath)
+        send_file(filepath, filename: File.basename(filepath), length: stat.size)
       end
     end
   end

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -11,8 +11,8 @@ class Admin::ProposalsController < ApplicationController
 
         @talks = @conference.talks.order('conference_day_id ASC, start_time ASC, track_id ASC')
         filename = Talk.export_csv(@conference, @talks)
-        stat = File.stat("./#{filename}.csv")
-        send_file("./#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+        stat = File.stat("./tmp/#{filename}.csv")
+        send_file("./tmp/#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
       end
     end
   end

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -9,9 +9,9 @@ class Admin::TalksController < ApplicationController
       format.csv do
         head(:no_content)
 
-        filename = Talk.export_csv(@conference, @talks)
-        stat = File.stat("./tmp/#{filename}")
-        send_file("./tmp/#{filename}", filename: filename, length: stat.size)
+        filepath = Talk.export_csv(@conference, @talks)
+        stat = File.stat(filepath)
+        send_file(filepath, filename: File.basename(filepath), length: stat.size)
       end
     end
   end

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -10,8 +10,8 @@ class Admin::TalksController < ApplicationController
         head(:no_content)
 
         filename = Talk.export_csv(@conference, @talks)
-        stat = File.stat("./#{filename}.csv")
-        send_file("./#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+        stat = File.stat("./tmp/#{filename}.csv")
+        send_file("./tmp/#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
       end
     end
   end

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -10,8 +10,8 @@ class Admin::TalksController < ApplicationController
         head(:no_content)
 
         filename = Talk.export_csv(@conference, @talks)
-        stat = File.stat("./tmp/#{filename}.csv")
-        send_file("./tmp/#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+        stat = File.stat("./tmp/#{filename}")
+        send_file("./tmp/#{filename}", filename: filename, length: stat.size)
       end
     end
   end

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -48,8 +48,8 @@ class Admin::TracksController < ApplicationController
 
   def export_talks(conference, talks, track_name, date)
     head(:no_content)
-    filename = Talk.export_csv(conference, talks, track_name, date)
-    stat = File.stat("./tmp/#{filename}")
-    send_file("./tmp/#{filename}", filename: filename, length: stat.size)
+    filepath = Talk.export_csv(conference, talks, track_name, date)
+    stat = File.stat(filepath)
+    send_file(filepath, filename: File.basename(filepath), length: stat.size)
   end
 end

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -49,7 +49,7 @@ class Admin::TracksController < ApplicationController
   def export_talks(conference, talks, track_name, date)
     head(:no_content)
     filename = Talk.export_csv(conference, talks, track_name, date)
-    stat = File.stat("./#{filename}.csv")
-    send_file("./#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+    stat = File.stat("./tmp/#{filename}.csv")
+    send_file("./tmp/#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
   end
 end

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -49,7 +49,7 @@ class Admin::TracksController < ApplicationController
   def export_talks(conference, talks, track_name, date)
     head(:no_content)
     filename = Talk.export_csv(conference, talks, track_name, date)
-    stat = File.stat("./tmp/#{filename}.csv")
-    send_file("./tmp/#{filename}.csv", filename: "#{filename}.csv", length: stat.size)
+    stat = File.stat("./tmp/#{filename}")
+    send_file("./tmp/#{filename}", filename: filename, length: stat.size)
   end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -148,11 +148,12 @@ class Talk < ApplicationRecord
       end
     end
 
-    File.open("./tmp/#{filename}", 'w', encoding: 'UTF-8') do |file|
+    filepath = Rails.root.join('tmp', filename)
+    File.open(filepath, 'w', encoding: 'UTF-8') do |file|
       file.write(csv)
     end
 
-    filename
+    filepath
   end
 
   def self.updatable_attributes

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -148,7 +148,7 @@ class Talk < ApplicationRecord
       end
     end
 
-    File.open("./#{filename}.csv", 'w', encoding: 'UTF-8') do |file|
+    File.open("./tmp/#{filename}.csv", 'w', encoding: 'UTF-8') do |file|
       file.write(csv)
     end
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -107,7 +107,7 @@ class Talk < ApplicationRecord
   }
 
   def self.export_csv(conference, talks, track_name = 'all', date = 'all')
-    filename = "#{conference.abbr}_#{date}_#{track_name}"
+    filename = "#{conference.abbr}_#{date}_#{track_name}.csv"
     columns = %w[id title abstract speaker session_time difficulty category created_at additional_documents twitter_id company start_to_end sponsor_session]
 
     labels = conference.proposal_item_configs.map(&:label).uniq
@@ -148,7 +148,7 @@ class Talk < ApplicationRecord
       end
     end
 
-    File.open("./tmp/#{filename}.csv", 'w', encoding: 'UTF-8') do |file|
+    File.open("./tmp/#{filename}", 'w', encoding: 'UTF-8') do |file|
       file.write(csv)
     end
 

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -117,7 +117,7 @@ describe Talk, type: :model do
 
     context 'has full attributes' do
       it 'export csv' do
-        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
+        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}", 'r', encoding: 'UTF-8') do |file|
           expect(file.read).to(eq(expected))
         end
       end
@@ -132,7 +132,7 @@ describe Talk, type: :model do
         EOS
       }
       it 'export csv without attributes will be decided later' do
-        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
+        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}", 'r', encoding: 'UTF-8') do |file|
           expect(file.read).to(eq(expected))
         end
       end

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -117,7 +117,7 @@ describe Talk, type: :model do
 
     context 'has full attributes' do
       it 'export csv' do
-        File.open("./#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
+        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
           expect(file.read).to(eq(expected))
         end
       end
@@ -132,7 +132,7 @@ describe Talk, type: :model do
         EOS
       }
       it 'export csv without attributes will be decided later' do
-        File.open("./#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
+        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}.csv", 'r', encoding: 'UTF-8') do |file|
           expect(file.read).to(eq(expected))
         end
       end

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -117,7 +117,7 @@ describe Talk, type: :model do
 
     context 'has full attributes' do
       it 'export csv' do
-        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}", 'r', encoding: 'UTF-8') do |file|
+        File.open(Talk.export_csv(cndt2020, [talk]), 'r', encoding: 'UTF-8') do |file|
           expect(file.read).to(eq(expected))
         end
       end
@@ -132,7 +132,7 @@ describe Talk, type: :model do
         EOS
       }
       it 'export csv without attributes will be decided later' do
-        File.open("./tmp/#{Talk.export_csv(cndt2020, [talk])}", 'r', encoding: 'UTF-8') do |file|
+        File.open(Talk.export_csv(cndt2020, [talk]), 'r', encoding: 'UTF-8') do |file|
           expect(file.read).to(eq(expected))
         end
       end


### PR DESCRIPTION
Change `Talk.export_csv` to use `./tmp/`, align with other CSV export paths used in `admin/speakers#export_speakers` and `admin/profiles#export_profiles`.

Also did a bit of refactoring; see each commit for details.
