### PR TITLE
Avoid overriding `set_speaker` method in SpeakerDashboardsController

### DIFF
--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -3,6 +3,7 @@ class SpeakerDashboardsController < ApplicationController
   before_action :set_speaker
 
   def show
+    @talks = @speaker ? @speaker.talks.not_sponsor : []
     @speaker_announcements = @conference.speaker_announcements.find_by_speaker(@speaker.id) unless @speaker.nil?
   end
 
@@ -16,13 +17,5 @@ class SpeakerDashboardsController < ApplicationController
 
   def logged_in_using_omniauth?
     current_user
-  end
-
-  def set_speaker
-    @conference ||= Conference.find_by(abbr: params[:event])
-    if current_user
-      @speaker = Speaker.find_by(conference_id: @conference.id, email: current_user[:info][:email])
-      @talks = @speaker ? @speaker.talks.not_sponsor : []
-    end
   end
 end


### PR DESCRIPTION
ApplicationController has `set_speaker` method.

https://github.com/cloudnativedaysjp/dreamkast/blob/6c4b9071bf895dea2f8006184382ed39e1ef885a/app/controllers/application_controller.rb#L140-L144

SpeakerDashboardsController's method is

https://github.com/cloudnativedaysjp/dreamkast/blob/6c4b9071bf895dea2f8006184382ed39e1ef885a/app/controllers/speaker_dashboards_controller.rb#L21-L27

Only differences are related to setting @talks, so setting of `@talks` into the action and remove overriding.

NOTE: `set_conference` implementation is here.

https://github.com/cloudnativedaysjp/dreamkast/blob/6c4b9071bf895dea2f8006184382ed39e1ef885a/app/controllers/application_controller.rb#L128-L130 https://github.com/cloudnativedaysjp/dreamkast/blob/6c4b9071bf895dea2f8006184382ed39e1ef885a/app/controllers/application_controller.rb#L39-L41