### PR TITLE
Implement skipped request spec

### DIFF
--- a/spec/requests/admin/speakers_spec.rb
+++ b/spec/requests/admin/speakers_spec.rb
@@ -31,12 +31,11 @@ describe Admin::SpeakersController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to //registration' do
-          skip 'TODO: `//registration` にリダイレクトされて名前解決できずにエラーになるので修正が必要'
-          get admin_speakers_path
+        it 'redirect to /:event/registration' do
+          get admin_speakers_path(event: 'cndt2020')
           expect(response).to_not(be_successful)
           expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('//registration'))
+          expect(response).to(redirect_to('/cndt2020/registration'))
         end
       end
 

--- a/spec/requests/admin/speakers_spec.rb
+++ b/spec/requests/admin/speakers_spec.rb
@@ -31,11 +31,9 @@ describe Admin::SpeakersController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to /:event/registration' do
+        it 'returns a forbidden response' do
           get admin_speakers_path(event: 'cndt2020')
-          expect(response).to_not(be_successful)
-          expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('/cndt2020/registration'))
+          expect(response).to(have_http_status('403'))
         end
       end
 

--- a/spec/requests/admin/talks_spec.rb
+++ b/spec/requests/admin/talks_spec.rb
@@ -31,12 +31,11 @@ describe Admin::SpeakersController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to //registration' do
-          skip 'TODO: `//registration` にリダイレクトされて名前解決できずにエラーになるので修正が必要'
-          get admin_talks_path
+        it 'redirect to /:event/registration' do
+          get admin_talks_path(event: 'cndt2020')
           expect(response).to_not(be_successful)
           expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('//registration'))
+          expect(response).to(redirect_to('/cndt2020/registration'))
         end
       end
 

--- a/spec/requests/admin/talks_spec.rb
+++ b/spec/requests/admin/talks_spec.rb
@@ -31,11 +31,9 @@ describe Admin::SpeakersController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to /:event/registration' do
+        it 'returns a forbidden response' do
           get admin_talks_path(event: 'cndt2020')
-          expect(response).to_not(be_successful)
-          expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('/cndt2020/registration'))
+          expect(response).to(have_http_status('403'))
         end
       end
 

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -31,12 +31,11 @@ describe AdminController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to //registration' do
-          skip 'TODO: `//registration` にリダイレクトされて名前解決できずにエラーになるので修正が必要'
+        it 'redirect to /:event/registration' do
           get admin_path(event: 'cndt2020')
           expect(response).to_not(be_successful)
           expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('//registration'))
+          expect(response).to(redirect_to('/cndt2020/registration'))
         end
       end
 
@@ -82,12 +81,11 @@ describe AdminController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to //registration' do
-          skip 'TODO: `//registration` にリダイレクトされて名前解決できずにエラーになるので修正が必要'
-          get '/admin/users'
+        it 'redirect to /:event/registration' do
+          get admin_users_path(event: 'cndt2020')
           expect(response).to_not(be_successful)
           expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('//registration'))
+          expect(response).to(redirect_to('/cndt2020/registration'))
         end
       end
 

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -31,11 +31,9 @@ describe AdminController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to /:event/registration' do
+        it 'returns a forbidden response' do
           get admin_path(event: 'cndt2020')
-          expect(response).to_not(be_successful)
-          expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('/cndt2020/registration'))
+          expect(response).to(have_http_status('403'))
         end
       end
 
@@ -81,11 +79,9 @@ describe AdminController, type: :request do
       end
 
       context 'user is not registered' do
-        it 'redirect to /:event/registration' do
+        it 'returns a forbidden response' do
           get admin_users_path(event: 'cndt2020')
-          expect(response).to_not(be_successful)
-          expect(response).to(have_http_status('302'))
-          expect(response).to(redirect_to('/cndt2020/registration'))
+          expect(response).to(have_http_status('403'))
         end
       end
 


### PR DESCRIPTION
This change is split into two parts:

* Resolved the cause of the skipped test:
  - The test was not correctly receiving `params[:event]`, leading to an incorrect redirection to `//registration` instead of `/:event/registration`
  - Modified the test to correctly redirect to `/:event/registration`, aligning with the intent at the time the test was written
* Updated the test to reflect the current implementation:
  - Following PR #854, the behavior has changed from a redirect to returning a 403 status
  - Adjusted the test to now expect a 403 Forbidden status

