### PR TITLE
チェックイン用のAPIエンドポイントを追加

### DIFF
--- a/app/controllers/api/v1/check_in_conferences_controller.rb
+++ b/app/controllers/api/v1/check_in_conferences_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::CheckInConferencesController < ApplicationController
   def create
     @params = check_in_conference_params(JSON.parse(request.body.read, { symbolize_names: true }))
     profile = Profile.find(@params[:profileId])
-    check_in_timestamp = Time.at(@params[:check_in_timestamp])
+    check_in_timestamp = Time.zone.at(@params[:check_in_timestamp])
     @check_in = CheckInConference.new(profile:, conference:, check_in_timestamp:)
 
     if @check_in.save

--- a/app/controllers/api/v1/check_in_conferences_controller.rb
+++ b/app/controllers/api/v1/check_in_conferences_controller.rb
@@ -9,8 +9,8 @@ class Api::V1::CheckInConferencesController < ApplicationController
   def create
     @params = check_in_conference_params(JSON.parse(request.body.read, { symbolize_names: true }))
     profile = Profile.find(@params[:profileId])
-    timestamp = Time.at(@params[:timestamp])
-    @check_in = CheckInConference.new(profile:, conference:, timestamp:)
+    check_in_timestamp = Time.at(@params[:check_in_timestamp])
+    @check_in = CheckInConference.new(profile:, conference:, check_in_timestamp:)
 
     if @check_in.save
       render(json: @check_in, status: :created)
@@ -21,6 +21,6 @@ class Api::V1::CheckInConferencesController < ApplicationController
 
   def check_in_conference_params(_params)
     json_params = ActionController::Parameters.new(JSON.parse(request.body.read))
-    json_params.permit(:profileId, :eventAbbr, :timestamp)
+    json_params.permit(:profileId, :eventAbbr, :check_in_timestamp)
   end
 end

--- a/app/controllers/api/v1/check_in_conferences_controller.rb
+++ b/app/controllers/api/v1/check_in_conferences_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::CheckInConferencesController < ApplicationController
+  include SecuredPublicApi
+  before_action :set_profile
+
+  skip_before_action :verify_authenticity_token
+
+  rescue_from Pundit::NotAuthorizedError, with: :not_authorized
+
+  def create
+    @params = check_in_conference_params(JSON.parse(request.body.read, { symbolize_names: true }))
+    profile = Profile.find(@params[:profileId])
+    timestamp = Time.at(@params[:timestamp])
+    @check_in = CheckInConference.new(profile:, conference:, timestamp:)
+
+    if @check_in.save
+      render(json: @check_in, status: :created)
+    else
+      render(json: @check_in.errors, status: :unprocessable_entity)
+    end
+  end
+
+  def check_in_conference_params(_params)
+    json_params = ActionController::Parameters.new(JSON.parse(request.body.read))
+    json_params.permit(:profileId, :eventAbbr, :timestamp)
+  end
+end

--- a/app/controllers/api/v1/check_in_talks_controller.rb
+++ b/app/controllers/api/v1/check_in_talks_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::CheckInTalksController < ApplicationController
   def create
     talk = Talk.find(check_in_talk_params[:talkId])
     profile = Profile.find(check_in_talk_params[:profileId])
-    check_in_timestamp = Time.at(check_in_talk_params[:check_in_timestamp])
+    check_in_timestamp = Time.zone.at(check_in_talk_params[:check_in_timestamp])
     @check_in = CheckInTalk.new(profile:, talk:, check_in_timestamp:)
 
     if @check_in.save

--- a/app/controllers/api/v1/check_in_talks_controller.rb
+++ b/app/controllers/api/v1/check_in_talks_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::CheckInTalksController < ApplicationController
+  include SecuredPublicApi
+  before_action :set_profile
+
+  skip_before_action :verify_authenticity_token
+
+  rescue_from Pundit::NotAuthorizedError, with: :not_authorized
+
+  def create
+    talk = Talk.find(check_in_talk_params[:talkId])
+    profile = Profile.find(check_in_talk_params[:profileId])
+    timestamp = Time.at(check_in_talk_params[:timestamp])
+    @check_in = CheckInTalk.new(profile:, talk:, timestamp:)
+
+    if @check_in.save
+      render(json: @check_in, status: :created)
+    else
+      render(json: @check_in.errors, status: :unprocessable_entity)
+    end
+  end
+
+  def check_in_talk_params
+    json_params = ActionController::Parameters.new(JSON.parse(request.body.read))
+    json_params.permit(:eventAbbr, :profileId, :talkId, :timestamp)
+  end
+end

--- a/app/controllers/api/v1/check_in_talks_controller.rb
+++ b/app/controllers/api/v1/check_in_talks_controller.rb
@@ -9,8 +9,8 @@ class Api::V1::CheckInTalksController < ApplicationController
   def create
     talk = Talk.find(check_in_talk_params[:talkId])
     profile = Profile.find(check_in_talk_params[:profileId])
-    timestamp = Time.at(check_in_talk_params[:timestamp])
-    @check_in = CheckInTalk.new(profile:, talk:, timestamp:)
+    check_in_timestamp = Time.at(check_in_talk_params[:check_in_timestamp])
+    @check_in = CheckInTalk.new(profile:, talk:, check_in_timestamp:)
 
     if @check_in.save
       render(json: @check_in, status: :created)
@@ -21,6 +21,6 @@ class Api::V1::CheckInTalksController < ApplicationController
 
   def check_in_talk_params
     json_params = ActionController::Parameters.new(JSON.parse(request.body.read))
-    json_params.permit(:eventAbbr, :profileId, :talkId, :timestamp)
+    json_params.permit(:eventAbbr, :profileId, :talkId, :check_in_timestamp)
   end
 end

--- a/app/controllers/concerns/secured_public_api.rb
+++ b/app/controllers/concerns/secured_public_api.rb
@@ -40,4 +40,12 @@ module SecuredPublicApi
     end
     @current_user
   end
+
+  def conference
+    @conference ||= Conference.find_by(abbr: params[:eventAbbr])
+  end
+
+  def set_conference
+    conference
+  end
 end

--- a/app/models/check_in_conference.rb
+++ b/app/models/check_in_conference.rb
@@ -2,12 +2,12 @@
 #
 # Table name: check_in_conferences
 #
-#  id            :bigint           not null, primary key
-#  timestamp     :datetime         not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  conference_id :bigint           not null
-#  profile_id    :bigint           not null
+#  id                 :bigint           not null, primary key
+#  check_in_timestamp :datetime         not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  conference_id      :bigint           not null
+#  profile_id         :bigint           not null
 #
 # Indexes
 #

--- a/app/models/check_in_conference.rb
+++ b/app/models/check_in_conference.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: check_in_conferences
+#
+#  id            :bigint           not null, primary key
+#  timestamp     :datetime         not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  conference_id :bigint           not null
+#  profile_id    :bigint           not null
+#
+# Indexes
+#
+#  index_check_in_conferences_on_conference_id  (conference_id)
+#  index_check_in_conferences_on_profile_id     (profile_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#  fk_rails_...  (profile_id => profiles.id)
+#
+class CheckInConference < ApplicationRecord
+  belongs_to :conference
+  belongs_to :profile
+end

--- a/app/models/check_in_talk.rb
+++ b/app/models/check_in_talk.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: check_in_talks
+#
+#  id         :bigint           not null, primary key
+#  timestamp  :datetime         not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  profile_id :bigint           not null
+#  talk_id    :bigint           not null
+#
+# Indexes
+#
+#  index_check_in_talks_on_profile_id  (profile_id)
+#  index_check_in_talks_on_talk_id     (talk_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (profile_id => profiles.id)
+#  fk_rails_...  (talk_id => talks.id)
+#
+class CheckInTalk < ApplicationRecord
+  belongs_to :talk
+  belongs_to :profile
+end

--- a/app/models/check_in_talk.rb
+++ b/app/models/check_in_talk.rb
@@ -2,12 +2,12 @@
 #
 # Table name: check_in_talks
 #
-#  id         :bigint           not null, primary key
-#  timestamp  :datetime         not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  profile_id :bigint           not null
-#  talk_id    :bigint           not null
+#  id                 :bigint           not null, primary key
+#  check_in_timestamp :datetime         not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  profile_id         :bigint           not null
+#  talk_id            :bigint           not null
 #
 # Indexes
 #

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -73,6 +73,8 @@ class Conference < ApplicationRecord
   has_many :admin_profiles
   has_many :media_package_harvest_jobs
   has_many :rooms
+  has_many :check_in_conferences
+  has_many :check_in_talks
 
   scope :upcoming, -> {
     merge(where(conference_status: Conference::STATUS_REGISTERED).or(where(conference_status: Conference::STATUS_OPENED)))

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -74,7 +74,6 @@ class Conference < ApplicationRecord
   has_many :media_package_harvest_jobs
   has_many :rooms
   has_many :check_in_conferences
-  has_many :check_in_talks
 
   scope :upcoming, -> {
     merge(where(conference_status: Conference::STATUS_REGISTERED).or(where(conference_status: Conference::STATUS_OPENED)))

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -73,6 +73,8 @@ class Profile < ApplicationRecord
   has_many :form_items, through: :agreements
   has_many :chat_messages
   has_many :check_ins
+  has_many :check_in_conferences
+  has_many :check_in_talks
   has_one :public_profile, dependent: :destroy
 
   before_create do

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -58,6 +58,7 @@ class Talk < ApplicationRecord
   has_many :speakers, through: :talks_speakers
   has_many :profiles, through: :registered_talks
   has_many :media_package_harvest_jobs
+  has_many :check_in_talks
 
   has_many :proposal_items, autosave: true, dependent: :destroy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
       resources :chat_messages, only: [:index, :create, :update]
       resources :booths, only: [:show]
       resources :debug, only: [:index]
+      resources :check_in_conferences, only: [:create]
+      resources :check_in_talks, only: [:create]
       namespace 'talks' do
         get ':id/video_registration' => 'video_registration#show'
         put ':id/video_registration' => 'video_registration#update'

--- a/db/migrate/20240421052443_add_new_check_ins_tables.rb
+++ b/db/migrate/20240421052443_add_new_check_ins_tables.rb
@@ -3,7 +3,7 @@ class AddNewCheckInsTables < ActiveRecord::Migration[7.0]
     create_table :check_in_conferences do |t|
       t.belongs_to :conference, null: false, foreign_key: true
       t.belongs_to :profile, null: false, foreign_key: true
-      t.datetime :timestamp, null: false
+      t.datetime :check_in_timestamp, null: false
 
       t.timestamps
     end
@@ -11,7 +11,7 @@ class AddNewCheckInsTables < ActiveRecord::Migration[7.0]
     create_table :check_in_talks do |t|
       t.belongs_to :talk, null: false, foreign_key: true
       t.belongs_to :profile, null: false, foreign_key: true
-      t.datetime :timestamp, null: false
+      t.datetime :check_in_timestamp, null: false
 
       t.timestamps
     end

--- a/db/migrate/20240421052443_add_new_check_ins_tables.rb
+++ b/db/migrate/20240421052443_add_new_check_ins_tables.rb
@@ -1,0 +1,19 @@
+class AddNewCheckInsTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :check_in_conferences do |t|
+      t.belongs_to :conference, null: false, foreign_key: true
+      t.belongs_to :profile, null: false, foreign_key: true
+      t.datetime :timestamp, null: false
+
+      t.timestamps
+    end
+
+    create_table :check_in_talks do |t|
+      t.belongs_to :talk, null: false, foreign_key: true
+      t.belongs_to :profile, null: false, foreign_key: true
+      t.datetime :timestamp, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,6 +84,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_29_040134) do
     t.index ["speaker_id"], name: "index_chat_messages_on_speaker_id"
   end
 
+  create_table "check_in_conferences", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "timestamp", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["conference_id"], name: "index_check_in_conferences_on_conference_id"
+    t.index ["profile_id"], name: "index_check_in_conferences_on_profile_id"
+  end
+
+  create_table "check_in_talks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "talk_id", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "timestamp", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_check_in_talks_on_profile_id"
+    t.index ["talk_id"], name: "index_check_in_talks_on_talk_id"
+  end
+
   create_table "check_ins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "profile_id"
     t.datetime "created_at", null: false
@@ -575,6 +595,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_29_040134) do
   add_foreign_key "chat_messages", "conferences"
   add_foreign_key "chat_messages", "profiles"
   add_foreign_key "chat_messages", "speakers"
+  add_foreign_key "check_in_conferences", "conferences"
+  add_foreign_key "check_in_conferences", "profiles"
+  add_foreign_key "check_in_talks", "profiles"
+  add_foreign_key "check_in_talks", "talks"
   add_foreign_key "links", "conferences"
   add_foreign_key "live_streams", "conferences"
   add_foreign_key "live_streams", "tracks"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,7 +87,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_29_040134) do
   create_table "check_in_conferences", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.bigint "profile_id", null: false
-    t.datetime "timestamp", null: false
+    t.datetime "check_in_timestamp", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["conference_id"], name: "index_check_in_conferences_on_conference_id"
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_29_040134) do
   create_table "check_in_talks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "talk_id", null: false
     t.bigint "profile_id", null: false
-    t.datetime "timestamp", null: false
+    t.datetime "check_in_timestamp", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_id"], name: "index_check_in_talks_on_profile_id"

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -31,6 +31,34 @@ paths:
                 $ref: '#/components/schemas/Profile'
         '403':
           description: You don't logged in
+  /api/v1/check_in_event:
+    post:
+      tags:
+        - CheckIn
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckInEvent'
+      responses:
+        '201':
+          description: CREATED
+        '400':
+          description: Invalid params supplied
+  /api/v1/check_in_talk:
+    post:
+      tags:
+        - CheckIn
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckInTalk'
+      responses:
+        '201':
+          description: CREATED
+        '400':
+          description: Invalid params supplied
   /api/v1/events:
     get:
       tags:
@@ -1025,4 +1053,30 @@ components:
         }
         createdAt: "2022-04-30T10:06:33.938Z"
         updatedAt: "2022-05-30T22:02:11.123Z"
-
+    CheckInEvent:
+      type: object
+      properties:
+        profileId:
+          type: string
+        eventId:
+          type: string
+        timestamp:
+          type: number
+      required:
+        - profileId
+        - eventAbbr
+        - timestamp
+    CheckInTalk:
+      type: object
+      properties:
+        profileId:
+          type: string
+        talkId:
+          type: string
+        timestamp:
+          type: number
+      required:
+        - eventAbbr
+        - profileId
+        - talkId
+        - timestamp

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -1065,7 +1065,7 @@ components:
       required:
         - profileId
         - eventAbbr
-        - timestamp
+        - check_in_timestamp
     CheckInTalk:
       type: object
       properties:
@@ -1079,4 +1079,4 @@ components:
         - eventAbbr
         - profileId
         - talkId
-        - timestamp
+        - check_in_timestamp

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,7 @@ end
 def claim
   [JSON.parse('{
     "https://cloudnativedays.jp/roles": [
+      "CNDT2020-Admin",
       "CNDT2022-Admin",
       "CNSEC2022-Admin"
     ],

--- a/spec/requests/api/v1/check_in_conferences_create_spec.rb
+++ b/spec/requests/api/v1/check_in_conferences_create_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::CheckInConferencesController, type: :request do
 
     context 'create without JWT token' do
       it 'return 401' do
-        post('/api/v1/check_in_conferences', params: { eventAbbr: 'cndt2020', profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        post('/api/v1/check_in_conferences', params: { eventAbbr: 'cndt2020', profileId: alice.id, check_in_timestamp: 1_715_483_605 }, as: :json)
         expect(response).to(have_http_status(:unauthorized))
       end
     end
@@ -19,7 +19,7 @@ describe Api::V1::CheckInConferencesController, type: :request do
       end
 
       it 'return ok' do
-        post('/api/v1/check_in_conferences', params: { eventAbbr: 'cndt2020', profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        post('/api/v1/check_in_conferences', params: { eventAbbr: 'cndt2020', profileId: alice.id, check_in_timestamp: 1_715_483_605 }, as: :json)
         expect(response).to(have_http_status(:created))
       end
     end

--- a/spec/requests/api/v1/check_in_conferences_create_spec.rb
+++ b/spec/requests/api/v1/check_in_conferences_create_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Api::V1::CheckInConferencesController, type: :request do
+  describe 'POST /api/v1/check_in_conferences' do
+    let!(:cndt2020) { create(:cndt2020) }
+    let!(:alice) { create(:alice, :on_cndt2020, conference: cndt2020) }
+    let!(:talk) { create(:talk1) }
+
+    context 'create without JWT token' do
+      it 'return 401' do
+        post('/api/v1/check_in_conferences', params: { eventAbbr: 'cndt2020', profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        expect(response).to(have_http_status(:unauthorized))
+      end
+    end
+
+    context 'create' do
+      before do
+        allow(JsonWebToken).to(receive(:verify).and_return(claim))
+      end
+
+      it 'return ok' do
+        post('/api/v1/check_in_conferences', params: { eventAbbr: 'cndt2020', profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        expect(response).to(have_http_status(:created))
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/check_in_talks_create_spec.rb
+++ b/spec/requests/api/v1/check_in_talks_create_spec.rb
@@ -8,7 +8,7 @@ describe Api::V1::CheckInTalksController, type: :request do
 
     context 'create without JWT token' do
       it 'return 401' do
-        post('/api/v1/check_in_talks', params: { eventAbbr: 'cndt2020', talkId: talk.id, profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        post('/api/v1/check_in_talks', params: { eventAbbr: 'cndt2020', talkId: talk.id, profileId: alice.id, check_in_timestamp: 1_715_483_605 }, as: :json)
         expect(response).to(have_http_status(:unauthorized))
       end
     end
@@ -19,7 +19,7 @@ describe Api::V1::CheckInTalksController, type: :request do
       end
 
       it 'return ok' do
-        post('/api/v1/check_in_talks', params: { eventAbbr: 'cndt2020', talkId: talk.id, profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        post('/api/v1/check_in_talks', params: { eventAbbr: 'cndt2020', talkId: talk.id, profileId: alice.id, check_in_timestamp: 1_715_483_605 }, as: :json)
         expect(response).to(have_http_status(:created))
       end
     end

--- a/spec/requests/api/v1/check_in_talks_create_spec.rb
+++ b/spec/requests/api/v1/check_in_talks_create_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Api::V1::CheckInTalksController, type: :request do
+  describe 'POST /api/v1/check_in_talks' do
+    let!(:cndt2020) { create(:cndt2020) }
+    let!(:alice) { create(:alice, :on_cndt2020, conference: cndt2020) }
+    let!(:talk) { create(:talk1) }
+
+    context 'create without JWT token' do
+      it 'return 401' do
+        post('/api/v1/check_in_talks', params: { eventAbbr: 'cndt2020', talkId: talk.id, profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        expect(response).to(have_http_status(:unauthorized))
+      end
+    end
+
+    context 'create' do
+      before do
+        allow(JsonWebToken).to(receive(:verify).and_return(claim))
+      end
+
+      it 'return ok' do
+        post('/api/v1/check_in_talks', params: { eventAbbr: 'cndt2020', talkId: talk.id, profileId: alice.id, timestamp: 1_715_483_605 }, as: :json)
+        expect(response).to(have_http_status(:created))
+      end
+    end
+  end
+end


### PR DESCRIPTION
- イベントとセッションそれぞれにチェックイン用のエンドポイントを追加しました
- UI側の実装を楽にするため追記型にして、同じ参加者でも何回でもチェックインできるようにしています。