### PR TITLE
Remove duplicate call of logged_in_using_omniauth?

### DIFF
--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -1,6 +1,6 @@
 class SpeakerDashboardsController < ApplicationController
   include SecuredSpeaker
-  before_action :logged_in_using_omniauth?, :set_speaker
+  before_action :set_speaker
 
   def show
     @speaker_announcements = @conference.speaker_announcements.find_by_speaker(@speaker.id) unless @speaker.nil?

--- a/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
@@ -1,6 +1,6 @@
 class SponsorDashboards::SponsorDashboardsController < ApplicationController
   include SecuredSponsor
-  before_action :logged_in_using_omniauth?, :set_sponsor_profile
+  before_action :set_sponsor_profile
 
   def show
     @sponsor = Sponsor.find(params[:sponsor_id])


### PR DESCRIPTION
`logged_in_using_omniauth?` before_action is enabled in all `SecuredSponsor` or `SecuredSpeaker` modules.