### PR TITLE
Sentry sampling_rate を 1% に上げる (戻す)

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,8 +6,8 @@ Sentry.init do |config|
 
   # To activate performance monitoring, set one of these options.
   # We recommend adjusting the value in production:
-  config.traces_sample_rate = 0.0001
-  config.profiles_sample_rate = 0.0001
+  config.traces_sample_rate = 0.01
+  config.profiles_sample_rate = 0.01
   # set the instrumenter to use OpenTelemetry instead of Sentry
   config.instrumenter = :otel
 


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast/pull/2324 で下げていたのを、戻す
下げた当時の問題は https://github.com/cloudnativedaysjp/dreamkast/pull/2342 で解決した