### PR TITLE
Move TalkTable from controller concerns to helpers

### DIFF
--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -1,6 +1,5 @@
 class Admin::TalksController < ApplicationController
   include SecuredAdmin
-  include TalksTable
 
   def index
     @talks = @conference.talks.accepted_and_intermission.order('conference_day_id ASC, start_time ASC, track_id ASC')

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -1,6 +1,5 @@
 class Admin::TracksController < ApplicationController
   include SecuredAdmin
-  include TalksTable
 
   def index
     @date = params[:date] || @conference.conference_days.first.date.strftime('%Y-%m-%d')

--- a/app/helpers/admin/talk_table_helper.rb
+++ b/app/helpers/admin/talk_table_helper.rb
@@ -1,15 +1,4 @@
-module TalksTable
-  extend ActiveSupport::Concern
-
-  included do
-    helper_method :active_date_tab?,
-                  :active_track_tab?,
-                  :on_air_url,
-                  :confirm_message,
-                  :alert_type,
-                  :already_recorded?
-  end
-
+module Admin::TalkTableHelper
   def active_date_tab?(conference_day)
     conference_day.date.strftime('%Y-%m-%d') == @date
   end

--- a/spec/factories/talks_speakers.rb
+++ b/spec/factories/talks_speakers.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: talks_speakers
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  speaker_id :integer
+#  talk_id    :integer
+#
+# Indexes
+#
+#  index_talks_speakers_on_speaker_id  (speaker_id)
+#
+FactoryBot.define do
+  factory :talks_speaker
+end

--- a/spec/helpers/admin/talk_table_helper_spec.rb
+++ b/spec/helpers/admin/talk_table_helper_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.describe(Admin::TalkTableHelper, type: :helper) do
+  describe '#active_date_tab?' do
+    subject { helper.active_date_tab?(conference_day) }
+
+    before do
+      conference = create(:cndt2020)
+      @day1 = conference.conference_days.first
+      @day2 = conference.conference_days.second
+
+      @date = @day1.date.strftime('%Y-%m-%d')
+    end
+
+    context 'when conference_day.date is equal to @date' do
+      let(:conference_day) { @day1 }
+      it { is_expected.to(eq(true)) }
+    end
+
+    context 'when conference_day.date is not equal to @date' do
+      let(:conference_day) { @day2 }
+      it { is_expected.to(eq(false)) }
+    end
+  end
+
+  describe '#active_track_tab?' do
+    subject { helper.active_track_tab?(track) }
+
+    before do
+      conference = create(:cndt2020)
+      @track_a = conference.tracks.first
+      @track_b = conference.tracks.second
+
+      @track_name = @track_a.name
+    end
+
+    context 'when track.name is equal to @track_name' do
+      let(:track) { @track_a }
+      it { is_expected.to(eq(true)) }
+    end
+
+    context 'when track.name is not equal to @track_name' do
+      let(:track) { @track_b }
+      it { is_expected.to(eq(false)) }
+    end
+  end
+
+  describe '#on_air_url' do
+    subject { helper.on_air_url(@talk) }
+
+    before do
+      @conference = create(:cndt2020)
+      @talk = create(:talk1, conference: @conference)
+      create(:video, talk: @talk, on_air:)
+
+      # Rails auto-fills parts of a path parameter using the current page's parameters.
+      # In tests, there's no "current page" to use, so url_helper (xxx_path) can't auto-fill without workarounds.
+      # Add `event` to `url_options` here to fix paths like in the real app.
+      url_options_with_event = helper.url_options.merge(event: @conference.abbr)
+      allow(helper).to(receive(:url_options).and_return(url_options_with_event))
+    end
+
+    context 'when talk.video.on_air is true' do
+      let(:on_air) { true }
+      it { is_expected.to(eq('/cndt2020/admin/stop_on_air')) }
+    end
+
+    context 'when talk.video.on_air is false' do
+      let(:on_air) { false }
+      it { is_expected.to(eq('/cndt2020/admin/start_on_air')) }
+    end
+  end
+
+  describe '#confirm_message' do
+    subject { helper.confirm_message(@talk) }
+
+    before do
+      conference = create(:cndt2020)
+      @talk = create(:talk1, conference:, title: 'Talk Title')
+      create(:video, talk: @talk, on_air:)
+      speaker1 = create(:speaker_alice, conference:, name: 'Alice')
+      speaker2 = create(:speaker_bob, conference:, name: 'Bob')
+      create(:talks_speaker, talk: @talk, speaker: speaker1)
+      create(:talks_speaker, talk: @talk, speaker: speaker2)
+    end
+
+    context 'when talk.video.on_air? is true' do
+      let(:on_air) { true }
+      it { is_expected.to(eq("Waitingに切り替えます:\nAlice,Bob Talk Title")) }
+    end
+
+    context 'when talk.video.on_air? is false' do
+      let(:on_air) { false }
+      it { is_expected.to(eq("OnAirに切り替えます:\nAlice,Bob Talk Title")) }
+    end
+  end
+
+  describe '#alert_type' do
+    subject { helper.alert_type(message_type) }
+
+    context 'when message_type is notice' do
+      let(:message_type) { 'notice' }
+      it { is_expected.to(eq('success')) }
+    end
+
+    context 'when message_type is danger' do
+      let(:message_type) { 'danger' }
+      it { is_expected.to(eq('danger')) }
+    end
+
+    context 'when message_type is alert' do
+      let(:message_type) { 'alert' }
+      it { is_expected.to(eq('danger')) }
+    end
+
+    context 'when message_type is other' do
+      let(:message_type) { 'other' }
+      it { is_expected.to(eq('primary')) }
+    end
+  end
+
+  describe '#already_recorded?' do
+    subject { helper.already_recorded?(@talk) }
+
+    before do
+      conference = create(:cndt2020)
+      @talk = create(:talk1, conference:)
+      create(:video, talk: @talk, video_id:)
+    end
+
+    context 'when talk.video.video_id is present' do
+      let(:video_id) { 'abcdefg' }
+      it { is_expected.to(eq(true)) }
+    end
+
+    context 'when talk.video.video_id is blank' do
+      let(:video_id) { nil }
+      it { is_expected.to(eq(false)) }
+    end
+  end
+end


### PR DESCRIPTION
`TalkTable` module contains only helper methods and has no methods intended for use in controllers. According to Rails best practices, methods only used in views should be in the helpers directory.