### PR TITLE
Fix duplicate routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,13 +140,11 @@ Rails.application.routes.draw do
     resources :attachments, only: [:show]
 
     # Profile
-    resources :profiles, only: [:new, :edit, :update, :destroy, :create]
+    resources :profiles, only: [:new, :edit, :update, :create]
     namespace :profiles do
       post 'talks', to: 'talks#create'
     end
     get 'profiles/calendar', to: 'profiles#calendar'
-    get 'profiles/new', to: 'profiles#new'
-    post 'profiles', to: 'profiles#create'
     post 'profiles/:id', to: 'profiles#edit'
     put 'profiles', to: 'profiles#update'
     delete 'profiles', to: 'profiles#destroy'


### PR DESCRIPTION
before:

```
GET    /:event/profiles/new(.:format) profiles#new
GET    /:event/profiles/new(.:format) profiles#new
POST   /:event/profiles(.:format)     profiles#create
POST   /:event/profiles(.:format)     profiles#create
DELETE /:event/profiles/:id(.:format) profiles#destroy
DELETE /:event/profiles(.:format)     profiles#destroy
DELETE /:event/profiles/:id(.:format) profiles#destroy_id
```

after:

```
GET    /:event/profiles/new(.:format) profiles#new
POST   /:event/profiles(.:format)     profiles#create
DELETE /:event/profiles(.:format)     profiles#destroy
DELETE /:event/profiles/:id(.:format) profiles#destroy_id
```

memo:

`profiles#destroy` searches for the target Profile from session, and `profiles#destroy_id` searches for the target Profile in `params[:id]`.

Normally, if ProfilesController does not depend on `params[:id]`, you should use `resource` instead of `resources` for routing. (and use singular name) However, there is also use-case for deleting Profile by id. :(