### PR TITLE
chore: use json by website

### DIFF
--- a/lib/tasks/render_json_for_website.rake
+++ b/lib/tasks/render_json_for_website.rake
@@ -58,15 +58,8 @@ namespace :util do
       json_obj = JSON.parse(json_builder)
       a = JSON.pretty_generate(json_obj)
 
-      template = <<~EOS
-        import type { Talk } from "../types/talk";
-
-        export const <%= abbr.upcase %>Talks: Talk[] = <%= a %>
-      EOS
-
-      erb = ERB.new(template)
-      File.open("#{abbr}_talks.ts", 'w') do |f|
-        f.write(erb.result(binding))
+      File.open("#{abbr}_talks.json", 'w') do |f|
+        f.write(a)
       end
 
       json_builder = Jbuilder.encode do |json|
@@ -85,15 +78,8 @@ namespace :util do
       json_obj = JSON.parse(json_builder)
       a = JSON.pretty_generate(json_obj)
 
-      template = <<~EOS
-        import type { Speaker } from "../types/speaker";
-
-        export const <%= abbr.upcase %>Speakers: Speaker[] = <%= a %>
-      EOS
-
-      erb = ERB.new(template)
-      File.open("#{abbr}_speakers.ts", 'w') do |f|
-        f.write(erb.result(binding))
+      File.open("#{abbr}_speakers.json", 'w') do |f|
+        f.write(a)
       end
     end
   end


### PR DESCRIPTION
Currently, we use json for data of talks and speakers.


```
#!/usr/bin/env bash

ABBR=cnds2024
export AWS_REGION=ap-northeast-1

TASK_ARN=$(aws ecs list-tasks --output text --cluster dreamkast-prod --service-name dreamkast --query "taskArns[0]")

aws ecs execute-command --interactive --cluster dreamkast-prod --task $TASK_ARN --container dreamkast --command "bundle exec rake util:render_json_for_website[$ABBR]"
aws ecs execute-command --interactive --cluster dreamkast-prod --task $TASK_ARN --container dreamkast --command "cat ${ABBR}_speakers.json" \
  | gsed -z 's/\nThe Session Manager plugin was installed successfully\. Use the AWS CLI to start a session\.\n\n\nStarting session with SessionId: .*\n\[/\[/g' \
  | gsed 's/^Exiting session with sessionId:.*$//g' \
  > ./src/data/speakers/$ABBR.json

aws ecs execute-command --interactive --cluster dreamkast-prod --task $TASK_ARN --container dreamkast --command "cat ${ABBR}_talks.json" \
  | gsed -z 's/\nThe Session Manager plugin was installed successfully\. Use the AWS CLI to start a session\.\n\n\nStarting session with SessionId: .*\n\[/\[/g' \
  | gsed 's/^Exiting session with sessionId:.*$//g' \
  > ./src/data/talks/$ABBR.json
```