### PR TITLE
fix: an issue where two forms were added when clicking `add new session` in sponsor session form

### DIFF
--- a/app/views/speaker_dashboard/speakers/_form.html.erb
+++ b/app/views/speaker_dashboard/speakers/_form.html.erb
@@ -100,5 +100,3 @@
     <%= form.submit class: "btn btn-primary btn-lg btn-block" %>
   </div>
 <% end %>
-
-<%= javascript_pack_tag "speaker_form.js" %>


### PR DESCRIPTION
speaker_form.js is imported in form.html, but it's already imported in cnds2024.js.