### PR TITLE
Prepare for enabling open redirect protection in Rails 7.0

### DIFF
--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -21,9 +21,9 @@ module Secured
     if set_conference.migrated?
       case [controller_name, action_name]
       in ['talks', 'show']
-        redirect_to(URI.join(WEBSITE_BASE_URL, request.fullpath).to_s)
+        redirect_to(URI.join(WEBSITE_BASE_URL, request.fullpath).to_s, allow_other_host: true)
       else
-        redirect_to(URI.join(WEBSITE_BASE_URL, params[:event]).to_s)
+        redirect_to(URI.join(WEBSITE_BASE_URL, params[:event]).to_s, allow_other_host: true)
       end
     end
   end

--- a/app/controllers/logout_controller.rb
+++ b/app/controllers/logout_controller.rb
@@ -1,7 +1,7 @@
 class LogoutController < ApplicationController
   def logout
     reset_session
-    redirect_to(auth0_logout_url)
+    redirect_to(auth0_logout_url, allow_other_host: true)
   end
 
   private


### PR DESCRIPTION
Rails 7.0 introduced open redirect protection as a new security feature.
Dreamkast is currently running on Rails 7.0 but has not fully transitioned to the defaults (with `new_framework_defaults_7_0.rb` still pending updates).
This commit prepares for Rails 7.0 default settings, including open redirect protection.
