### PR TITLE
Sentry への接続 transaction 自体は Sentry に送らない

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,4 +10,11 @@ Sentry.init do |config|
   config.profiles_sample_rate = 0.0001
   # set the instrumenter to use OpenTelemetry instead of Sentry
   config.instrumenter = :otel
+
+  config.before_send_transaction = lambda do |event, _hint|
+    # Sentry への接続 transaction 自体は Sentry に送らない
+    return nil if event.transaction == 'connect'
+
+    event
+  end
 end


### PR DESCRIPTION
## 現象 : 

- Sentry に `connect` という transaction が大量に送られてきて Sentry のディスクがいっぱいになる事象がたびたび起こっている
  - 中身は、dreamkast から Sentry への HTTP リクエスト。200 OK で返っている
    - ```json
      {
        // ...
        "breadcrumbs": {
          "values": [
            {
              "category": "net.http",
              "data": {
                "method": "PUT",
                "status": 200,
                "url": "[Filtered]"
              },
              "level": "info",
              "message": "",
              "timestamp": 1717554939.0,
              "type": "info"
            },
            // ...
            {
              "category": "net.http",
              "data": {
                "method": "GET",
                "status": 200,
                "url": "[Filtered]"
              },
              "level": "info",
              "message": "",
              "timestamp": 1717554939.0,
              "type": "info"
            }
          ]
        },
        // ...
        "title": "connect",
        "transaction": "connect",
        // ...
      }
      ```
  - こういう event が × 10 万件くらい一気に送られている

## 何が起こっているのか : 

おそらく…

- dreamkast から Sentry に event や tansaction を送っている。この送る動作自体の transaction が生成されている
  - 一連の `Net:HTTP.connect` 呼び出しが 1 つの transaction に溜め込まれている
- `traces_sample_rate = 0.0001` にたまたまこの transaction が抽選されると、大きな transaction が一気に送られる

## この差分は何をするものか : 

- `"transaction": "connect",` である transaction は Sentry に送らない
  - https://docs.sentry.io/platforms/ruby/configuration/options/#:~:text=end-,before_send_transaction,-Provide%20a%20lambda