### PR TITLE
Add basic singular factories for all tables

### DIFF
--- a/spec/factories/admin_profiles.rb
+++ b/spec/factories/admin_profiles.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: admin_profiles
+#
+#  id                :bigint           not null, primary key
+#  avatar_data       :text(65535)
+#  email             :string(255)
+#  name              :string(255)
+#  show_on_team_page :boolean
+#  sub               :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  conference_id     :bigint           not null
+#  github_id         :string(255)
+#  twitter_id        :string(255)
+#
+# Indexes
+#
+#  index_admin_profiles_on_conference_id  (conference_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#
 FactoryBot.define do
   factory :admin_profile
 end

--- a/spec/factories/admin_profiles.rb
+++ b/spec/factories/admin_profiles.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :admin_profile
+end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id            :bigint           not null, primary key
+#  body          :text(65535)
+#  publish       :boolean
+#  publish_time  :datetime
+#  conference_id :bigint           not null
+#
+# Indexes
+#
+#  index_announcements_on_conference_id  (conference_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#
 FactoryBot.define do
   factory :announcement
 end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :announcement
+end

--- a/spec/factories/chat_messages.rb
+++ b/spec/factories/chat_messages.rb
@@ -34,6 +34,8 @@
 #  fk_rails_...  (speaker_id => speakers.id)
 #
 FactoryBot.define do
+  factory :chat_message
+
   sequence :body do |i|
     "chat message #{i}"
   end

--- a/spec/factories/conference_days.rb
+++ b/spec/factories/conference_days.rb
@@ -17,6 +17,8 @@
 #
 
 FactoryBot.define do
+  factory :conference_day
+
   factory :day1, class: ConferenceDay do
     id { 1 }
     conference_id { 1 }

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -33,6 +33,8 @@
 #
 
 FactoryBot.define do
+  factory :conference
+
   factory :cndt2020, class: Conference do
     id { 1 }
     name { 'CloudNative Days Tokyo 2020' }

--- a/spec/factories/form_items.rb
+++ b/spec/factories/form_items.rb
@@ -10,6 +10,8 @@
 #
 
 FactoryBot.define do
+  factory :form_item
+
   factory :form_item1, class: FormItem do
     id { 1 }
     conference_id { 1 }

--- a/spec/factories/live_streams.rb
+++ b/spec/factories/live_streams.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: live_streams
+#
+#  id            :bigint           not null, primary key
+#  params        :json
+#  type          :string(255)
+#  conference_id :bigint           not null
+#  track_id      :bigint           not null
+#
+# Indexes
+#
+#  index_live_streams_on_conference_id  (conference_id)
+#  index_live_streams_on_track_id       (track_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#  fk_rails_...  (track_id => tracks.id)
+#
 FactoryBot.define do
   factory :live_stream
 end

--- a/spec/factories/live_streams.rb
+++ b/spec/factories/live_streams.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :live_stream
+end

--- a/spec/factories/media_live_channels.rb
+++ b/spec/factories/media_live_channels.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :media_live_channel
+end

--- a/spec/factories/media_live_channels.rb
+++ b/spec/factories/media_live_channels.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: media_live_channels
+#
+#  id                  :string(255)      not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  channel_id          :string(255)
+#  media_live_input_id :string(255)      not null
+#  streaming_id        :string(255)      not null
+#
+# Indexes
+#
+#  index_media_live_channels_on_media_live_input_id  (media_live_input_id)
+#  index_media_live_channels_on_streaming_id         (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (media_live_input_id => media_live_inputs.id)
+#  fk_rails_...  (streaming_id => streamings.id)
+#
 FactoryBot.define do
   factory :media_live_channel
 end

--- a/spec/factories/media_live_input_security_groups.rb
+++ b/spec/factories/media_live_input_security_groups.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :media_live_input_security_group
+end

--- a/spec/factories/media_live_input_security_groups.rb
+++ b/spec/factories/media_live_input_security_groups.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: media_live_input_security_groups
+#
+#  id                      :string(255)      not null, primary key
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  input_security_group_id :string(255)
+#  streaming_id            :string(255)      not null
+#
+# Indexes
+#
+#  index_media_live_input_security_groups_on_streaming_id  (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (streaming_id => streamings.id)
+#
 FactoryBot.define do
   factory :media_live_input_security_group
 end

--- a/spec/factories/media_live_inputs.rb
+++ b/spec/factories/media_live_inputs.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :media_live_input
+end

--- a/spec/factories/media_live_inputs.rb
+++ b/spec/factories/media_live_inputs.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: media_live_inputs
+#
+#  id                                 :string(255)      not null, primary key
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
+#  input_id                           :string(255)
+#  media_live_input_security_group_id :string(255)      not null
+#  streaming_id                       :string(255)      not null
+#
+# Indexes
+#
+#  index_media_live_inputs_on_media_live_input_security_group_id  (media_live_input_security_group_id)
+#  index_media_live_inputs_on_streaming_id                        (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (media_live_input_security_group_id => media_live_input_security_groups.id)
+#  fk_rails_...  (streaming_id => streamings.id)
+#
 FactoryBot.define do
   factory :media_live_input
 end

--- a/spec/factories/media_package_channels.rb
+++ b/spec/factories/media_package_channels.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: media_package_channels
+#
+#  id           :bigint           not null, primary key
+#  channel_id   :string(255)      default("")
+#  streaming_id :string(255)
+#
+# Indexes
+#
+#  index_media_package_channels_on_channel_id    (channel_id)
+#  index_media_package_channels_on_streaming_id  (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (streaming_id => streamings.id)
+#
 FactoryBot.define do
   factory :media_package_channel
 end

--- a/spec/factories/media_package_channels.rb
+++ b/spec/factories/media_package_channels.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :media_package_channel
+end

--- a/spec/factories/media_package_harvest_jobs.rb
+++ b/spec/factories/media_package_harvest_jobs.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :media_package_harvest_job
+end

--- a/spec/factories/media_package_harvest_jobs.rb
+++ b/spec/factories/media_package_harvest_jobs.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: media_package_harvest_jobs
+#
+#  id                       :bigint           not null, primary key
+#  end_time                 :datetime
+#  start_time               :datetime
+#  status                   :string(255)
+#  conference_id            :bigint           not null
+#  job_id                   :string(255)
+#  media_package_channel_id :bigint           not null
+#  talk_id                  :bigint           not null
+#
+# Indexes
+#
+#  index_media_package_harvest_jobs_on_conference_id             (conference_id)
+#  index_media_package_harvest_jobs_on_media_package_channel_id  (media_package_channel_id)
+#  index_media_package_harvest_jobs_on_talk_id                   (talk_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#  fk_rails_...  (media_package_channel_id => media_package_channels.id)
+#  fk_rails_...  (talk_id => talks.id)
+#
 FactoryBot.define do
   factory :media_package_harvest_job
 end

--- a/spec/factories/media_package_origin_endpoints.rb
+++ b/spec/factories/media_package_origin_endpoints.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :media_package_origin_endpoint
+end

--- a/spec/factories/media_package_origin_endpoints.rb
+++ b/spec/factories/media_package_origin_endpoints.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: media_package_origin_endpoints
+#
+#  id                       :bigint           not null, primary key
+#  endpoint_id              :string(255)
+#  media_package_channel_id :bigint           not null
+#  streaming_id             :string(255)
+#
+# Indexes
+#
+#  index_media_package_origin_endpoints_on_media_package_channel_id  (media_package_channel_id)
+#  index_media_package_origin_endpoints_on_streaming_id              (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (media_package_channel_id => media_package_channels.id)
+#  fk_rails_...  (streaming_id => streamings.id)
+#
 FactoryBot.define do
   factory :media_package_origin_endpoint
 end

--- a/spec/factories/media_package_parameters.rb
+++ b/spec/factories/media_package_parameters.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: media_package_parameters
+#
+#  id                       :string(255)      not null, primary key
+#  name                     :string(255)
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  media_package_channel_id :bigint           not null
+#  streaming_id             :string(255)      not null
+#
+# Indexes
+#
+#  index_media_package_parameters_on_media_package_channel_id  (media_package_channel_id)
+#  index_media_package_parameters_on_streaming_id              (streaming_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (media_package_channel_id => media_package_channels.id)
+#  fk_rails_...  (streaming_id => streamings.id)
+#
 FactoryBot.define do
   factory :media_package_parameter
 end

--- a/spec/factories/media_package_parameters.rb
+++ b/spec/factories/media_package_parameters.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :media_package_parameter
+end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -37,6 +37,8 @@
 #
 
 FactoryBot.define do
+  factory :profile
+
   factory :alice, class: Profile do
     sub { 'alice' }
     email { 'alice@example.com' }

--- a/spec/factories/proposal_item_configs.rb
+++ b/spec/factories/proposal_item_configs.rb
@@ -24,6 +24,8 @@
 #
 
 FactoryBot.define do
+  factory :proposal_item_config
+
   factory :check_box_item_config_1, class: ProposalItemConfig do
     type { 'ProposalItemConfigCheckBox' }
     label { 'check_box_item_1' }

--- a/spec/factories/proposal_items.rb
+++ b/spec/factories/proposal_items.rb
@@ -19,6 +19,8 @@
 #
 
 FactoryBot.define do
+  factory :proposal_item
+
   factory :check_box_item_1, class: ProposalItem do
     label { 'check_box_item_1' }
   end

--- a/spec/factories/public_profiles.rb
+++ b/spec/factories/public_profiles.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :public_profile
+end

--- a/spec/factories/public_profiles.rb
+++ b/spec/factories/public_profiles.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: public_profiles
+#
+#  id          :bigint           not null, primary key
+#  avatar_data :text(65535)
+#  is_public   :boolean          default(FALSE)
+#  nickname    :string(255)      default("")
+#  github_id   :string(255)      default("")
+#  profile_id  :bigint           not null
+#  twitter_id  :string(255)      default("")
+#
+# Indexes
+#
+#  index_public_profiles_on_profile_id  (profile_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (profile_id => profiles.id)
+#
 FactoryBot.define do
   factory :public_profile
 end

--- a/spec/factories/speaker_announcement_middles.rb
+++ b/spec/factories/speaker_announcement_middles.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: speaker_announcement_middles
+#
+#  id                      :bigint           not null, primary key
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  speaker_announcement_id :bigint           not null
+#  speaker_id              :bigint           not null
+#
+# Indexes
+#
+#  index_speaker_announcement_middles_on_speaker_announcement_id  (speaker_announcement_id)
+#  index_speaker_announcement_middles_on_speaker_id               (speaker_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (speaker_announcement_id => speaker_announcements.id)
+#  fk_rails_...  (speaker_id => speakers.id)
+#
 FactoryBot.define do
   factory :speaker_announcement_middle
 end

--- a/spec/factories/speaker_announcement_middles.rb
+++ b/spec/factories/speaker_announcement_middles.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :speaker_announcement_middle
+end

--- a/spec/factories/speakers.rb
+++ b/spec/factories/speakers.rb
@@ -24,6 +24,8 @@
 #
 
 FactoryBot.define do
+  factory :speaker
+
   factory :speaker_alice, class: Speaker do
     id { 1 }
     sub { 'aaa' }

--- a/spec/factories/sponsor_profiles.rb
+++ b/spec/factories/sponsor_profiles.rb
@@ -22,6 +22,8 @@
 #
 
 FactoryBot.define do
+  factory :sponsor_profile
+
   factory :sponsor_alice, class: SponsorProfile do
     sub { 'alice' }
     email { 'alice@example.com' }

--- a/spec/factories/stats_of_registrants.rb
+++ b/spec/factories/stats_of_registrants.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: stats_of_registrants
+#
+#  id                    :bigint           not null, primary key
+#  number_of_registrants :integer
+#  offline_attendees     :decimal(10, )
+#  online_attendees      :decimal(10, )
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  conference_id         :bigint
+#
+# Indexes
+#
+#  index_stats_of_registrants_on_conference_id  (conference_id)
+#
 FactoryBot.define do
   factory :stats_of_registrant
 end

--- a/spec/factories/stats_of_registrants.rb
+++ b/spec/factories/stats_of_registrants.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :stats_of_registrant
+end

--- a/spec/factories/talk_categories.rb
+++ b/spec/factories/talk_categories.rb
@@ -14,6 +14,8 @@
 #
 
 FactoryBot.define do
+  factory :talk_category
+
   factory :talk_category1, class: TalkCategory do
     id { 1 }
     name { 'category 1' }

--- a/spec/factories/talk_difficulties.rb
+++ b/spec/factories/talk_difficulties.rb
@@ -14,6 +14,8 @@
 #
 
 FactoryBot.define do
+  factory :talk_difficulty
+
   factory :talk_difficulties1, class: TalkDifficulty do
     id { 1 }
     name { 'Beginner - 初級者' }

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -42,6 +42,8 @@
 #
 
 FactoryBot.define do
+  factory :talk
+
   factory :talk1, class: Talk do
     id { 1 }
     type { 'Session' }

--- a/spec/factories/talks_speakers.rb
+++ b/spec/factories/talks_speakers.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :talks_speaker
+end

--- a/spec/factories/talks_speakers.rb
+++ b/spec/factories/talks_speakers.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: talks_speakers
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  speaker_id :integer
+#  talk_id    :integer
+#
+# Indexes
+#
+#  index_talks_speakers_on_speaker_id  (speaker_id)
+#
 FactoryBot.define do
   factory :talks_speaker
 end


### PR DESCRIPTION
Generate basic factories for all tables, each named in singular form and having no column values.

In the following PR, I will add [Faker gem](https://github.com/faker-ruby/faker) to generate random test data.
These factories enable test authors to easily generate objects by overriding only the necessary values as needed.

```ruby
factory :access_log do
  name { Faker::Internet.username }
  sub { Faker::Internet.uuid }
  page { "#{Faker::Internet.slug}/#{Faker::Internet.slug}/#{Faker::Number.number(digits: 5)}" }
  ip { Faker::Internet.ip_v4_address }
end
```

```
# Generate random data easily.
[1] pry(main)> FactoryBot.build(:access_log)
=> #<AccessLog:0x0000000161e7de90
 id: nil,
 name: "toi_larkin",
 sub: "c47d2c38-68cb-4562-9cc2-5bdd9d773469",
 page: "cutting-diagram/general_diagram/88268",
 ip: "22.24.253.83",
 created_at: nil,
 updated_at: nil,
 profile_id: nil>

# Can overwrite only the columns that are the focus of the test.
[2] pry(main)> FactoryBot.build(:access_log, ip: "127.0.0.1")
=> #<AccessLog:0x0000000179392770
 id: nil,
 name: "eduardo",
 sub: "3c1db0b3-8ee2-426e-9ac7-70ee4b340202",
 page: "laser-exhibition/glow-trivial/43184",
 ip: "127.0.0.1",
 created_at: nil,
 updated_at: nil,
 profile_id: nil>
```
