### PR TITLE
Rename `current_user` to avoid confusion

### DIFF
--- a/app/controllers/concerns/secured_public_api.rb
+++ b/app/controllers/concerns/secured_public_api.rb
@@ -26,7 +26,7 @@ module SecuredPublicApi
     JsonWebToken.verify(http_token)
   end
 
-  def set_current_user_from_claim(claim)
+  def set_current_user_from_claim(claim) # rubocop:disable Naming/AccessorMethodName
     @current_user = {}
     @current_user[:info] = {}
     @current_user[:extra] = {}

--- a/app/controllers/concerns/secured_public_api.rb
+++ b/app/controllers/concerns/secured_public_api.rb
@@ -11,7 +11,7 @@ module SecuredPublicApi
 
   def authenticate_request!
     claim = verify_token
-    current_user(claim[0])
+    set_current_user_from_claim(claim[0])
   rescue JWT::VerificationError, JWT::DecodeError
     render(json: { errors: ['Not Authenticated'] }, status: :unauthorized)
   end
@@ -26,7 +26,7 @@ module SecuredPublicApi
     JsonWebToken.verify(http_token)
   end
 
-  def current_user(claim)
+  def set_current_user_from_claim(claim)
     @current_user = {}
     @current_user[:info] = {}
     @current_user[:extra] = {}


### PR DESCRIPTION
Currently, the `current_user` method is used as a setter, which can be misleading due to its name. To improve clarity and reduce confusion, rename this method to `set_current_user_from_claim`.

This change is to prepare for adding new `current_user` method in the following Pull Request.