### PR TITLE
docker build --check の簡単なものを直す

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
 # syntax = docker/dockerfile:1.9
 
-FROM node:18.20.4-slim as node
+FROM node:18.20.4-slim AS node
 WORKDIR /app
 COPY --link package.json yarn.lock ./
 RUN --mount=type=cache,uid=1000,target=/app/.cache/node_modules \
     yarn install --modules-folder .cache/node_modules && \
     cp -ar .cache/node_modules node_modules
 
-FROM public.ecr.aws/docker/library/ruby:3.3.4 as fetch-lib
+FROM public.ecr.aws/docker/library/ruby:3.3.4 AS fetch-lib
 WORKDIR /app
 COPY --link Gemfile* ./
 RUN apt-get update && apt-get install -y shared-mime-info libmariadb3
 RUN bundle install
 
-FROM public.ecr.aws/docker/library/ruby:3.3.4 as asset-compile
-ENV YARN_VERSION 1.22.19
+FROM public.ecr.aws/docker/library/ruby:3.3.4 AS asset-compile
+ENV YARN_VERSION=1.22.19
 COPY --link --from=node /opt/yarn-v$YARN_VERSION /opt/yarn
 COPY --link --from=node /usr/local/bin/node /usr/local/bin/
 RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
@@ -37,7 +37,7 @@ RUN --mount=type=cache,uid=1000,target=/app/tmp/cache SECRET_KEY_BASE=hoge RAILS
 
 FROM public.ecr.aws/docker/library/ruby:3.3.4-slim
 
-ENV YARN_VERSION 1.22.19
+ENV YARN_VERSION=1.22.19
 COPY --link --from=node /opt/yarn-v$YARN_VERSION /opt/yarn
 COPY --link --from=node /usr/local/bin/node /usr/local/bin/
 RUN ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \


### PR DESCRIPTION
pull request を作ると以下がこんな https://github.com/cloudnativedaysjp/dreamkast/pull/2396/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557 な感じでコメントされるので、簡単に直せるものを直した。

```
 6 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 17)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "AWS_ACCESS_KEY_ID") (line 34)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 40)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 10)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 16)
 ```

確認方法 : 
`docker --debug buildx build -t dreamkast-app:latest --check .` で SecretsUsedInArgOrEnv 以外が出ない。


[SecretsUsedInArgOrEnv | Docker Docs](https://docs.docker.com/reference/build-checks/secrets-used-in-arg-or-env/)で言われているAWS_ACCESS_KEY_IDは`app/config/initializers/shrine.rb` に要り用で、今の私には直せません…。