### PR TITLE
Refactor: Use `current_conference` instead of `set_conference` and `conference` (1/3)

### DIFF
--- a/app/controllers/api/v1/chat_messages_controller.rb
+++ b/app/controllers/api/v1/chat_messages_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ChatMessagesController < ApplicationController
   include SecuredPublicApi
-  before_action :set_profile
+  before_action :set_conference, :set_profile
 
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ProfilesController < ApplicationController
   include SecuredPublicApi
-  before_action :set_profile
+  before_action :set_conference, :set_profile
 
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -138,7 +138,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_speaker
-    set_conference
     if current_user
       @speaker = Speaker.find_by(email: current_user[:info][:email], conference_id: @conference.id)
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,7 +130,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_profile
-    set_conference
     @profile = if current_user && (@conference.opened? || @conference.registered?)
                  Profile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
                else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,16 +130,18 @@ class ApplicationController < ActionController::Base
   end
 
   def set_profile
-    @profile = if current_user && (set_conference.opened? || set_conference.registered?)
-                 Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
+    set_conference
+    @profile = if current_user && (@conference.opened? || @conference.registered?)
+                 Profile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
                else
                  GuestProfile.new
                end
   end
 
   def set_speaker
+    set_conference
     if current_user
-      @speaker = Speaker.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
+      @speaker = Speaker.find_by(email: current_user[:info][:email], conference_id: @conference.id)
     end
   end
 

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -3,7 +3,7 @@ module Secured
   WEBSITE_BASE_URL = 'https://cloudnativedays.jp'.freeze
 
   included do
-    before_action :redirect_to_website
+    before_action :set_conference, :redirect_to_website
     before_action :to_preparance, :redirect_to_registration, if: :should_redirect?
     before_action :logged_in_using_omniauth?, :to_preparance, if: :use_secured_before_action?
     helper_method :admin?, :speaker?, :beta_user?
@@ -14,7 +14,6 @@ module Secured
   end
 
   def redirect_to_website
-    set_conference
     if @conference.migrated?
       case [controller_name, action_name]
       in ['talks', 'show']
@@ -32,7 +31,6 @@ module Secured
   end
 
   def should_redirect?
-    set_conference
     new_user? && !@conference.archived?
   end
 
@@ -45,7 +43,6 @@ module Secured
   end
 
   def new_user?
-    set_conference
     logged_in? && !Profile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
   end
 

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -14,7 +14,8 @@ module Secured
   end
 
   def redirect_to_website
-    if set_conference.migrated?
+    set_conference
+    if @conference.migrated?
       case [controller_name, action_name]
       in ['talks', 'show']
         redirect_to(URI.join(WEBSITE_BASE_URL, request.fullpath).to_s, allow_other_host: true)
@@ -31,7 +32,8 @@ module Secured
   end
 
   def should_redirect?
-    new_user? && !set_conference.archived?
+    set_conference
+    new_user? && !@conference.archived?
   end
 
   def redirect_to_registration
@@ -43,7 +45,8 @@ module Secured
   end
 
   def new_user?
-    logged_in? && !Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
+    set_conference
+    logged_in? && !Profile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
   end
 
   def admin?

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -27,7 +27,7 @@ module Secured
   def to_preparance
     # ログイン状態
     # かつカンファレンスが一般参加応募不可状態
-    redirect_to(preparation_url) if conference.attendee_entry_disabled? && logged_in?
+    redirect_to(preparation_url) if @conference.attendee_entry_disabled? && logged_in?
   end
 
   def should_redirect?
@@ -47,15 +47,15 @@ module Secured
   end
 
   def admin?
-    conference && current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+    @conference && current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Admin")
   end
 
   def speaker?
-    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Speaker")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Speaker")
   end
 
   def beta_user?
-    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Beta")
   end
 
   def conference

--- a/app/controllers/concerns/secured.rb
+++ b/app/controllers/concerns/secured.rb
@@ -59,6 +59,7 @@ module Secured
   end
 
   def conference
+    ActiveSupport::Deprecation.warn('conference is deprecated. Please use @conference instead.')
     @conference ||= Conference.find_by(abbr: event_name)
   end
 

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -31,7 +31,8 @@ module SecuredAdmin
   end
 
   def get_or_create_admin_profile
-    @admin_profile ||= AdminProfile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
+    set_conference
+    @admin_profile ||= AdminProfile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
 
     if admin? && @admin_profile.blank?
       @admin_profile = AdminProfile.new(conference_id: @conference.id)

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -20,6 +20,7 @@ module SecuredAdmin
   end
 
   def conference
+    ActiveSupport::Deprecation.warn('conference is deprecated. Please use @conference instead.')
     @conference ||= Conference.find_by(abbr: event_name)
   end
 

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -2,7 +2,8 @@ module SecuredAdmin
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_conference, :logged_in_using_omniauth?, :is_admin?, :get_or_create_admin_profile, if: :use_secured_before_action?
+    before_action :set_conference
+    before_action :logged_in_using_omniauth?, :is_admin?, :get_or_create_admin_profile, if: :use_secured_before_action?
     helper_method :admin?, :speaker?
   end
 
@@ -31,7 +32,6 @@ module SecuredAdmin
   end
 
   def get_or_create_admin_profile
-    set_conference
     @admin_profile ||= AdminProfile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
 
     if admin? && @admin_profile.blank?

--- a/app/controllers/concerns/secured_admin.rb
+++ b/app/controllers/concerns/secured_admin.rb
@@ -16,7 +16,7 @@ module SecuredAdmin
   end
 
   def admin?
-    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Admin")
   end
 
   def conference

--- a/app/controllers/concerns/secured_beta.rb
+++ b/app/controllers/concerns/secured_beta.rb
@@ -6,7 +6,7 @@ module SecuredBeta
   end
 
   def beta_user?
-    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Beta")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Beta")
   end
 
   def is_beta_user?
@@ -14,6 +14,6 @@ module SecuredBeta
   end
 
   def admin?
-    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{conference.abbr.upcase}-Admin")
+    current_user[:extra][:raw_info]['https://cloudnativedays.jp/roles'].include?("#{@conference.abbr.upcase}-Admin")
   end
 end

--- a/app/controllers/concerns/secured_speaker.rb
+++ b/app/controllers/concerns/secured_speaker.rb
@@ -2,7 +2,7 @@ module SecuredSpeaker
   extend ActiveSupport::Concern
 
   included do
-    before_action :logged_in_using_omniauth?
+    before_action :set_conference, :logged_in_using_omniauth?
     helper_method :admin?, :speaker?
   end
 

--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -40,7 +40,8 @@ class EventController < ApplicationController
 
   # CFP募集期間は登壇者登録の有無でリダイレクトする
   def should_redirect?
-    if set_conference.speaker_entry_enabled?
+    set_conference
+    if @conference.speaker_entry_enabled?
       @speaker.present?
     else
       false

--- a/app/controllers/event_controller.rb
+++ b/app/controllers/event_controller.rb
@@ -40,7 +40,6 @@ class EventController < ApplicationController
 
   # CFP募集期間は登壇者登録の有無でリダイレクトする
   def should_redirect?
-    set_conference
     if @conference.speaker_entry_enabled?
       @speaker.present?
     else

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,6 @@
 class ProfilesController < ApplicationController
   include Secured
 
-  before_action :set_conference
   before_action :set_current_profile, only: [:edit, :update, :destroy, :checkin]
   skip_before_action :logged_in_using_omniauth?, only: [:new]
   before_action :find_profile, only: [:destroy_id, :set_role]
@@ -120,7 +119,6 @@ class ProfilesController < ApplicationController
   end
 
   def set_current_profile
-    set_conference
     @profile = Profile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -120,7 +120,8 @@ class ProfilesController < ApplicationController
   end
 
   def set_current_profile
-    @profile = Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
+    set_conference
+    @profile = Profile.find_by(email: current_user[:info][:email], conference_id: @conference.id)
   end
 
   def profile_params

--- a/app/controllers/public_profiles_controller.rb
+++ b/app/controllers/public_profiles_controller.rb
@@ -1,6 +1,6 @@
 class PublicProfilesController < ApplicationController
   include Secured
-  before_action :set_conference, :set_profile
+  before_action :set_profile
 
   def new
     @public_profile = PublicProfile.new(profile_id: @profile.id)

--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -3,6 +3,7 @@ class SpeakerDashboardsController < ApplicationController
   before_action :set_speaker
 
   def show
+    @talks = @speaker ? @speaker.talks.not_sponsor : []
     @speaker_announcements = @conference.speaker_announcements.find_by_speaker(@speaker.id) unless @speaker.nil?
   end
 
@@ -16,13 +17,5 @@ class SpeakerDashboardsController < ApplicationController
 
   def logged_in_using_omniauth?
     current_user
-  end
-
-  def set_speaker
-    @conference ||= Conference.find_by(abbr: params[:event])
-    if current_user
-      @speaker = Speaker.find_by(conference_id: @conference.id, email: current_user[:info][:email])
-      @talks = @speaker ? @speaker.talks.not_sponsor : []
-    end
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -118,12 +118,14 @@ class TalksController < ApplicationController
   # CFP募集期間中は登壇者登録だけでも表示する
   # CFP期間後はProfileの登録が必要
   def new_user?
-    (speaker? && set_conference.speaker_entry_enabled?) || super
+    set_conference
+    (speaker? && @conference.speaker_entry_enabled?) || super
   end
 
   def speaker?
     return false if current_user.nil?
-    Speaker.find_by(email: current_user[:info][:email], conference_id: set_conference.id).present?
+    set_conference
+    Speaker.find_by(email: current_user[:info][:email], conference_id: @conference.id).present?
   end
 
   def talk_params
@@ -133,7 +135,8 @@ class TalksController < ApplicationController
   # CFP募集期間中は登壇者登録だけでも表示する
   # CFP期間後はProfileの登録が必要
   def should_redirect?
-    super && (!speaker? || !set_conference.speaker_entry_enabled?)
+    set_conference
+    super && (!speaker? || !@conference.speaker_entry_enabled?)
   end
 
   def talk_start_to_end(talk)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -118,13 +118,11 @@ class TalksController < ApplicationController
   # CFP募集期間中は登壇者登録だけでも表示する
   # CFP期間後はProfileの登録が必要
   def new_user?
-    set_conference
     (speaker? && @conference.speaker_entry_enabled?) || super
   end
 
   def speaker?
     return false if current_user.nil?
-    set_conference
     Speaker.find_by(email: current_user[:info][:email], conference_id: @conference.id).present?
   end
 
@@ -135,7 +133,6 @@ class TalksController < ApplicationController
   # CFP募集期間中は登壇者登録だけでも表示する
   # CFP期間後はProfileの登録が必要
   def should_redirect?
-    set_conference
     super && (!speaker? || !@conference.speaker_entry_enabled?)
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -14,7 +14,7 @@ class TalksController < ApplicationController
   # - Conferenceのstatusが `migrated` の場合：websiteにリダイレクトする
   def show
     @conference = Conference.find_by(abbr: event_name)
-    @talk = Talk.find_by(id: params[:id], conference_id: conference.id)
+    @talk = Talk.find_by(id: params[:id], conference_id: @conference.id)
 
     unless @conference.cfp_result_visible
       raise(ActiveRecord::RecordNotFound)

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   include Secured
-  before_action :set_conference, :set_profile, :set_speaker
+  before_action :set_profile, :set_speaker
 
   def logged_in_using_omniauth?
     current_user


### PR DESCRIPTION
1. Unify Access to `@conference`
   - Avoid using return value of `set_conference`:
     - Call `set_conference` and use `@conference` ivar; instead of using the return value from `set_conference`.
   - Ensure `set_conference` is always called via `before_action`:
     - Ensure that `@conference` is always set before any action that using `@conference` is executed.
   - Deprecate `conference` Method:
     - Remove usage of the redundant `conference` method. this can replaced with using `@conference` ivar.set by `set_conference`.
2. Transition from `@conference` to `current_conference` method
   - Implement `current_conference`:
     - Introduce a new method `current_conference` that will centralize the access to the conference data.
   - Replace all `@conference` with `current_conference`
3. Cleanup
   - Remove `conference` method:
     - After confirming its redundancy, the `conference` method will be removed from the code base.
   - Remove unnecessary `before_action`:
     - Since `current_conference` reliably setting conference data, `set_conference` can be removed from `before_action` hooks.

### Motivation

The application currently has four different ways to access the conference data, leading to confusion and inconsistent usage:

- `set_conference` method:
  - Defined in `ApplicationController`, sets and returns `@conference`.
  - Called inconsistently as a `before_action` or not, and its return value is used.
- `conference` method:
  - Exists in both `Secured` and `SecuredAdmin` concern modules with the same implementation as `set_conference`.
  - This is not used in `before_action` and is called when its return value is needed.
- `@conference` ivar:
  - Set by either `set_conference` or `conference` method.
  - Its usage is unreliable as `set_conference` isn't always called.
- Direct calls in actions:
  - Uses `Conference.find_by(abbr: params[...])` in actions where neither `before_action` nor instance variable setups are in place.

This refactor aims to unify and simplify how the conference data is accessed within the application.

After completing these changes, we can use `current_conference` to access the conference data.

The chosen method name `current_conference` comes from the commonly used `current_user` and improves readability compared to `conference` and avoids confusion with local variables.
