### PR TITLE
Refactor: Use `current_user` instead of `set_current_user` (2/3)

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -13,7 +13,7 @@ class AdminController < ApplicationController
   end
 
   def destroy_user
-    @profile = Profile.find_by(sub: @current_user[:extra][:raw_info][:sub])
+    @profile = Profile.find_by(sub: current_user[:extra][:raw_info][:sub])
     @profile.destroy
     redirect_to(logout_url)
   end

--- a/app/controllers/api/v1/chat_messages_controller.rb
+++ b/app/controllers/api/v1/chat_messages_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::ChatMessagesController < ApplicationController
 
     attr = { profile_id: @profile.id, body:, conference_id: conference.id, room_id:, room_type:, message_type: }
 
-    speaker = Speaker.find_by(conference: conference.id, email: @current_user[:info][:email])
+    speaker = Speaker.find_by(conference: conference.id, email: current_user[:info][:email])
     attr[:speaker_id] = speaker.id if speaker.present?
 
     if reply_to
@@ -55,8 +55,8 @@ class Api::V1::ChatMessagesController < ApplicationController
   end
 
   def pundit_user
-    if @current_user
-      Profile.find_by(conference: @conference.id, email: @current_user[:info][:email])
+    if current_user
+      Profile.find_by(conference: @conference.id, email: current_user[:info][:email])
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,16 +130,16 @@ class ApplicationController < ActionController::Base
   end
 
   def set_profile
-    @profile = if @current_user && (set_conference.opened? || set_conference.registered?)
-                 Profile.find_by(email: @current_user[:info][:email], conference_id: set_conference.id)
+    @profile = if current_user && (set_conference.opened? || set_conference.registered?)
+                 Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
                else
                  GuestProfile.new
                end
   end
 
   def set_speaker
-    if @current_user
-      @speaker = Speaker.find_by(email: @current_user[:info][:email], conference_id: set_conference.id)
+    if current_user
+      @speaker = Speaker.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
     end
   end
 

--- a/app/controllers/concerns/logging.rb
+++ b/app/controllers/concerns/logging.rb
@@ -6,11 +6,11 @@ module Logging
   end
 
   def write_accesslog
-    profile = Profile.find_by(sub: @current_user[:extra][:raw_info][:sub])
+    profile = Profile.find_by(sub: current_user[:extra][:raw_info][:sub])
     AccessLog.create(
       profile_id: profile.id,
-      name: @current_user[:info][:name],
-      sub: @current_user[:extra][:raw_info][:sub],
+      name: current_user[:info][:name],
+      sub: current_user[:extra][:raw_info][:sub],
       page: controller_name + '/' + action_name + '/' + params[:id].to_s
     )
   end

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -51,15 +51,15 @@ module Secured
   end
 
   def admin?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
   end
 
   def speaker?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Speaker")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Speaker")
   end
 
   def beta_user?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
   end
 
   def conference

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -51,7 +51,7 @@ module Secured
   end
 
   def admin?
-    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+    conference && current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
   end
 
   def speaker?

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -19,7 +19,7 @@ module SecuredAdmin
   end
 
   def admin?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
   end
 
   def conference
@@ -39,12 +39,12 @@ module SecuredAdmin
   end
 
   def get_or_create_admin_profile
-    @admin_profile ||= AdminProfile.find_by(email: @current_user[:info][:email], conference_id: set_conference.id)
+    @admin_profile ||= AdminProfile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
 
     if admin? && @admin_profile.blank?
       @admin_profile = AdminProfile.new(conference_id: @conference.id)
-      @admin_profile.sub = @current_user[:extra][:raw_info][:sub]
-      @admin_profile.email = @current_user[:info][:email]
+      @admin_profile.sub = current_user[:extra][:raw_info][:sub]
+      @admin_profile.email = current_user[:info][:email]
 
       @admin_profile.save!
     end

--- a/app/controllers/concerns/secured_beta.rb
+++ b/app/controllers/concerns/secured_beta.rb
@@ -6,7 +6,7 @@ module SecuredBeta
   end
 
   def beta_user?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
   end
 
   def is_beta_user?
@@ -18,6 +18,6 @@ module SecuredBeta
   end
 
   def admin?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
   end
 end

--- a/app/controllers/concerns/secured_speaker.rb
+++ b/app/controllers/concerns/secured_speaker.rb
@@ -23,11 +23,11 @@ module SecuredSpeaker
   end
 
   def admin?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Admin")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Admin")
   end
 
   def speaker?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Speaker")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Speaker")
   end
 
   def prepare_create

--- a/app/controllers/concerns/secured_sponsor.rb
+++ b/app/controllers/concerns/secured_sponsor.rb
@@ -23,10 +23,10 @@ module SecuredSponsor
   end
 
   def admin?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Admin")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Admin")
   end
 
   def speaker?
-    @current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Speaker")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Speaker")
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
   def new
     @profile = Profile.new
     @conference = Conference.find_by(abbr: params[:event])
-    if current_user && Profile.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
+    if current_user && Profile.find_by(conference_id: @conference.id, email: current_user[:info][:email])
       redirect_to(dashboard_path)
     end
     @event = params[:event]
@@ -23,8 +23,8 @@ class ProfilesController < ApplicationController
     tel = profile_params[:company_tel].gsub(/-/, '')
 
     @profile = Profile.new(profile_params.merge(conference_id: @conference.id, company_postal_code: postal_code, company_tel: tel))
-    @profile.sub = @current_user[:extra][:raw_info][:sub]
-    @profile.email = @current_user[:info][:email]
+    @profile.sub = current_user[:extra][:raw_info][:sub]
+    @profile.email = current_user[:info][:email]
 
     if @profile.save
       Agreement.create!(profile_id: @profile.id, form_item_id: 1, value: 1) if agreement_params['require_email']
@@ -126,7 +126,7 @@ class ProfilesController < ApplicationController
   end
 
   def set_current_profile
-    @profile = Profile.find_by(email: @current_user[:info][:email], conference_id: set_conference.id)
+    @profile = Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
   end
 
   def profile_params

--- a/app/controllers/public_profiles_controller.rb
+++ b/app/controllers/public_profiles_controller.rb
@@ -45,8 +45,8 @@ class PublicProfilesController < ApplicationController
   end
 
   def pundit_user
-    if @current_user
-      Profile.find_by(conference: @conference.id, email: @current_user[:info][:email])
+    if current_user
+      Profile.find_by(conference: @conference.id, email: current_user[:info][:email])
     end
   end
 

--- a/app/controllers/speaker_dashboard/speakers_controller.rb
+++ b/app/controllers/speaker_dashboard/speakers_controller.rb
@@ -17,7 +17,7 @@ class SpeakerDashboard::SpeakersController < ApplicationController
     @sponsor = Sponsor.find(params[:sponsor_id]) if params[:sponsor_id]
 
     if current_user
-      if Speaker.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
+      if Speaker.find_by(conference_id: @conference.id, email: current_user[:info][:email])
         redirect_to(speaker_dashboard_path)
       end
     end
@@ -43,8 +43,8 @@ class SpeakerDashboard::SpeakersController < ApplicationController
     @conference = Conference.find_by(abbr: params[:event])
 
     @speaker_form = SpeakerForm.new(speaker_params, speaker: Speaker.new, conference: @conference)
-    @speaker_form.sub = @current_user[:extra][:raw_info][:sub]
-    @speaker_form.email = @current_user[:info][:email]
+    @speaker_form.sub = current_user[:extra][:raw_info][:sub]
+    @speaker_form.email = current_user[:info][:email]
 
     respond_to do |format|
       if r = @speaker_form.save
@@ -69,8 +69,8 @@ class SpeakerDashboard::SpeakersController < ApplicationController
     authorize(@speaker)
 
     @speaker_form = SpeakerForm.new(speaker_params, speaker: @speaker, conference: @conference)
-    @speaker_form.sub = @current_user[:extra][:raw_info][:sub]
-    @speaker_form.email = @current_user[:info][:email]
+    @speaker_form.sub = current_user[:extra][:raw_info][:sub]
+    @speaker_form.email = current_user[:info][:email]
     # @speaker_form.load
     exists_talks = @speaker.talk_ids
 
@@ -106,8 +106,8 @@ class SpeakerDashboard::SpeakersController < ApplicationController
   end
 
   def pundit_user
-    if @current_user
-      Speaker.find_by(conference: @conference.id, email: @current_user[:info][:email])
+    if current_user
+      Speaker.find_by(conference: @conference.id, email: current_user[:info][:email])
     end
   end
 

--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -11,7 +11,7 @@ class SpeakerDashboardsController < ApplicationController
   helper_method :sponsor?
 
   def sponsor?
-    !@conference.sponsors.where('speaker_emails like(?)', "%#{@current_user[:info][:email]}%").empty?
+    !@conference.sponsors.where('speaker_emails like(?)', "%#{current_user[:info][:email]}%").empty?
   end
 
   def logged_in_using_omniauth?
@@ -20,8 +20,8 @@ class SpeakerDashboardsController < ApplicationController
 
   def set_speaker
     @conference ||= Conference.find_by(abbr: params[:event])
-    if @current_user
-      @speaker = Speaker.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
+    if current_user
+      @speaker = Speaker.find_by(conference_id: @conference.id, email: current_user[:info][:email])
       @talks = @speaker ? @speaker.talks.not_sponsor : []
     end
   end

--- a/app/controllers/sponsor_dashboards/speakers_controller.rb
+++ b/app/controllers/sponsor_dashboards/speakers_controller.rb
@@ -9,7 +9,7 @@ class SponsorDashboards::SpeakersController < ApplicationController
     @sponsor = Sponsor.find(params[:sponsor_id]) if params[:sponsor_id]
 
     if current_user
-      if Speaker.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
+      if Speaker.find_by(conference_id: @conference.id, email: current_user[:info][:email])
         redirect_to(speaker_dashboard_path)
       end
     end
@@ -35,8 +35,8 @@ class SponsorDashboards::SpeakersController < ApplicationController
     @sponsor = Sponsor.find(params[:sponsor_id])
 
     @speaker_form = SpeakerForm.new(speaker_params, speaker: Speaker.new, conference: @conference)
-    @speaker_form.sub = @current_user[:extra][:raw_info][:sub]
-    @speaker_form.email = @current_user[:info][:email]
+    @speaker_form.sub = current_user[:extra][:raw_info][:sub]
+    @speaker_form.email = current_user[:info][:email]
 
     respond_to do |format|
       if r = @speaker_form.save
@@ -60,8 +60,8 @@ class SponsorDashboards::SpeakersController < ApplicationController
     authorize(@speaker)
 
     @speaker_form = SpeakerForm.new(speaker_params, speaker: @speaker, sponsor: @sponsor, conference: @conference)
-    @speaker_form.sub = @current_user[:extra][:raw_info][:sub]
-    @speaker_form.email = @current_user[:info][:email]
+    @speaker_form.sub = current_user[:extra][:raw_info][:sub]
+    @speaker_form.email = current_user[:info][:email]
     # @speaker_form.load
     exists_talks = @speaker.talk_ids
 
@@ -91,8 +91,8 @@ class SponsorDashboards::SpeakersController < ApplicationController
   end
 
   def pundit_user
-    if @current_user
-      Speaker.find_by(conference: @conference.id, email: @current_user[:info][:email])
+    if current_user
+      Speaker.find_by(conference: @conference.id, email: current_user[:info][:email])
     end
   end
 

--- a/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
@@ -7,14 +7,14 @@ class SponsorDashboards::SponsorDashboardsController < ApplicationController
     unless logged_in? && @sponsor.present? && @sponsor_profile.present?
       redirect_to(sponsor_dashboards_login_path)
     else
-      @speaker = @conference.speakers.find_by(email: @current_user[:info][:email])
+      @speaker = @conference.speakers.find_by(email: current_user[:info][:email])
       @talks = @speaker ? @speaker.talks.sponsor : []
     end
   end
 
   def login
     if logged_in?
-      @sponsor = Sponsor.where(conference_id: @conference.id).where('speaker_emails like(?)', "%#{@current_user[:info][:email]}%").first
+      @sponsor = Sponsor.where(conference_id: @conference.id).where('speaker_emails like(?)', "%#{current_user[:info][:email]}%").first
       if @sponsor.nil?
         raise(Forbidden)
       elsif logged_in? && @sponsor.present? && @sponsor_profile.nil?
@@ -39,8 +39,8 @@ class SponsorDashboards::SponsorDashboardsController < ApplicationController
 
   def set_sponsor_profile
     @conference ||= Conference.find_by(abbr: params[:event])
-    if @current_user
-      @sponsor_profile = SponsorProfile.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
+    if current_user
+      @sponsor_profile = SponsorProfile.find_by(conference_id: @conference.id, email: current_user[:info][:email])
     end
   end
 end

--- a/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_profiles_controller.rb
@@ -12,11 +12,11 @@ class SponsorDashboards::SponsorProfilesController < ApplicationController
       redirect_to(sponsor_dashboards_login_path)
     else
       if current_user
-        if SponsorProfile.find_by(conference_id: @conference.id, email: @current_user[:info][:email])
+        if SponsorProfile.find_by(conference_id: @conference.id, email: current_user[:info][:email])
           redirect_to(sponsor_dashboards_path)
         end
 
-        unless @sponsor.speaker_emails && @sponsor.speaker_emails.downcase.include?(@current_user[:info][:email].downcase)
+        unless @sponsor.speaker_emails && @sponsor.speaker_emails.downcase.include?(current_user[:info][:email].downcase)
           redirect_to("/#{@conference.abbr}/sponsor_dashboards/login", notice: 'ログインが許可されていません')
         end
       end
@@ -36,14 +36,14 @@ class SponsorDashboards::SponsorProfilesController < ApplicationController
   # POST :event/sponsor_dashboard/sponsor_profiles
   def create
     @conference = Conference.find_by(abbr: params[:event])
-    @sponsor = Sponsor.where(conference_id: @conference.id).where('speaker_emails like(?)', "%#{@current_user[:info][:email]}%").first
+    @sponsor = Sponsor.where(conference_id: @conference.id).where('speaker_emails like(?)', "%#{current_user[:info][:email]}%").first
     unless @sponsor
       redirect_to("/#{@conference.abbr}/sponsor_dashboards", notice: 'ログインが許可されていません')
     else
       @sponsor_profile = SponsorProfile.new(sponsor_profile_params.merge(conference_id: @conference.id))
-      @sponsor_profile.sub = @current_user[:extra][:raw_info][:sub]
+      @sponsor_profile.sub = current_user[:extra][:raw_info][:sub]
 
-      @sponsor_profile.email = @current_user[:info][:email]
+      @sponsor_profile.email = current_user[:info][:email]
       @sponsor_profile.sponsor_id = @sponsor.id
 
       respond_to do |format|
@@ -89,8 +89,8 @@ class SponsorDashboards::SponsorProfilesController < ApplicationController
   end
 
   def pundit_user
-    if @current_user
-      SponsorProfile.find_by(conference: @conference.id, email: @current_user[:info][:email])
+    if current_user
+      SponsorProfile.find_by(conference: @conference.id, email: current_user[:info][:email])
     end
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -122,8 +122,8 @@ class TalksController < ApplicationController
   end
 
   def speaker?
-    return false if @current_user.nil?
-    Speaker.find_by(email: @current_user[:info][:email], conference_id: set_conference.id).present?
+    return false if current_user.nil?
+    Speaker.find_by(email: current_user[:info][:email], conference_id: set_conference.id).present?
   end
 
   def talk_params

--- a/app/views/admin/debug.html.erb
+++ b/app/views/admin/debug.html.erb
@@ -2,10 +2,10 @@
   <h2>Current user</h2>
   <div class="row">
     <div class="col-6">
-      <pre><%= JSON.pretty_generate(@current_user) %></pre>
-      <pre><%= JSON.pretty_generate(@current_user[:info]) %></pre>
-      <pre><%= JSON.pretty_generate(@current_user[:extra][:raw_info]) %></pre>
-      <div><%= JSON.pretty_generate(@current_user[:extra][:raw_info]["https://cloudnativedays.jp/roles"]) %></div>
+      <pre><%= JSON.pretty_generate(current_user) %></pre>
+      <pre><%= JSON.pretty_generate(current_user[:info]) %></pre>
+      <pre><%= JSON.pretty_generate(current_user[:extra][:raw_info]) %></pre>
+      <div><%= JSON.pretty_generate(current_user[:extra][:raw_info]["https://cloudnativedays.jp/roles"]) %></div>
       <%= form_with url: 'admin/destroy_user', method: 'delete' do |form| %>
         <%= form.submit "ログインユーザーを削除", class: "btn btn-primary form-control" %>
       <% end %>

--- a/app/views/api/v1/debug/index.json.jbuilder
+++ b/app/views/api/v1/debug/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.current_user(@current_user)
+json.current_user(current_user)

--- a/app/views/contents/cicd2021_discussion.html.erb
+++ b/app/views/contents/cicd2021_discussion.html.erb
@@ -16,7 +16,7 @@
           </h6>
           <h6 class="card-subtitle mb-3">
             参加URL：
-            <% if @current_user %>
+            <% if current_user %>
               <a href="https://event.cloudnativedays.jp/cicd2021/ui/discussionboard" target="_blank">https://event.cloudnativedays.jp/cicd2021/ui/discussionboard</a>
             <% else %>
               <strong>表示するには CI/CD Conference 2021 サイトにログインしてください。</strong>

--- a/app/views/contents/cicd2023_hands_on.html.erb
+++ b/app/views/contents/cicd2023_hands_on.html.erb
@@ -50,7 +50,7 @@
           <h5 id="hs0"><strong>『Snyk ハンズオン ワークショップ - Snyk四製品(Snyk Code & Open Source & Container & IaC)の体験』by Snyk株式会社</strong></h5>
           <ul>
             <li>
-            <% if @current_user %>
+            <% if current_user %>
               申し込みURL：<a href="https://go.snyk.io/jp-workshop-20230317.html">https://go.snyk.io/jp-workshop-20230317.html</a>
             <% else %>
               <strong class="alert-url">申し込みURLを表示するには CICD2023 サイトにログインしてください。</strong>
@@ -74,7 +74,7 @@
           <h5 id="hs1"><strong>『Sysdigを使ってKubernetes環境のランタイム脅威検知とセキュリティポスチャー管理を実施』by Sysdig Japan合同会社</strong></h5>
           <ul>
             <li>
-            <% if @current_user %>
+            <% if current_user %>
               申し込みURL：<a href="https://go.sysdig.com/2023.03.17-cloudsecurityhandson_sysdig.html">https://go.sysdig.com/2023.03.17-cloudsecurityhandson_sysdig.html</a>
             <% else %>
               <strong class="alert-url">申し込みURLを表示するには CICD2023 サイトにログインしてください。</strong>
@@ -94,7 +94,7 @@
           <h5 id="hs2"><strong>『Jenkins・ArgoCD を利用したCI/CD の実践とコンテナイメージの脆弱性検知』by テクマトリックス株式会社</strong></h5>
           <ul>
             <li>
-            <% if @current_user %>
+            <% if current_user %>
               申し込みURL：<a href="https://www.techmatrix.co.jp/es/event/20230317-cico2023.html">https://www.techmatrix.co.jp/es/event/20230317-cico2023.html</a>
             <% else %>
               <strong class="alert-url">申し込みURLを表示するには CICD2023 サイトにログインしてください。</strong>

--- a/app/views/contents/cndt2020_discussion.html.erb
+++ b/app/views/contents/cndt2020_discussion.html.erb
@@ -16,7 +16,7 @@
           </h6>
           <h6 class="card-subtitle mb-3">
             参加URL：
-            <% if @current_user %>
+            <% if current_user %>
               <a href="https://miro.com/app/board/o9J_kodoxUo=/" target="_blank">https://miro.com/app/board/o9J_kodoxUo=/</a> (Miroが開きます)
             <% else %>
               <strong>表示するには CNDT2020 サイトにログインしてください。</strong>
@@ -26,7 +26,7 @@
           <p class="card-text">この CNDT2020 Discussion Board は、ともに悩みを共有し、ともに解決して一歩進んでいくことを目的に作られています。議論の多様性を認めあって、友好的な場にしましょう。オンラインだからこその電子ボード上で、URLや画像を共有しながら気軽に情報交換することができます。</p>
           <p class="card-text"><strong>初級者も歓迎しています！</strong></p>
           
-          <% if @current_user %>
+          <% if current_user %>
             <hr />
             <h4>↓ Discussion Board 現在の様子</h4>
             <iframe src="https://miro.com/app/embed/o9J_kodoxUo=/?autoplay=yep" style="width: 100%; min-height: 600px;" frameborder="0" scrolling="no" allowfullscreen></iframe>

--- a/app/views/contents/cndt2021_hands_on.html.erb
+++ b/app/views/contents/cndt2021_hands_on.html.erb
@@ -65,7 +65,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://forms.gle/cgkL94Jc1xPzrCMF7">https://forms.gle/cgkL94Jc1xPzrCMF7</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -94,7 +94,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://forms.gle/kF7zuuyoopD7BuA16">https://forms.gle/kF7zuuyoopD7BuA16</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -117,7 +117,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://connpass.com/event/228437/">https://connpass.com/event/228437/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -140,7 +140,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://newrelic.com/jp/events/2021-11-02/nru-for-amazoneks">https://newrelic.com/jp/events/2021-11-02/nru-for-amazoneks</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -167,7 +167,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://openshift.connpass.com/event/228279/">https://openshift.connpass.com/event/228279/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -205,7 +205,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://rancher.connpass.com/event/227382/">https://rancher.connpass.com/event/227382/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -227,7 +227,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://connpass.com/event/228162/">https://connpass.com/event/228162/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -248,7 +248,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://aws-container.connpass.com/event/227811/">https://aws-container.connpass.com/event/227811/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -269,7 +269,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://aws-container.connpass.com/event/227809/">https://aws-container.connpass.com/event/227809/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -290,7 +290,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://docs.google.com/forms/d/e/1FAIpQLSemJNRMjg5xMmwpQ6mDHlUJLpXvPMrBrTU6I3zzKn7Qkv0iqg/viewform">https://docs.google.com/forms/d/e/1FAIpQLSemJNRMjg5xMmwpQ6mDHlUJLpXvPMrBrTU6I3zzKn7Qkv0iqg/viewform</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -318,7 +318,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://page.gitlab.com/cloud-native-days-security-workshop.html">https://page.gitlab.com/cloud-native-days-security-workshop.html</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -347,7 +347,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://elastic.connpass.com/event/228222/">https://elastic.connpass.com/event/228222/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2021 サイトにログインしてください。</strong>

--- a/app/views/contents/cndt2021_job_board.html.erb
+++ b/app/views/contents/cndt2021_job_board.html.erb
@@ -13,7 +13,7 @@
           </h6>
           <h6 class="card-subtitle mb-3">
             参加URL：
-            <% if @current_user %>
+            <% if current_user %>
               <a href="https://miro.com/app/board/o9J_lrLaU1A=/" target="_blank">https://miro.com/app/board/o9J_lrLaU1A=/</a> (Miroが開きます)
             <% else %>
               <strong class="alert-url">URLを表示するには CNDT2021 サイトにログインしてください。</strong>
@@ -24,7 +24,7 @@
           <p class="card-text">興味があるポジションがあれば、連絡をとってみましょう！</p>
           <p class="card-text"><strong>なお、各社・各団体で1枚までとしてください。</strong></p>
           
-          <% if @current_user %>
+          <% if current_user %>
             <hr />
             <h4>↓ Job Board 現在の様子</h4>
             <iframe width="768" height="432" src="https://miro.com/app/live-embed/o9J_lrLaU1A=/?moveToViewport=-24938,-12732,39382,23860" frameBorder="0" scrolling="no" allowFullScreen></iframe>

--- a/app/views/contents/cndt2022_hands_on.html.erb
+++ b/app/views/contents/cndt2022_hands_on.html.erb
@@ -59,7 +59,7 @@
             <h5 id="hc0"><strong>『KubernetesのIngressとして動作するNGINX Ingress Controller設定入門ハンズオン』 by 田邊 淳一</strong></h5>
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://f5networks.zoom.us/webinar/register/WN_O1Xw0KAwRy6EXYmRkjFIEg">https://f5networks.zoom.us/webinar/register/WN_O1Xw0KAwRy6EXYmRkjFIEg</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2022 サイトにログインしてください。</strong>
@@ -92,7 +92,7 @@
             <h5 id="hs0"><strong>『Kubernetes Upstream Training』by 稲生章人 / 武藤周 / 大道憲一 / 毛利唯子 / カイシイ / 河村真樹 / 犬飼敏章</strong></h5>
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://docs.google.com/forms/d/e/1FAIpQLSeiJPvvwkTqCejHj9C7dQJClJoEqUibEAaG8q3yZfR47ismvA/viewform">https://docs.google.com/forms/d/e/1FAIpQLSeiJPvvwkTqCejHj9C7dQJClJoEqUibEAaG8q3yZfR47ismvA/viewform</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2022 サイトにログインしてください。</strong>
@@ -112,7 +112,7 @@
             <h5 id="hs1"><strong>『OCI DevOps で体験する CI/CD パイプライン』 by 市川豊 / 仁井田拓也</strong></h5>
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://ochacafe.connpass.com/event/262488/">https://ochacafe.connpass.com/event/262488/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2022 サイトにログインしてください。</strong>
@@ -131,7 +131,7 @@
             <h5 id="hs2"><strong>『Snyk ハンズオン ワークショップ  - 全四製品(Snyk Code & Open Source & Container & IaC)の体験』 by 相澤 俊幸 / Toshi Aizawa</strong></h5>
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://go.snyk.io/Jp-workshop-20221118.html">https://go.snyk.io/Jp-workshop-20221118.html</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2022 サイトにログインしてください。</strong>
@@ -152,7 +152,7 @@
             <h5 id="hs3"><strong>『Sysdigを使ってKubernetes環境のランタム脅威検知とセキュリティポスチャー管理を実施』 by 竹内 洋</strong></h5>
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://connpass.com/event/262601/">https://connpass.com/event/262601/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2022 サイトにログインしてください。</strong>
@@ -190,7 +190,7 @@
             <h5 id="hs4"><strong>『Docker+LandoでCMS環境を構築してみよう』 by 丸山 ひかる</strong></h5>
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://www.acquia.com/jp/events/webinars/drupal-handson-q42022">https://www.acquia.com/jp/events/webinars/drupal-handson-q42022</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2022 サイトにログインしてください。</strong>
@@ -208,7 +208,7 @@
             <h5 id="hs5"><strong>『Red Hat OpenShiftを活用してクラウドネイティブな開発を体験してみよう（中級編）+ 超初心者編』 by 暮林 達也(@Tatsuyak9i)、斎藤 和史(@capsmalt)、他有志</strong></h5>
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://connpass.com/event/264009/">https://connpass.com/event/264009/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには CNDT2022 サイトにログインしてください。</strong>

--- a/app/views/contents/cndt2023_hands_on.html.erb
+++ b/app/views/contents/cndt2023_hands_on.html.erb
@@ -61,7 +61,7 @@
       <a href="https://bit.ly/openshiftjp-slack" target="_blank"><%= image_tag 'cndt2023/handson/redhat.jpg', class: "logo" %></a>
       <ul>
         <li>
-          <% if @current_user %>
+          <% if current_user %>
             申し込みURL：<a href="https://openshift.connpass.com/event/301853/">https://openshift.connpass.com/event/301853/</a>
           <% else %>
             <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>
@@ -95,7 +95,7 @@
       <a href="https://www.cloudnatix.com/" target="_blank"><%= image_tag 'cndt2023/handson/CloudNatix.png', class: "logo" %></a>
       <ul>
         <li>
-          <% if @current_user %>
+          <% if current_user %>
             申し込みURL：<a href="https://forms.office.com/r/k0bgUneZiV">https://forms.office.com/r/k0bgUneZiV</a>
           <% else %>
             <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>
@@ -121,7 +121,7 @@
       <a href="https://bit.ly/openshiftjp-slack" target="_blank"><%= image_tag 'cndt2023/handson/redhat.jpg', class: "logo" %></a>
       <ul>
         <li>
-          <% if @current_user %>
+          <% if current_user %>
             申し込みURL：<a href="https://openshift.connpass.com/event/303064/">https://openshift.connpass.com/event/303064/</a>
           <% else %>
             <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>
@@ -154,7 +154,7 @@
       <a href="https://www.3-shake.com/" target="_blank"><%= image_tag 'cndt2023/handson/3-shake_logo.png', class: "logo" %></a>
       <ul>
         <li>
-          <% if @current_user %>
+          <% if current_user %>
             申し込みURL：<a href="https://www.securify.jp/event-seminar/handson-web/?utm_source=cndt2023&utm_medium=referral&utm_campaign=securify_web">https://www.securify.jp/event-seminar/handson-web/</a>
           <% else %>
             <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>
@@ -188,7 +188,7 @@
         <a href="https://www.dynatrace.com/ja/" target="_blank"><%= image_tag 'cndt2023/handson/dynatrace.png', class: "logo" %></a>
         <ul>
           <li>
-            <% if @current_user %>
+            <% if current_user %>
               申し込みURL：<a href="https://info.dynatrace.com/apac-japan-wc-hands-on-workshop-sre-19684-registration.html">https://info.dynatrace.com/apac-japan-wc-hands-on-workshop-sre-19684-registration.html</a>
             <% else %>
               <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>
@@ -220,7 +220,7 @@
       <a href="https://bit.ly/openshiftjp-slack" target="_blank"><%= image_tag 'cndt2023/handson/redhat.jpg', class: "logo" %></a>
       <ul>
         <li>
-          <% if @current_user %>
+          <% if current_user %>
             申し込みURL：<a href="https://openshift.connpass.com/event/303065/">https://openshift.connpass.com/event/303065/</a>
           <% else %>
             <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>
@@ -245,7 +245,7 @@
         <h3 id="hc6">『一日で学ぶクラウドネイティブ技術実践ハンズオン』by CloudNative Days Tokyo 2023 実行委員会</h3>
         <ul>
           <li>
-            <% if @current_user %>
+            <% if current_user %>
               申し込みURL：<a href="https://docs.google.com/forms/d/e/1FAIpQLSf41IhlbwDO-vNe0UCoJ6_EwnxN8eCyF5A4_JGGJ5wwvozUdw/viewform">https://docs.google.com/forms/d/e/1FAIpQLSf41IhlbwDO-vNe0UCoJ6_EwnxN8eCyF5A4_JGGJ5wwvozUdw/viewform</a>
             <% else %>
               <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>
@@ -291,7 +291,7 @@
       <a href="https://bit.ly/openshiftjp-slack" target="_blank"><%= image_tag 'cndt2023/handson/redhat.jpg', class: "logo" %></a>
       <ul>
         <li>
-          <% if @current_user %>
+          <% if current_user %>
             申し込みURL：<a href="https://openshift.connpass.com/event/303082/">https://openshift.connpass.com/event/303082/</a>
           <% else %>
             <strong class="alert-url">申し込みURLを表示するには CNDT2023 サイトにログインしてください。</strong>

--- a/app/views/contents/kontest.html.erb
+++ b/app/views/contents/kontest.html.erb
@@ -13,7 +13,7 @@
           </h6>
           <h6 class="card-subtitle mb-3">
             参加URL：
-            <% if @current_user %>
+            <% if current_user %>
               <a href="https://k-ontest.cloudnativedays.jp" target="_blank">https://k-ontest.cloudnativedays.jp</a>
             <% else %>
               <strong>表示するには CNDT2020 サイトにログインしてください。</strong>

--- a/app/views/contents/o11y2022_hands_on.html.erb
+++ b/app/views/contents/o11y2022_hands_on.html.erb
@@ -59,7 +59,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://www.elastic.co/jp/virtual-events/observability-hands-on-workshop">https://www.elastic.co/jp/virtual-events/observability-hands-on-workshop</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには Observebility Conference 2022 サイトにログインしてください。</strong>
@@ -83,7 +83,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://www.scsk.jp/event/2022/20220310.html">https://www.scsk.jp/event/2022/20220310.html</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには Observebility Conference 2022 サイトにログインしてください。</strong>
@@ -104,7 +104,7 @@
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://connpass.com/event/238995/">https://connpass.com/event/238995/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには Observebility Conference 2022 サイトにログインしてください。</strong>
@@ -126,7 +126,7 @@ Oracle Cloud Infrastructure(OCI)のオブザバビリティサービス（Applic
 
             <ul>
               <li>
-                <% if @current_user %>
+                <% if current_user %>
                   申し込みURL：<a href="https://connpass.com/event/240049/">https://connpass.com/event/240049/</a>
                 <% else %>
                   <strong class="alert-url">申し込みURLを表示するには Observebility Conference 2022 サイトにログインしてください。</strong>

--- a/app/views/event/cicd2021_show.html.erb
+++ b/app/views/event/cicd2021_show.html.erb
@@ -58,7 +58,7 @@
                         --row-start: <%= row_start %>;
                         --row-end: <%= row_end  %>;">
                 <div class="content
-                            <%= 'checked' if @current_user && @profile && talks_checked?(talk.id) %>"
+                            <%= 'checked' if current_user && @profile && talks_checked?(talk.id) %>"
                             talk_id="<%= talk.id %>"
                             track_number="<%= talk.track.number %>">
                   <h6>

--- a/app/views/event/cnsec2022_show.html.erb
+++ b/app/views/event/cnsec2022_show.html.erb
@@ -66,7 +66,7 @@
                             --row-start: <%= row_start %>;
                             --row-end: <%= row_end  %>;">
               <div class="content
-                                <%= 'checked' if @current_user && @profile && talks_checked?(talk.id) %>"
+                                <%= 'checked' if current_user && @profile && talks_checked?(talk.id) %>"
                 talk_id="<%= talk.id %>" track_number="<%= talk.track.number %>">
                 <h6>
                   <span class="track_name">Track <%= talk.track.name %>&nbsp;</span>

--- a/app/views/event/o11y2022_show.html.erb
+++ b/app/views/event/o11y2022_show.html.erb
@@ -81,7 +81,7 @@
                             --row-start: <%= row_start %>;
                             --row-end: <%= row_end  %>;">
                     <div class="content
-                                <%= 'checked' if @current_user && @profile && talks_checked?(talk.id) %>"
+                                <%= 'checked' if current_user && @profile && talks_checked?(talk.id) %>"
                                 talk_id="<%= talk.id %>"
                                 track_number="<%= talk.track.number %>">
                       <h6>

--- a/app/views/layouts/_karte.html.erb
+++ b/app/views/layouts/_karte.html.erb
@@ -3,10 +3,10 @@
 <script async src="https://cdn-edge.karte.io/8ecf5f9dea00108ea97718d81a3c6b4f/edge.js"></script>
 <!-- End KARTE Tag -->
 
-<% if @current_user %>
+<% if current_user %>
     <script>
         krt('send', 'identify', {
-            user_id: "<%= @current_user[:extra][:raw_info][:sub] %>",
+            user_id: "<%= current_user[:extra][:raw_info][:sub] %>",
             event: "<%= event_name %>",
         })
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,7 @@
   </footer>
   <% end %>
 
-  <% if @current_user && @conference&.abbr == 'cndt2020'%>
+  <% if current_user && @conference&.abbr == 'cndt2020'%>
     <div id="message_icon">
       <%= image_tag  "trademark.png" %>
     </div>

--- a/app/views/layouts/partial/_login_button.erb
+++ b/app/views/layouts/partial/_login_button.erb
@@ -1,8 +1,8 @@
 <% if @conference.present? && !@conference.archived? %>
-  <% if @current_user %>
+  <% if current_user %>
     <a class="nav-link" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <img class="thumbnail img-circle" src="<%= @current_user[:info][:image] %>" />
-      <%= @current_user[:info][:nickname] %>
+      <img class="thumbnail img-circle" src="<%= current_user[:info][:image] %>" />
+      <%= current_user[:info][:nickname] %>
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <% if event_name && @profile.present? && @profile.id %>
@@ -33,7 +33,7 @@
       <li class="nav-item"><%= button_to 'Log in', '/auth/auth0', {id: 'login', method: :post, class: "btn btn-primary btn-block btn-sm" } %></li>
   <% end %>
 <% else %>
-  <% if @current_user %>
+  <% if current_user %>
     <li class="nav-item dropdown">
       <%= link_to "Menu", '#', id: "navbarDropdown", class: 'nav-link', role: "button", 'data-toggle': "dropdown", 'aria-haspopup': "true", 'aria-expanded': "false" %>
       <div class="dropdown-menu" aria-labelledby="navbarDropdown">

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -31,7 +31,7 @@
 </div>
 
 
-<% if @current_user %>
+<% if current_user %>
   <script>
       window.talk_id = "<%= @talk.id %>";
       window.talk_name = "<%= @talk.title %>";

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -29,7 +29,7 @@
 </div>
 
 
-<% if @current_user %>
+<% if current_user %>
   <script>
       window.talk_id = "<%= @talk.id %>";
       window.talk_name = "<%= @talk.title %>";

--- a/app/views/timetable/_talk.html.erb
+++ b/app/views/timetable/_talk.html.erb
@@ -17,7 +17,7 @@
       <%= form.check_box "talks[#{talk.id}]", { talk_id: talk.id, checked: talks_checked?(talk.id)}, true, false %>
       <% end %>
 
-        <div class="content <%= 'checked' if @current_user && talks_checked?(talk.id) %>" talk_id="<%= talk.id %>" track_number="<%= talk.track.number %>">
+        <div class="content <%= 'checked' if current_user && talks_checked?(talk.id) %>" talk_id="<%= talk.id %>" track_number="<%= talk.track.number %>">
           <h6>
               <span class="track_name">Track <%= talk.track.name %>&nbsp;</span><%= talk.start_time.strftime("%H:%M") %>-<%= talk.end_time.strftime("%H:%M") %><%= ' (アーカイブ視聴不可)' unless talk.video_published %></span>
           </h6>

--- a/app/views/timetable/_timetable.html.erb
+++ b/app/views/timetable/_timetable.html.erb
@@ -14,7 +14,7 @@
       <% conference_day.talks.where(show_on_timetable: true).each do |talk| %>
         <div class="talk" slot="<%= talk.slot_number %>" style="--track: <%= talk.track.number - 1 %>; --duration: 60; --row-start: <%= talk.row_start %>; --row-end: <%= talk.row_end  %>;">
           <% day_slot = "#{talk.conference_day_id}_#{talk.slot_number}" %>
-          <div class="content <%= 'checked' if @current_user && talks_checked?(talk.id) %>  <%= 'first' unless day_slots.include?(day_slot) %>"
+          <div class="content <%= 'checked' if current_user && talks_checked?(talk.id) %>  <%= 'first' unless day_slots.include?(day_slot) %>"
                slot="<%= talk.slot_number %>"
                day_slot="<%= day_slot %>"
                talk_number="<%= talk.talk_number %>">

--- a/app/views/timetable/_timetable_cicd2021.html.erb
+++ b/app/views/timetable/_timetable_cicd2021.html.erb
@@ -27,7 +27,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>">
             <h6>

--- a/app/views/timetable/_timetable_cicd2023.html.erb
+++ b/app/views/timetable/_timetable_cicd2023.html.erb
@@ -47,7 +47,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>"
                style="margin-top:0">

--- a/app/views/timetable/_timetable_cndf2023.html.erb
+++ b/app/views/timetable/_timetable_cndf2023.html.erb
@@ -55,7 +55,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>"
                style="margin-top:0">

--- a/app/views/timetable/_timetable_cndt2021.html.erb
+++ b/app/views/timetable/_timetable_cndt2021.html.erb
@@ -26,7 +26,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>"
                style="margin-top:0">

--- a/app/views/timetable/_timetable_cndt2022.html.erb
+++ b/app/views/timetable/_timetable_cndt2022.html.erb
@@ -42,7 +42,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>"
                style="margin-top:0">

--- a/app/views/timetable/_timetable_cndt2023.html.erb
+++ b/app/views/timetable/_timetable_cndt2023.html.erb
@@ -55,7 +55,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %> <%= 'disabled' if form_status %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>"
                style="margin-top:0">

--- a/app/views/timetable/_timetable_cnsec2022.html.erb
+++ b/app/views/timetable/_timetable_cnsec2022.html.erb
@@ -27,7 +27,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>">
             <h6>

--- a/app/views/timetable/_timetable_o11y2022.html.erb
+++ b/app/views/timetable/_timetable_o11y2022.html.erb
@@ -27,7 +27,7 @@
                               false %>
           <% end %>
           <div class="content
-                      <%= 'checked' if @current_user && talks_checked?(talk.id) %>"
+                      <%= 'checked' if current_user && talks_checked?(talk.id) %>"
                       talk_id="<%= talk.id %>"
                       track_number="<%= talk.track.number %>">
             <h6>

--- a/app/views/timetable/index.html.erb
+++ b/app/views/timetable/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="modal fade" id="talk-modal" tabindex="-1" role="dialog" aria-hidden="true"></div>
 
-<% if @current_user %>
+<% if current_user %>
   <%= form_with url: 'profiles/talks', method: :post do |form| %>
     <%= render partial: timetable_partial_name, locals: {conference: @conference, form: form} %>
   <% end %>


### PR DESCRIPTION
1. Implements `current_user` with the same implementation as `set_current_user`
   * #2278
3. Replace all `@current_user` ivar access with `current_user` method <- This PR
4. Remove `set_current_user` method

## Impact

This PR changes many files to stop using `@current_user` ivar.
But the implementation between `current_user` and `set_current_user` is the same.
Therefore, any potential issues are expected to be limited.

