### PR TITLE
Refactor: Use `current_user` instead of `set_current_user` (3/3)

### DIFF
--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -10,11 +10,7 @@ module Secured
   end
 
   def logged_in_using_omniauth?
-    if logged_in?
-      set_current_user
-    else
-      redirect_to('/auth/login?origin=' + request.fullpath)
-    end
+    redirect_to('/auth/login?origin=' + request.fullpath) unless logged_in?
   end
 
   def redirect_to_website
@@ -68,10 +64,6 @@ module Secured
 
   def event_name
     params[:event]
-  end
-
-  def set_current_user
-    current_user
   end
 
   private

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -7,11 +7,7 @@ module SecuredAdmin
   end
 
   def logged_in_using_omniauth?
-    if logged_in?
-      set_current_user
-    else
-      redirect_to('/auth/login?origin=' + request.fullpath)
-    end
+    redirect_to('/auth/login?origin=' + request.fullpath) unless logged_in?
   end
 
   def logged_in?
@@ -32,10 +28,6 @@ module SecuredAdmin
 
   def is_admin?
     raise(Forbidden) unless admin?
-  end
-
-  def set_current_user
-    current_user
   end
 
   def get_or_create_admin_profile

--- a/app/controllers/concerns/secured_api.rb
+++ b/app/controllers/concerns/secured_api.rb
@@ -6,20 +6,12 @@ module SecuredApi
   end
 
   def logged_in_using_omniauth?
-    if logged_in?
-      set_current_user
-    else
-      raise(Forbidden)
-    end
+    raise(Forbidden) unless logged_in?
   end
 
   private
 
   def logged_in?
     session[:userinfo].present?
-  end
-
-  def set_current_user
-    current_user
   end
 end

--- a/app/controllers/concerns/secured_beta.rb
+++ b/app/controllers/concerns/secured_beta.rb
@@ -2,7 +2,7 @@ module SecuredBeta
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_current_user, :is_beta_user?
+    before_action :is_beta_user?
   end
 
   def beta_user?
@@ -11,10 +11,6 @@ module SecuredBeta
 
   def is_beta_user?
     raise(NotFound) unless beta_user? || admin?
-  end
-
-  def set_current_user
-    current_user
   end
 
   def admin?

--- a/app/controllers/concerns/secured_speaker.rb
+++ b/app/controllers/concerns/secured_speaker.rb
@@ -7,15 +7,7 @@ module SecuredSpeaker
   end
 
   def logged_in_using_omniauth?
-    if logged_in?
-      set_current_user
-    else
-      redirect_to("/#{params[:event]}/speaker_dashboard")
-    end
-  end
-
-  def set_current_user
-    current_user
+    redirect_to("/#{params[:event]}/speaker_dashboard") unless logged_in?
   end
 
   def logged_in?
@@ -31,10 +23,6 @@ module SecuredSpeaker
   end
 
   def prepare_create
-    if logged_in?
-      set_current_user
-    else
-      redirect_to("/#{params[:event]}/speakers/guidance")
-    end
+    redirect_to("/#{params[:event]}/speakers/guidance") unless logged_in?
   end
 end

--- a/app/controllers/concerns/secured_sponsor.rb
+++ b/app/controllers/concerns/secured_sponsor.rb
@@ -7,15 +7,7 @@ module SecuredSponsor
   end
 
   def logged_in_using_omniauth?
-    if logged_in?
-      set_current_user
-    else
-      redirect_to("/#{params[:event]}/sponsor_dashboards/login")
-    end
-  end
-
-  def set_current_user
-    current_user
+    redirect_to("/#{params[:event]}/sponsor_dashboards/login") unless logged_in?
   end
 
   def logged_in?

--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -3,7 +3,7 @@ class EventController < ApplicationController
   include SponsorHelper
   include ActionView::Helpers::UrlHelper
 
-  before_action :set_current_user, :set_profile, :set_speaker
+  before_action :set_profile, :set_speaker
 
   def show
     @conference = Conference
@@ -18,10 +18,6 @@ class EventController < ApplicationController
 
       render(event_view)
     end
-  end
-
-  def set_current_user
-    current_user
   end
 
   def privacy

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,13 +1,11 @@
 class ProposalsController < ApplicationController
   include Secured
-  before_action :set_current_user, :set_profile, :set_speaker
+  before_action :set_profile, :set_speaker
 
   helper_method :proposal_status
 
   def logged_in_using_omniauth?
-    if logged_in?
-      set_current_user
-    end
+    # nop
   end
 
   def show

--- a/app/controllers/speaker_dashboard/speakers_controller.rb
+++ b/app/controllers/speaker_dashboard/speakers_controller.rb
@@ -2,7 +2,6 @@ class SpeakerDashboard::SpeakersController < ApplicationController
   include SecuredSpeaker
 
   skip_before_action :logged_in_using_omniauth?, only: [:new, :guidance]
-  before_action :set_current_user, only: [:guidance]
   before_action :prepare_create, only: [:new]
 
   # GET :event/speaker_dashboard/speakers/guidance


### PR DESCRIPTION
1. Implements `current_user` with the same implementation as `set_current_user`
   * #2278
2. Replace all `@current_user` ivar access with `current_user` method
   * #2279
3. Remove `set_current_user` method <- This PR

## Impact

With the replacement of all `@current_user` ivar with `current_user` method, the `set_current_user` method has become redundant.
This PR removes the `set_current_user` method along with any codes that call it.

Since all `@current_user` ivar have already been replaced with `current_user` method call, there are no effects on functionality.