### PR TITLE
セルフチェックインの改修

### DIFF
--- a/app/controllers/check_in_conferences_controller.rb
+++ b/app/controllers/check_in_conferences_controller.rb
@@ -5,7 +5,7 @@ class CheckInConferencesController < ApplicationController
   skip_before_action :logged_in_using_omniauth?
 
   def new
-    if logged_in? && @profile.present?
+    if logged_in? && @profile.instance_of?(Profile)
       check_in = CheckInConference.new(
         conference_id: @conference.id,
         profile_id: @profile.id,
@@ -14,7 +14,7 @@ class CheckInConferencesController < ApplicationController
       check_in.save
     end
 
-    if logged_in? && @profile.nil?
+    if logged_in? && (@profile.nil? || @profile.instance_of?(GuestProfile))
       flash[:alert] = 'チェックインするためには参加登録が必要です。登録後、再度スキャンしてチェックインしてください。'
       redirect_to("/#{params[:event]}/registration")
       nil

--- a/app/controllers/check_in_conferences_controller.rb
+++ b/app/controllers/check_in_conferences_controller.rb
@@ -1,0 +1,32 @@
+class CheckInConferencesController < ApplicationController
+  include Secured
+
+  skip_before_action :redirect_to_registration
+  skip_before_action :logged_in_using_omniauth?
+
+  def new
+    if logged_in? && @profile.present?
+      check_in = CheckInConference.new(
+        conference_id: @conference.id,
+        profile_id: @profile.id,
+        check_in_timestamp: Time.current
+      )
+      check_in.save
+    end
+
+    if logged_in? && @profile.nil?
+      flash[:alert] = 'チェックインするためには参加登録が必要です。登録後、再度スキャンしてチェックインしてください。'
+      redirect_to("/#{params[:event]}/registration")
+      nil
+    end
+  end
+
+  def check_in_conferences_params
+    params.require(:check_in_conference).permit(
+      :conference_id,
+      :profile_id,
+      :check_in_timestamp,
+      :scanner_profile_id
+    )
+  end
+end

--- a/app/controllers/check_in_conferences_controller.rb
+++ b/app/controllers/check_in_conferences_controller.rb
@@ -6,12 +6,12 @@ class CheckInConferencesController < ApplicationController
 
   def new
     if logged_in? && @profile.instance_of?(Profile)
-      check_in = CheckInConference.new(
+      @check_in = CheckInConference.new(
         conference_id: @conference.id,
         profile_id: @profile.id,
         check_in_timestamp: Time.current
       )
-      check_in.save
+      @check_in.save!
     end
 
     if logged_in? && (@profile.nil? || @profile.instance_of?(GuestProfile))

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -98,18 +98,6 @@ class ProfilesController < ApplicationController
     end
   end
 
-  def checkin
-    if @profile.present?
-      c = CheckIn.new
-      c.profile_id = @profile.id
-      c.save
-    elsif @profile.nil?
-      redirect_to("/#{params[:event]}/registration")
-    else
-      redirect_to(dashboard_path)
-    end
-  end
-
   def view_qr
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -73,7 +73,7 @@ class Profile < ApplicationRecord
   has_many :form_items, through: :agreements
   has_many :chat_messages
   has_many :check_ins
-  has_many :check_in_conferences
+  has_many :check_in_conferences, dependent: :destroy
   has_many :check_in_talks
   has_many :stamp_rally_check_ins
   has_one :public_profile, dependent: :destroy

--- a/app/views/check_in_conferences/new.html.erb
+++ b/app/views/check_in_conferences/new.html.erb
@@ -19,3 +19,9 @@
     </div>
   </div>
 </div>
+
+<script>
+setTimeout(() => {
+    location.href = "<%= dashboard_path %>";
+}, 3000);
+</script>

--- a/app/views/check_in_conferences/new.html.erb
+++ b/app/views/check_in_conferences/new.html.erb
@@ -1,0 +1,14 @@
+<% provide(:title, 'セルフチェックイン') %>
+<div class="container">
+  <div class="row">
+    <div class="col-12 col-md-12 py-4 contents white_background checkin">
+      <h2 class="text-center"><%= @conference.abbr.upcase %>へようこそ！</h2>
+      <% unless logged_in? %>
+      <div class="col-12 align-self-baseline my-4 justify-content-center text-center">
+        <%= label_tag 'entry', 'セルフチェックインにはログインが必要です' %>
+        <%= button_to 'ログイン', '/auth/auth0', {method: :post, class: "btn btn-secondary btn-xl inline" } %>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/check_in_conferences/new.html.erb
+++ b/app/views/check_in_conferences/new.html.erb
@@ -4,10 +4,17 @@
     <div class="col-12 col-md-12 py-4 contents white_background checkin">
       <h2 class="text-center"><%= @conference.abbr.upcase %>へようこそ！</h2>
       <% unless logged_in? %>
-      <div class="col-12 align-self-baseline my-4 justify-content-center text-center">
-        <%= label_tag 'entry', 'セルフチェックインにはログインが必要です' %>
-        <%= button_to 'ログイン', '/auth/auth0', {method: :post, class: "btn btn-secondary btn-xl inline" } %>
-      </div>
+        <div class="col-12 align-self-baseline my-4 justify-content-center text-center">
+          <%= label_tag 'entry', 'セルフチェックインにはログインが必要です' %>
+          <%= button_to 'ログイン', '/auth/auth0', {method: :post, class: "btn btn-secondary btn-xl inline" } %>
+        </div>
+      <% end %>
+      <% if @check_in.present? %>
+        <div class="checked text-center center-block">
+          &nbsp;
+        </div>
+        <p>チェックインが完了しました！</p>
+        <p>3秒後にイベントダッシュボードにリダイレクトします</p>
       <% end %>
     </div>
   </div>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,9 +1,13 @@
 <div class="container">
   <div class="row justify-content-lg-center">
     <div class="col-12 col-lg-6 registration-form py-3 my-3 px-md-5">
+      <% flash.each do |message_type, message| %>
+        <div class="alert alert-<%= alert_type(message_type) %> alert-dismissible fade show" role="alert">
+          <%= message %>
+        </div>
+      <% end %>
       <h2><%= @conference.abbr.upcase %> 参加登録フォーム</h2>
       <div class="block"></div>
-
       <% if logged_in? %>
         <%= render 'form', profile: @profile, submit_button_label: "個人情報保護方針に同意して参加登録" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,8 @@ Rails.application.routes.draw do
 
     resources :attachments, only: [:show]
 
+    get 'self_check_in' => 'check_in_conferences#new'
+
     # Profile
     resources :profiles, only: [:new, :edit, :update, :create]
     namespace :profiles do
@@ -170,7 +172,6 @@ Rails.application.routes.draw do
     delete 'profiles', to: 'profiles#destroy'
     get 'profiles', to: 'profiles#edit'
     get 'profiles/edit', to: 'profiles#edit'
-    get 'profiles/checkin', to: 'profiles#checkin'
     get 'profiles/entry_sheet' => 'profiles#entry_sheet'
     get 'profiles/view_qr' => 'profiles#view_qr'
     get 'profiles/entry_sheet' => 'profiles#entry_sheet'

--- a/spec/requests/check_in_conferences_spec.rb
+++ b/spec/requests/check_in_conferences_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe(CheckInConferencesController, type: :request) do
+  let!(:cndt2020) { create(:cndt2020) }
+  let!(:session) { { userinfo: { info: { email: 'alice@example.com', extra: { sub: 'aaa' } }, extra: { raw_info: { sub: 'aaa', 'https://cloudnativedays.jp/roles' => roles } } } } }
+  let(:roles) { [] }
+
+  describe 'GET /:event/self_check_in' do
+    context 'when not logged in' do
+      it 'redirects to login page' do
+        get '/cndt2020/self_check_in'
+        expect(response).to(have_http_status('200'))
+        expect(response.body).to(include('セルフチェックインにはログインが必要です'))
+      end
+    end
+
+    context 'when logged in and has profile' do
+      before do
+        create(:alice, :on_cndt2020)
+        ActionDispatch::Request::Session.define_method(:original, ActionDispatch::Request::Session.instance_method(:[]))
+        allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]) do |*arg|
+          if arg[1] == :userinfo
+            session[:userinfo]
+          else
+            arg[0].send(:original, arg[1])
+          end
+        end)
+      end
+
+      it 'creates a check-in record' do
+        expect {
+          get('/cndt2020/self_check_in')
+        }.to(change(CheckInConference, :count).by(1))
+
+        expect(response).to(have_http_status(:ok))
+
+        check_in = CheckInConference.last
+        expect(check_in.conference_id).to(eq(cndt2020.id))
+        expect(check_in.profile_id).to(eq(Profile.find_by(email: 'alice@example.com').id))
+        expect(check_in.check_in_timestamp).to(be_present)
+      end
+    end
+
+    context 'when logged in but no profile' do
+      before do
+        ActionDispatch::Request::Session.define_method(:original, ActionDispatch::Request::Session.instance_method(:[]))
+        allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]) do |*arg|
+          if arg[1] == :userinfo
+            session[:userinfo]
+          else
+            arg[0].send(:original, arg[1])
+          end
+        end)
+      end
+
+      it 'redirects to registration page with alert' do
+        get '/cndt2020/self_check_in'
+        expect(response).to(redirect_to('/cndt2020/registration'))
+        expect(flash[:alert]).to(eq('チェックインするためには参加登録が必要です。登録後、再度スキャンしてチェックインしてください。'))
+      end
+    end
+  end
+end

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,9 +82,9 @@ module.exports = {
       },
       {
         test: /\.(png|jpe?g|gif|eot|woff2|woff|ttf|svg)$/i,
-        generator: {
-          filename: 'images/[name][ext]',
-        },
+        // generator: {
+        //   filename: 'images/[name][ext]',
+        // },
         type: 'asset/resource',
       },
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,10 @@ module.exports = {
       },
       {
         test: /\.(png|jpe?g|gif|eot|woff2|woff|ttf|svg)$/i,
-        use: 'file-loader',
+        generator: {
+          filename: 'images/[name][ext]',
+        },
+        type: 'asset/resource',
       },
     ],
   },


### PR DESCRIPTION
- チェックイン情報を保持するテーブルをcheck_in_conferencesに統一
  - check_in_conferencesUIからスキャンしてチェックインする時に使うテーブル
- ログインしていない時にいきなりauth0にリダイレクトするのではなく、ログインボタンを表示したページを挟むよう変更
  - iPhoneでスキャンした時、未ログインの内部ブラウザで開いてしまうと困ることがあるため
- セルフチェックイン用のURLを `/:event_abbr/self_check_in` に変更