### PR TITLE
Remove unused debug_media_live_information

### DIFF
--- a/app/views/admin/tracks/index.js.erb
+++ b/app/views/admin/tracks/index.js.erb
@@ -3,7 +3,3 @@ $("#messages").html('<%= j(render partial: 'admin/tracks/partial/messages', loca
 recording_group_target = document.getElementById('talks_table_tbody');
 html = "<%= j(render partial: 'admin/tracks/partial/talks_table', locals: {conference_day: @conference_day, talks: @talks, track: @track}) %>"
 recording_group_target.innerHTML = html
-
-debug_media_live_information_target = document.getElementById('debug_media_live_information');
-html = "<%= j(render partial: 'admin/tracks/partial/debug_media_live_information') %>";
-debug_media_live_information_target.innerHTML = html;

--- a/app/views/admin/tracks/partial/_debug_media_live_information.html.erb
+++ b/app/views/admin/tracks/partial/_debug_media_live_information.html.erb
@@ -1,7 +1,0 @@
-<ul>
-  <% if @track.live_stream_media_live %>
-    <li id='debug_channel_state'>Channel State: <%= @track.live_stream_media_live.channel_state %></li>
-    <li>Channel URL: <%= link_to "https://ap-northeast-1.console.aws.amazon.com/medialive/home?region=ap-northeast-1#!/channels/#{@track.live_stream_media_live.channel_id}" %></li>
-    <li id='debug_channel_destination'>Channel Destination: <%= @track.live_stream_media_live.destination %></li>
-  <% end %>
-</ul>


### PR DESCRIPTION
To render this partial template, we get `#debug_media_live_information` node from JavaScript and fill it with its `innerHTML`. But, this HTML node was removed in PR #2060. Now, there's no place for it.