### PR TITLE
fix: An issue where the form adding a session would not be displayed and would be reloaded when the `add session` button was pressed

### DIFF
--- a/app/javascript/packs/speaker_form.js
+++ b/app/javascript/packs/speaker_form.js
@@ -9,7 +9,7 @@ const fieldLength = () => {
 }
 
 
-window.onload = () => {
+document.addEventListener('DOMContentLoaded', () => {
     document.getElementsByClassName('add_talk_fields')[0].addEventListener('click', (e) => {
         e.preventDefault();
         const time = new Date().getTime();
@@ -24,7 +24,7 @@ window.onload = () => {
         return false;
     });
     document.getElementsByClassName('remove_talk_field').forEach((obj) => {addDeleteButtonListener(obj)});
-}
+})
 
 document.addEventListener('change', (e) => {
     if (e.target.classList.contains('talk-categories')) {


### PR DESCRIPTION
If using `window.onload`, addEventListener runs before complete render dom. In that case, `add session` button have no event listener.

reproduction steps:

1. Go to `/cnds2024/admin/sponsors` and add sponsor. Add your email into speaker list.
2. Go to `/cnds2024/sponsor_dashboards/login` . Input your name and proceed form, you can open `/cnds2024/sponsor_dashboards/${sponsor_id}/speakers/new` that is form for inputting sponsor speaker and sponsor session.
3. Click `セッションを追加する` . Expected behavior is adding form for session, but nothing happens.