### PR TITLE
GET /metrics の n+1 を解消

### DIFF
--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -85,18 +85,20 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
   end
 
   def dreamkast_registrants_count(metrics)
+    profile_counts = Profile.group(:conference_id).count
     Conference.all.each do |conf|
       metrics.set(
-        conf.profiles.count,
+        profile_counts[conf.id] || 0,
         labels: { conference_id: conf.id }
       )
     end
   end
 
   def dreamkast_talks_count(metrics)
+    talk_counts = Talk.group(:conference_id).count
     Conference.all.each do |talks_count|
       metrics.set(
-        talks_count.talks.count,
+        talk_counts[talks_count.id] || 0,
         labels: { conference_id: talks_count.id }
       )
     end


### PR DESCRIPTION
GET /metrics で、`SELECT COUNT(*) FROM profiles WHERE profiles.conference_id = 1` と `SELECT COUNT(*) FROM talks WHERE talks.conference_id = 1` が Conference ごとに実行されている。

この差分で、以下のように Profile Count と Talk Count とにまとめられる。

```
Profile Count (0.9ms)  SELECT COUNT(*) AS `count_all`, `profiles`.`conference_id` AS `profiles_conference_id` FROM `profiles` GROUP BY `profiles`.`conference_id`
↳ app/middlewares/dreamkast_exporter.rb:88:in `dreamkast_registrants_count'
Conference Load (0.7ms)  SELECT `conferences`.* FROM `conferences`
↳ app/middlewares/dreamkast_exporter.rb:89:in `dreamkast_registrants_count'

Talk Count (0.8ms)  SELECT COUNT(*) AS `count_all`, `talks`.`conference_id` AS `talks_conference_id` FROM `talks` GROUP BY `talks`.`conference_id`
↳ app/middlewares/dreamkast_exporter.rb:98:in `dreamkast_talks_count'
CACHE Conference Load (0.0ms)  SELECT `conferences`.* FROM `conferences`
↳ app/middlewares/dreamkast_exporter.rb:99:in `dreamkast_talks_count'
```

確認方法 : 
`curl http://localhost:3000/metrics` で app の log に吐かれる SQL を眺める。
差分をあてる前後で `curl http://localhost:3000/metrics` の結果に diff が出ない事も確認した。