### PR TITLE
Talk一覧をPrometheusから取得する

### DIFF
--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -33,8 +33,13 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
         labels: [:conference_id, :talk_difficulty_name]
       ),
       Prometheus::Client::Gauge.new(
+        :dreamkast_select_talks,
+        docstring: 'Select dreamkast talks',
+        labels: [:talk_id, :conference_id, :title, :talk_difficulty_name]
+      ),
+      Prometheus::Client::Gauge.new(
         :dreamkast_select_proposal_items,
-        docstring: 'select dreamkast proposal items',
+        docstring: 'Select dreamkast proposal items',
         labels: [:talk_id, :conference_id, :proposal_items_label, :proposal_items_params]
       )
     ]
@@ -102,6 +107,15 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
       metrics.set(
         talk_difficulties_count.count,
         labels: { conference_id: talk_difficulties_count.conference_id, talk_difficulty_name: talk_difficulties_count.name }
+      )
+    end
+  end
+
+  def dreamkast_select_talks(metrics)
+    Talk.preload(:talk_difficulty).all.each do |talk|
+      metrics.set(
+        talk.id,
+        labels: { talk_id: talk.id, conference_id: talk.conference_id, title: talk.title, talk_difficulty_name: talk.talk_difficulty&.name }
       )
     end
   end


### PR DESCRIPTION
オブザーバビリティチームでtelegrafを廃止を進めています。その一環で、以前に https://github.com/cloudnativedaysjp/dreamkast/pull/2064 が https://github.com/cloudnativedaysjp/dreamkast-infra/blob/b5d51cfcf912e82fb583fd5d1dd8fcee15c7e289/manifests/infra/telegraf/base/configmap.yaml#L99-L102 を置き換えたように、このpull requestで https://github.com/cloudnativedaysjp/dreamkast-infra/blob/b5d51cfcf912e82fb583fd5d1dd8fcee15c7e289/manifests/infra/telegraf/base/configmap.yaml#L95-L98 を置き換えます。

計装されるメトリック (`curl http://localhost:3000/metrics | ag dreamkast_select_talks`) : 

```
TYPE dreamkast_select_talks gauge
# HELP dreamkast_select_talks Select dreamkast talks
dreamkast_select_talks{talk_id="1",conference_id="1",title="云々",talk_difficulty_name="初級者"} 1.0
…
dreamkast_select_talks{talk_id="803",conference_id="7",title="CM1",talk_difficulty_name=""} 803.0
…
```

実行される SQL

```
Talk Load (1.1ms)  SELECT `talks`.* FROM `talks`
↳ app/middlewares/dreamkast_exporter.rb:115:in `dreamkast_select_talks'
TalkDifficulty Load (0.4ms)  SELECT `talk_difficulties`.* FROM `talk_difficulties` WHERE `talk_difficulties`.`id` IN (1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 41, 43, 42, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68)
↳ app/middlewares/dreamkast_exporter.rb:115:in `dreamkast_select_talks'
```