### PR TITLE
fix: セッション登録フォームでセッションを削除した後に登録・更新できない問題を修正

### DIFF
--- a/app/javascript/packs/speaker_form.js
+++ b/app/javascript/packs/speaker_form.js
@@ -71,9 +71,13 @@ const buttonListener = (e) => {
     if (confirm("このセッションを削除しますか？")) {
         e.target.parentElement.querySelector('.destroy_flag_field').value = 1;
         e.target.closest('.talk-field').hidden = true;
-        e.target.parentElement.querySelector('input').removeAttribute('required max min maxlength pattern');
-        e.target.parentElement.querySelector('textarea').removeAttribute('required max min maxlength pattern');
-        e.target.parentElement.querySelector('select').removeAttribute('required max min maxlength pattern');
+        ['input', 'textarea', 'select'].forEach((selector) => {
+            ['required', 'max', 'min', 'maxlength', 'pattern'].forEach((attr) => {
+                e.target.parentElement.querySelectorAll(selector).forEach((elm) => {
+                    elm.removeAttribute(attr);
+                })
+            })
+        })
         if (fieldLength() < 3) {
             document.getElementsByClassName('add-talk')[0].hidden = false;
         }

--- a/app/javascript/packs/speaker_form.js
+++ b/app/javascript/packs/speaker_form.js
@@ -72,8 +72,8 @@ const buttonListener = (e) => {
         e.target.parentElement.querySelector('.destroy_flag_field').value = 1;
         e.target.closest('.talk-field').hidden = true;
         ['input', 'textarea', 'select'].forEach((selector) => {
-            ['required', 'max', 'min', 'maxlength', 'pattern'].forEach((attr) => {
-                e.target.parentElement.querySelectorAll(selector).forEach((elm) => {
+            e.target.parentElement.querySelectorAll(selector).forEach((elm) => {
+                ['required', 'max', 'min', 'maxlength', 'pattern'].forEach((attr) => {
                     elm.removeAttribute(attr);
                 })
             })


### PR DESCRIPTION
`Delete talk` ボタンクリック時にinput要素などからrequiredを消す処理がうまく動いていなかった