### PR TITLE
feat: manage stamp rally check points

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,3 +123,5 @@ gem 'faraday-retry'
 
 # QRcode rendering
 gem "rqrcode", "~> 2.0"
+
+gem 'ulid'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,6 +659,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    ulid (1.4.0)
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     uppy-s3_multipart (1.2.0)
@@ -745,6 +746,7 @@ DEPENDENCIES
   steep
   turbo-rails (= 2.0.5)
   tzinfo-data
+  ulid
   uppy-s3_multipart (~> 1.0)
   web-console (>= 3.3.0)
 

--- a/app/controllers/admin/stamp_rally_check_points_controller.rb
+++ b/app/controllers/admin/stamp_rally_check_points_controller.rb
@@ -1,0 +1,60 @@
+class Admin::StampRallyCheckPointsController < ApplicationController
+  include SecuredAdmin
+
+  def index
+    @stamp_rally_check_points = conference.stamp_rally_check_points
+  end
+
+  def new
+    @stamp_rally_check_point = StampRallyCheckPoint.new
+    @sponsors = conference.sponsors
+    @type_options = StampRallyCheckPoint::Type::KLASSES.map(&:name)
+  end
+
+  def create
+    @stamp_rally_check_point = StampRallyCheckPoint.new(stamp_rally_check_point_params.merge(conference:))
+    @sponsors = conference.sponsors
+    @type_options = StampRallyCheckPoint::Type::KLASSES.map(&:name)
+    if @stamp_rally_check_point.save
+      flash.now[:notice] = "スタンプラリーチェックポイント #{@stamp_rally_check_point.id} を登録しました"
+    else
+      render(:new, status: :unprocessable_entity)
+    end
+  end
+
+  def edit
+    @stamp_rally_check_point = StampRallyCheckPoint.find(params[:id])
+    @sponsors = conference.sponsors
+    @type_options = StampRallyCheckPoint::Type::KLASSES.map(&:name)
+  end
+
+  def update
+    @stamp_rally_check_point = StampRallyCheckPoint.find(params[:id])
+    if @stamp_rally_check_point.update(stamp_rally_check_point_params)
+      flash.now.notice = "スタンプラリーチェックポイント #{@stamp_rally_check_point.id} を更新しました"
+    else
+      render(:edit, status: :unprocessable_entity)
+    end
+  end
+
+  def destroy
+    @stamp_rally_check_point = StampRallyCheckPoint.find(params[:id])
+    if @stamp_rally_check_point.destroy
+      flash.now.notice = "スタンプラリーチェックポイント #{@stamp_rally_check_point.id} を削除しました"
+    else
+      flash.now.alert = "スタンプラリーチェックポイント #{@stamp_rally_check_point.id} の削除に失敗しました"
+    end
+  end
+
+  helper_method :turbo_stream_flash
+
+  private
+
+  def stamp_rally_check_point_params
+    params.require(:stamp_rally_check_point).permit(:sponsor_id, :type)
+  end
+
+  def turbo_stream_flash
+    turbo_stream.append('flashes', partial: 'flash')
+  end
+end

--- a/app/javascript/packs/controllers/index.js
+++ b/app/javascript/packs/controllers/index.js
@@ -21,3 +21,12 @@ application.register("copy", CopyController)
 
 import CropUploadController from "./crop_upload_controller.js"
 application.register("crop-upload", CropUploadController)
+
+import ModalController from "./modal_controller";
+application.register("modal", ModalController);
+
+import ToastController from "./toast_controller.js"
+application.register("toast", ToastController)
+
+import SponsorController from "./sponsor_controller.js"
+application.register("sponsor", SponsorController)

--- a/app/javascript/packs/controllers/modal_controller.js
+++ b/app/javascript/packs/controllers/modal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+import { Modal } from "bootstrap"
+
+export default class extends Controller {
+    connect() {
+        this.modal = new Modal(this.element)
+        this.modal.show()
+    }
+
+    open() {
+        this.modal.classList.remove('hidden')
+    }
+
+    close(event) {
+        if (event.detail.success) {
+            this.modal.hide()
+        }
+    }
+}

--- a/app/javascript/packs/controllers/sponsor_controller.js
+++ b/app/javascript/packs/controllers/sponsor_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["sponsorField", "type"];
+
+    connect() {
+        this.toggleSponsorField();
+    }
+
+    toggleSponsorField() {
+        console.log(this.typeTarget.value)
+        if (this.typeTarget.value === 'StampRallyCheckPointBooth') {
+            this.sponsorFieldTarget.style.display = '';
+        } else {
+            this.sponsorFieldTarget.style.display = 'none';
+        }
+    }
+
+    handleTypeChange() {
+        this.toggleSponsorField();
+    }
+}

--- a/app/javascript/packs/controllers/toast_controller.js
+++ b/app/javascript/packs/controllers/toast_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+import { Toast } from "bootstrap"
+
+// Connects to data-controller="toast"
+export default class extends Controller {
+  connect() {
+    const toast = new Toast(this.element)
+    toast.show()
+  }
+}

--- a/app/models/concerns/ulid_pk.rb
+++ b/app/models/concerns/ulid_pk.rb
@@ -1,0 +1,11 @@
+module UlidPk
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :set_ulid
+  end
+
+  def set_ulid
+    self.id = ULID.generate
+  end
+end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -73,6 +73,7 @@ class Conference < ApplicationRecord
   has_many :media_package_harvest_jobs
   has_many :rooms
   has_many :check_in_conferences
+  has_many :stamp_rally_check_points
 
   scope :upcoming, -> {
     merge(where(conference_status: Conference::STATUS_REGISTERED).or(where(conference_status: Conference::STATUS_OPENED)))

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -29,6 +29,7 @@ class Sponsor < ApplicationRecord
   has_many :sponsors_sponsor_types, dependent: :delete_all
   has_many :sponsor_types, through: :sponsors_sponsor_types
   has_many :talks
+  has_many :stamp_rally_check_point_booths
 
   def booth_sponsor?
     sponsor_types.each do |type|

--- a/app/models/stamp_rally_check_point.rb
+++ b/app/models/stamp_rally_check_point.rb
@@ -1,0 +1,43 @@
+# == Schema Information
+#
+# Table name: stamp_rally_check_points
+#
+#  id            :string(26)       not null, primary key
+#  type          :string(255)      not null
+#  conference_id :bigint           not null
+#  sponsor_id    :bigint
+#
+# Indexes
+#
+#  index_stamp_rally_check_points_on_conference_id  (conference_id)
+#  index_stamp_rally_check_points_on_sponsor_id     (sponsor_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#
+class StampRallyCheckPoint < ApplicationRecord
+  include UlidPk
+
+  self.inheritance_column = :type
+
+  belongs_to :conference
+  belongs_to :sponsor, optional: true
+
+  # typeが"StampRallyDefBooth"の場合にsponsor_idが必須であること
+  validates :sponsor_id, presence: true, if: :stamp_rally_check_point_booth?
+  # typeが"StampRallyCheckPointFinish"のレコードはカンファレンス内で1つしか作成できない
+  validate :check_point_finish_is_unique_in_conference
+
+  private
+
+  def stamp_rally_check_point_booth?
+    type == StampRallyCheckPointBooth.name
+  end
+
+  def check_point_finish_is_unique_in_conference
+    if type == StampRallyCheckPointFinish.name && StampRallyCheckPoint.where(conference_id:, type: StampRallyCheckPointFinish.name).exists?
+      errors.add(:type, 'StampRallyCheckPointFinishは1つのカンファレンス内で複数作成できません')
+    end
+  end
+end

--- a/app/models/stamp_rally_check_point/type.rb
+++ b/app/models/stamp_rally_check_point/type.rb
@@ -1,0 +1,5 @@
+class StampRallyCheckPoint < ApplicationRecord
+  class Type < ApplicationRecord
+    KLASSES = [StampRallyCheckPoint, StampRallyCheckPointBooth, StampRallyCheckPointFinish].freeze
+  end
+end

--- a/app/models/stamp_rally_check_point_booth.rb
+++ b/app/models/stamp_rally_check_point_booth.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: stamp_rally_check_points
+#
+#  id            :string(26)       not null, primary key
+#  type          :string(255)      not null
+#  conference_id :bigint           not null
+#  sponsor_id    :bigint
+#
+# Indexes
+#
+#  index_stamp_rally_check_points_on_conference_id  (conference_id)
+#  index_stamp_rally_check_points_on_sponsor_id     (sponsor_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#
+class StampRallyCheckPointBooth < StampRallyCheckPoint
+end

--- a/app/models/stamp_rally_check_point_finish.rb
+++ b/app/models/stamp_rally_check_point_finish.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: stamp_rally_check_points
+#
+#  id            :string(26)       not null, primary key
+#  type          :string(255)      not null
+#  conference_id :bigint           not null
+#  sponsor_id    :bigint
+#
+# Indexes
+#
+#  index_stamp_rally_check_points_on_conference_id  (conference_id)
+#  index_stamp_rally_check_points_on_sponsor_id     (sponsor_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conference_id => conferences.id)
+#
+class StampRallyCheckPointFinish < StampRallyCheckPoint
+end

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -20,6 +20,7 @@
     <%= render 'admin/nav_item', name: 'HarvestJobs', path: admin_harvest_jobs_path, active: action_name == 'media_package_harvest_job' %>
     <%= render 'admin/nav_item', name: 'Statistics', path: admin_statistics_path, active: action_name == 'statistics' %>
     <%= render 'admin/nav_item', name: 'Sponsors', path: admin_sponsors_path, active: controller_name == 'sponsors' || action_name == 'show_sponsor' %>
+    <%= render 'admin/nav_item', name: 'Stamp Rally Checkpoints', path: admin_stamp_rally_check_points_path, active: controller_name == 'stamp_rally_check_points' || controller_name == 'qr_code_for_stamp_rallies' || action_name == 'show_sponsor' %>
     <%= render 'admin/nav_item', name: 'Debug', path: admin_debug_path, active: action_name == 'debug' %>
     <%= render 'admin/nav_item', name: 'Edit Admin Profile', path: edit_admin_admin_profile_path(id: @admin_profile), active: action_name == 'administrators' %>
     <%= render 'admin/nav_item', name: 'Edit Team Page', path: admin_team_path, active: controller_name == 'teams' %>

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <ul class="list-unstyled components">
-    <%= render 'admin/nav_item', name: 'Admin Top', path: admin_path, active: action_name == 'show' %>
+    <%= render 'admin/nav_item', name: 'Admin Top', path: admin_path, active: controller_name == 'admin' &&  action_name == 'show' %>
     <%= render 'admin/nav_item', name: 'Announcements', path: admin_announcements_path, active: action_name == 'announcements' %>
     <%= render 'admin/nav_item', name: 'Users', path: admin_users_path, active: action_name == 'users' %>
     <%= render 'admin/nav_item', name: 'Speakers', path: admin_speakers_path, active:  controller_name == 'speakers' || action_name == 'check_in_statuses' %>

--- a/app/views/admin/stamp_rally_check_points/_form.html.erb
+++ b/app/views/admin/stamp_rally_check_points/_form.html.erb
@@ -1,0 +1,43 @@
+<%= turbo_frame_tag stamp_rally_check_point.becomes(StampRallyCheckPoint) do %>
+  <%= form_with(model: [:admin, stamp_rally_check_point.becomes(StampRallyCheckPoint)],
+                url: @stamp_rally_check_point.new_record? ? admin_stamp_rally_check_points_path(event: params[:event]) : admin_stamp_rally_check_point_path(@stamp_rally_check_point, event: params[:event]),
+                data: { action: "turbo:submit-end->modal#close" }) do |form| %>
+    <% if stamp_rally_check_point.errors.any? %>
+      <ul>
+        <% stamp_rally_check_point.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    <% end %>
+    <div class="row py-2 border-top" data-controller="sponsor">
+      <div class="mb-3">
+        <%= form.label :type, class: "form-label" %>
+        <%= form.select :type, options_for_select(type_options, selected: stamp_rally_check_point.type), {},
+                        {
+                          class: "form-select",
+                          id: "stamp_rally_check_point_type",
+                          data: {
+                            target: "sponsor.type",
+                            action: "change->sponsor#handleTypeChange"
+                          }
+                        }
+        %>
+      </div>
+      <div class="mb-3" data-target="sponsor.sponsorField" >
+        <%= form.label :sponsor_id, class: "form-label"  %>
+        <%= form.collection_select :sponsor_id, sponsors, :id, :name, {include_blank: true},
+                                   {
+                                     class: "form-select",
+                                     id: "stamp_rally_check_point_sponsor_id"
+                                   }
+        %>
+      </div>
+
+      <div class="mb-3">
+        <div class="d-flex justify-content-end">
+          <%= form.submit class: "btn btn-primary btn-sm me-2" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/stamp_rally_check_points/_stamp_rally_check_point.html.erb
+++ b/app/views/admin/stamp_rally_check_points/_stamp_rally_check_point.html.erb
@@ -1,0 +1,20 @@
+<%= turbo_frame_tag stamp_rally_check_point do %>
+  <div class="row py-2 border-top">
+    <div class="col-2 my-auto">
+      <%= stamp_rally_check_point.id %>
+    </div>
+    <div class="col-2 my-auto">
+      <%= stamp_rally_check_point.type %>
+    </div>
+    <div class="col-2 my-auto">
+      <%= stamp_rally_check_point.sponsor&.name %>
+    </div>
+    <div class="col-2">
+      <div class="d-flex justify-content-end">
+        <% p stamp_rally_check_point.conference %>
+        <%= link_to "編集", edit_admin_stamp_rally_check_point_path(event: stamp_rally_check_point.conference.abbr, id: stamp_rally_check_point.id), class: "btn btn-sm btn-outline-primary me-2", data: { turbo_frame: "modal" } %>
+        <%= link_to "削除", admin_stamp_rally_check_point_path(event: stamp_rally_check_point.conference.abbr, id: stamp_rally_check_point.id), class: "btn btn-sm btn-outline-danger", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/stamp_rally_check_points/create.turbo_stream.erb
+++ b/app/views/admin/stamp_rally_check_points/create.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.prepend "stamp_rally_check_points", @stamp_rally_check_point.becomes(StampRallyCheckPoint) do %>
+  <%= render partial: 'admin/stamp_rally_check_points/stamp_rally_check_point', locals: { stamp_rally_check_point: @stamp_rally_check_point, conference: @conference } %>
+<% end %>
+<%= turbo_stream_flash %>
+<%= yield %>

--- a/app/views/admin/stamp_rally_check_points/destroy.turbo_stream.erb
+++ b/app/views/admin/stamp_rally_check_points/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.remove @stamp_rally_check_point %>
+<%= turbo_stream_flash %>
+<%= yield %>

--- a/app/views/admin/stamp_rally_check_points/edit.html.erb
+++ b/app/views/admin/stamp_rally_check_points/edit.html.erb
@@ -1,0 +1,4 @@
+<%= render "layouts/modal", title: "編集" do %>
+  <%= render "form", stamp_rally_check_point: @stamp_rally_check_point, sponsors: @sponsors, type_options: @type_options%>
+<% end %>
+

--- a/app/views/admin/stamp_rally_check_points/index.html.erb
+++ b/app/views/admin/stamp_rally_check_points/index.html.erb
@@ -1,0 +1,33 @@
+<% provide(:title, 'スタンプラリーチェックポイント一覧') %>
+<%= render 'admin/layout' do %>
+  <div class="row">
+    <h2>スタンプラリーチェックポイント一覧</h2>
+  </div>
+
+  <%= turbo_frame_tag "stamp_rally_check_point_list" do %>
+    <div class="col-4 d-flex">
+      <%= link_to "登録",
+                  new_admin_stamp_rally_check_point_path,
+                  class: "btn btn-outline-primary",
+                  data: { turbo_frame: "modal" }
+      %>
+    </div>
+
+
+    <div class="row py-2 border-top">
+      <div class="col-2 my-auto">ID</div>
+      <div class="col-2 my-auto">Type</div>
+      <div class="col-2 my-auto">Sponsor Name</div>
+      <div class="col-2"></div>
+    </div>
+    <div id="stamp_rally_check_points">
+      <% @stamp_rally_check_points.each do |stamp_rally_check_point| %>
+        <%= render 'admin/stamp_rally_check_points/stamp_rally_check_point', conference: @conference, stamp_rally_check_point: stamp_rally_check_point %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= turbo_frame_tag "modal" %>
+  <div id="flashes" class="position-fixed bottom-0 end-0" style="margin: 0.75rem"></div>
+
+<% end %>

--- a/app/views/admin/stamp_rally_check_points/new.html.erb
+++ b/app/views/admin/stamp_rally_check_points/new.html.erb
@@ -1,0 +1,3 @@
+<%= render "layouts/modal", title: "登録" do %>
+  <%= render "form", stamp_rally_check_point: @stamp_rally_check_point, sponsors: @sponsors, type_options: @type_options%>
+<% end %>

--- a/app/views/admin/stamp_rally_check_points/update.turbo_stream.erb
+++ b/app/views/admin/stamp_rally_check_points/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace @stamp_rally_check_point do %>
+  <%= render partial: 'admin/stamp_rally_check_points/stamp_rally_check_point', locals: { stamp_rally_check_point: @stamp_rally_check_point, conference: @conference } %>
+<% end %>
+<%= turbo_stream_flash %>
+<%= yield %>

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,0 +1,19 @@
+<% if notice %>
+  <div class="mb-2 toast hide border-primary" data-controller="toast">
+    <div class="toast-header text-primary">
+      <strong class="me-auto">成功</strong>
+      <button class="btn-close" data-bs-dismiss="toast"></button>
+    </div>
+    <div class="toast-body"><%= notice %></div>
+  </div>
+<% end %>
+
+<% if alert %>
+  <div class="mb-2 toast hide border-danger" data-controller="toast">
+    <div class="toast-header text-danger">
+      <strong class="me-auto">エラー</strong>
+      <button class="btn-close" data-bs-dismiss="toast"></button>
+    </div>
+    <div class="toast-body"><%= alert %></div>
+  </div>
+<% end %>

--- a/app/views/layouts/_modal.html.erb
+++ b/app/views/layouts/_modal.html.erb
@@ -1,0 +1,20 @@
+<%= turbo_frame_tag "modal" do %>
+  <div class="modal fade" data-controller="modal">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title"><%= title%></h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-info" role="alert">
+              <%= message %>
+            </div>
+          <% end %>
+          <%= yield %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="https://use.typekit.net/ntd4lbp.css">
     <%= stylesheet_link_tag event_js_path, media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag event_js_path, 'data-turbolinks-track': 'reload' %>
+  <meta name="turbo-cache-control" content="no-cache">
 
     <script src="https://transloadit.edgly.net/releases/uppy/v1.6.0/uppy.min.js"></script>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
       resources :announcements
       resources :speaker_announcements
       resources :streamings
+      resources :stamp_rally_check_points
       post 'create_aws_resources' => 'streamings#create_aws_resources'
       post 'delete_aws_resources' => 'streamings#delete_aws_resources'
       post 'start_media_live_channel' => 'media_live_channel#start_channel'

--- a/db/fixtures/development/03_sponsors.rb
+++ b/db/fixtures/development/03_sponsors.rb
@@ -42,3 +42,41 @@ SponsorType.seed(
     order: 5,
   },
 )
+
+Sponsor.seed(
+  {
+    id: 1,
+    abbr: "booth1",
+    conference_id: 12,
+    name: "Booth Sponsor 1",
+    url: "https://example.com",
+    description: "Booth Sponsor 1",
+  },
+  {
+    id: 2,
+    abbr: "booth2",
+    conference_id: 12,
+    name: "Booth Sponsor 2",
+    url: "https://example.com",
+    description: "Booth Sponsor 2",
+  },
+)
+
+StampRallyCheckPointBooth.seed(
+  {
+    id: '01J9G65KEWB1NW637VDPWAA88W',
+    conference_id: 12,
+    sponsor_id: 1,
+  },
+  {
+    id: '01J9G65KEZVCX8NKJXF3RB6PH5',
+    conference_id: 12,
+    sponsor_id: 2,
+  }
+)
+StampRallyCheckPointFinish.seed(
+  {
+    id: '01J9G65KF4H9108RQ0ATRCT8H8',
+    conference_id: 12
+  },
+)

--- a/db/migrate/20241006001733_add_tables_for_stamp_rally_check_points.rb
+++ b/db/migrate/20241006001733_add_tables_for_stamp_rally_check_points.rb
@@ -1,0 +1,10 @@
+class AddTablesForStampRallyCheckPoints < ActiveRecord::Migration[7.0]
+  def change
+    create_table :stamp_rally_check_points, id: false do |t|
+      t.string :id, limit: 26, primary_key: true
+      t.references :conference, null: false, foreign_key: true
+      t.references :sponsor, null: true
+      t.string :type, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_26_095613) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_06_001733) do
   create_table "admin_profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.string "sub"
@@ -450,6 +450,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_26_095613) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "stamp_rally_check_points", id: { type: :string, limit: 26 }, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "conference_id", null: false
+    t.bigint "sponsor_id"
+    t.string "type", null: false
+    t.index ["conference_id"], name: "index_stamp_rally_check_points_on_conference_id"
+    t.index ["sponsor_id"], name: "index_stamp_rally_check_points_on_sponsor_id"
+  end
+
   create_table "stats_of_registrants", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "conference_id"
     t.integer "number_of_registrants"
@@ -630,6 +638,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_26_095613) do
   add_foreign_key "sponsor_profiles", "conferences"
   add_foreign_key "sponsor_types", "conferences"
   add_foreign_key "sponsors", "conferences"
+  add_foreign_key "stamp_rally_check_points", "conferences"
   add_foreign_key "streamings", "conferences"
   add_foreign_key "streamings", "tracks"
   add_foreign_key "talk_times", "conferences"


### PR DESCRIPTION
Implement https://www.notion.so/pfem/34dbdb151f134b07808f27add4a7a1dc?pvs=4#ccb4f4e91fc94661ac016eeb97c28980

- [x] typeがStampRallyCheckPointBoothのときだけsponsorを選択可能にする
- [x] CheckPoint作成時のバリデーションにひっかかったときの処理（画面表示）