### PR TITLE
QRコードの表示画面を追加

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,7 +2,7 @@ class ProfilesController < ApplicationController
   include Secured
 
   before_action :set_conference
-  before_action :set_current_profile, only: [:edit, :update, :destroy, :checkin, :entry_sheet]
+  before_action :set_current_profile, only: [:edit, :update, :destroy, :checkin, :entry_sheet, :view_qr]
   skip_before_action :logged_in_using_omniauth?, only: [:new]
   before_action :find_profile, only: [:destroy_id, :set_role]
   before_action :is_admin?, :find_profile, only: [:destroy_id, :set_role]
@@ -111,6 +111,9 @@ class ProfilesController < ApplicationController
   end
 
   def entry_sheet
+  end
+
+  def view_qr
   end
 
   helper_method :profile_url

--- a/app/javascript/stylesheets/_entry_sheet.scss
+++ b/app/javascript/stylesheets/_entry_sheet.scss
@@ -125,3 +125,25 @@
     display: none;
   }
 }
+
+// QRコード表示ページのスタイル
+.qr_view {
+  // 600px以下の場合（スマートフォンの想定）
+  @media only screen and (max-width: 700px) {
+    img { width: 50%; }
+    h5 { margin-top: 20%; }
+  }
+
+  // 600px以上の場合（PCの想定）
+  @media only screen and (min-width: 700px) {
+    img { height: 40vh; }
+  }
+
+  // 表示スタイル
+  display:flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  h5 { text-align: center; }
+}

--- a/app/views/layouts/partial/_login_button.erb
+++ b/app/views/layouts/partial/_login_button.erb
@@ -17,9 +17,17 @@
         <% if @profile.participation.present? %>
           <%= link_to '参加方法を変更する', edit_profile_path(id: @profile.id, anchor: "participation"), class: "dropdown-item"  %>
         <% end %>
+
+        <!-- 現地参加の場合のみ有効 -->
         <% if @profile.attend_offline? %>
           <div class="dropdown-divider"></div>
           <%= link_to '参加表を印刷する', profiles_entry_sheet_path, class: "dropdown-item"  %>
+
+          <!-- 開催中のみQRコードビューを有効にする -->
+          <% if @conference.present? && @conference.opened? %>
+            <div class="dropdown-divider"></div>
+            <%= link_to '受付用QRコードを表示する', profiles_view_qr_path, class: "dropdown-item"  %>
+          <% end %>
         <% end %>
       <% end %>
       <% if display_speaker_dashboard_link? %>

--- a/app/views/profiles/view_qr.html.erb
+++ b/app/views/profiles/view_qr.html.erb
@@ -1,0 +1,5 @@
+<div class="qr_view">
+  <!-- QRコード表示 -->
+  <h5>受付用QRコード</h5>
+  <img src=<%= "data:image/png;base64,#{@profile.qrcode_image}" %> />
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
     get 'profiles/edit', to: 'profiles#edit'
     get 'profiles/checkin', to: 'profiles#checkin'
     get 'profiles/entry_sheet' => 'profiles#entry_sheet'
+    get 'profiles/view_qr' => 'profiles#view_qr'
     resources :public_profiles
 
 


### PR DESCRIPTION
ナビバーに受付用QRコードを表示する遷移を追加しました。

スマートフォン表示を前提にしています。
QRコードの表示サイズはスマートフォン表示時で横幅の50％にしていいますがこちらは随時調整可能です。

PCで開くことはないと思いますが、一応最低限表示できるようにCSSを分けています。
![image](https://github.com/cloudnativedaysjp/dreamkast/assets/40717789/40a66ce0-8c15-4bc2-af8e-2989af59595f)
