### PR TITLE
Refactor: Use `current_user` instead of `set_current_user` (1/3)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,14 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  def current_user
+    unless defined?(@current_user)
+      @current_user = session[:userinfo]
+    end
+    @current_user
+  end
+  helper_method :current_user
+
   def user_not_authorized
     render(template: 'errors/error_403', status: 403, layout: 'application', content_type: 'text/html')
   end

--- a/app/controllers/attendees_controller.rb
+++ b/app/controllers/attendees_controller.rb
@@ -3,9 +3,7 @@ class AttendeesController < ApplicationController
   before_action :set_profile, :set_speaker
 
   def logged_in_using_omniauth?
-    if session[:userinfo].present?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   def index

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -71,7 +71,7 @@ module Secured
   end
 
   def set_current_user
-    @current_user ||= session[:userinfo]
+    current_user
   end
 
   def is_admin?

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -47,7 +47,7 @@ module Secured
   end
 
   def new_user?
-    logged_in? && !Profile.find_by(email: set_current_user[:info][:email], conference_id: set_conference.id)
+    logged_in? && !Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
   end
 
   def admin?

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -35,7 +35,7 @@ module SecuredAdmin
   end
 
   def set_current_user
-    @current_user ||= session[:userinfo]
+    current_user
   end
 
   def get_or_create_admin_profile

--- a/app/controllers/concerns/secured_api.rb
+++ b/app/controllers/concerns/secured_api.rb
@@ -20,6 +20,6 @@ module SecuredApi
   end
 
   def set_current_user
-    @current_user ||= session[:userinfo]
+    current_user
   end
 end

--- a/app/controllers/concerns/secured_beta.rb
+++ b/app/controllers/concerns/secured_beta.rb
@@ -14,7 +14,7 @@ module SecuredBeta
   end
 
   def set_current_user
-    @current_user ||= session[:userinfo]
+    current_user
   end
 
   def admin?

--- a/app/controllers/concerns/secured_speaker.rb
+++ b/app/controllers/concerns/secured_speaker.rb
@@ -15,7 +15,7 @@ module SecuredSpeaker
   end
 
   def set_current_user
-    @current_user = session[:userinfo]
+    current_user
   end
 
   def logged_in?

--- a/app/controllers/concerns/secured_sponsor.rb
+++ b/app/controllers/concerns/secured_sponsor.rb
@@ -15,7 +15,7 @@ module SecuredSponsor
   end
 
   def set_current_user
-    @current_user = session[:userinfo]
+    current_user
   end
 
   def logged_in?

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -3,9 +3,7 @@ class ContentsController < ApplicationController
   before_action :set_profile, :set_speaker
 
   def logged_in_using_omniauth?
-    if session[:userinfo].present?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   def index

--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -21,9 +21,7 @@ class EventController < ApplicationController
   end
 
   def set_current_user
-    if session[:userinfo].present?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   def privacy

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
   def new
     @profile = Profile.new
     @conference = Conference.find_by(abbr: params[:event])
-    if set_current_user && Profile.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
+    if current_user && Profile.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
       redirect_to(dashboard_path)
     end
     @event = params[:event]

--- a/app/controllers/speaker_dashboard/speakers_controller.rb
+++ b/app/controllers/speaker_dashboard/speakers_controller.rb
@@ -16,7 +16,7 @@ class SpeakerDashboard::SpeakersController < ApplicationController
     @conference = Conference.find_by(abbr: params[:event])
     @sponsor = Sponsor.find(params[:sponsor_id]) if params[:sponsor_id]
 
-    if set_current_user
+    if current_user
       if Speaker.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
         redirect_to(speaker_dashboard_path)
       end

--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -15,9 +15,7 @@ class SpeakerDashboardsController < ApplicationController
   end
 
   def logged_in_using_omniauth?
-    if logged_in?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   def set_speaker

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -5,9 +5,7 @@ class SpeakersController < ApplicationController
   before_action :set_profile
 
   def logged_in_using_omniauth?
-    if session[:userinfo].present?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   # GET /speakers

--- a/app/controllers/sponsor_dashboards/speakers_controller.rb
+++ b/app/controllers/sponsor_dashboards/speakers_controller.rb
@@ -8,7 +8,7 @@ class SponsorDashboards::SpeakersController < ApplicationController
     @conference = Conference.find_by(abbr: params[:event])
     @sponsor = Sponsor.find(params[:sponsor_id]) if params[:sponsor_id]
 
-    if set_current_user
+    if current_user
       if Speaker.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
         redirect_to(speaker_dashboard_path)
       end

--- a/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
@@ -34,9 +34,7 @@ class SponsorDashboards::SponsorDashboardsController < ApplicationController
   end
 
   def logged_in_using_omniauth?
-    if logged_in?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   def set_sponsor_profile

--- a/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
@@ -11,7 +11,7 @@ class SponsorDashboards::SponsorProfilesController < ApplicationController
     unless logged_in?
       redirect_to(sponsor_dashboards_login_path)
     else
-      if set_current_user
+      if current_user
         if SponsorProfile.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
           redirect_to(sponsor_dashboards_path)
         end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -4,9 +4,7 @@ class TalksController < ApplicationController
   helper_method :talk_start_to_end
 
   def logged_in_using_omniauth?
-    if session[:userinfo].present?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   # - プロポーザルの採択結果を表示する場合

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -3,9 +3,7 @@ class TeamsController < ApplicationController
   before_action :set_conference, :set_profile, :set_speaker
 
   def logged_in_using_omniauth?
-    if session[:userinfo].present?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   def show

--- a/app/controllers/timetable_controller.rb
+++ b/app/controllers/timetable_controller.rb
@@ -3,9 +3,7 @@ class TimetableController < ApplicationController
   before_action :set_profile, :set_speaker
 
   def logged_in_using_omniauth?
-    if session[:userinfo].present?
-      @current_user = session[:userinfo]
-    end
+    current_user
   end
 
   def index

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,4 @@
 module ApplicationHelper
-  def current_user
-    return unless session[:userinfo]
-    @current_user ||= session[:userinfo]
-  end
-
   def logged_in?
     !!session[:userinfo]
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe(ApplicationController, type: :controller) do
+  describe '#current_user' do
+    subject { controller.current_user }
+    context 'when omniauth session does not exist' do
+      it { is_expected.to(eq(nil)) }
+    end
+
+    context 'when omniauth session exists' do
+      before do
+        @userinfo = {
+          info: { email: 'alice@example.com' },
+          extra: { raw_info: { sub: 'mock', 'https://cloudnativedays.jp/roles' => '' } }
+        }
+        session[:userinfo] = @userinfo
+      end
+      it { is_expected.to(eq(@userinfo)) }
+    end
+  end
+end


### PR DESCRIPTION
1. Implements `current_user` with the same implementation as `set_current_user` <- This PR
2. Replace all `@current_user` ivar access with `current_user` method
3. Remove `set_current_user` method

## Motivation

We need to call the `set_current_user` method before using the `@current_user` variable. This can lead to mistakes.
So replace ivar to memoized `current_user` method call.

Once all changes are completed, `set_current_user` method will be removed, reducing the number of `before_action` callbacks.

## Impact

This PR simply replaces the implementation with an equivalent one, so there are no impacts.
