### PR TITLE
Added Stats of Registrants metrics

### DIFF
--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -142,7 +142,6 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
   end
 
   def dreamkast_stats_of_registrants_offline(metrics)
-    registrants_counts = StatsOfRegistrant.group(:conference_id).count
     StatsOfRegistrant.all.each do |stats|
       metrics.set(
         stats.offline_attendees,
@@ -152,7 +151,6 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
   end
 
   def dreamkast_stats_of_registrants_online(metrics)
-    registrants_counts = StatsOfRegistrant.group(:conference_id).count
     StatsOfRegistrant.all.each do |stats|
       metrics.set(
         stats.online_attendees,

--- a/app/middlewares/dreamkast_exporter.rb
+++ b/app/middlewares/dreamkast_exporter.rb
@@ -41,6 +41,16 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
         :dreamkast_select_proposal_items,
         docstring: 'Select dreamkast proposal items',
         labels: [:talk_id, :conference_id, :proposal_items_label, :proposal_items_params]
+      ),
+      Prometheus::Client::Gauge.new(
+        :dreamkast_stats_of_registrants_offline,
+        docstring: 'Stats of Registrants(Offline)',
+        labels: [:conference_id]
+      ),
+      Prometheus::Client::Gauge.new(
+        :dreamkast_stats_of_registrants_online,
+        docstring: 'Stats of Registrants(Online)',
+        labels: [:conference_id]
       )
     ]
     metrics.each do |metric|
@@ -127,6 +137,26 @@ class DreamkastExporter < Prometheus::Middleware::Exporter
       metrics.set(
         proposal_items.talk_id,
         labels: { talk_id: proposal_items.talk_id, conference_id: proposal_items.conference_id, proposal_items_label: proposal_items.label, proposal_items_params: proposal_items.params }
+      )
+    end
+  end
+
+  def dreamkast_stats_of_registrants_offline(metrics)
+    registrants_counts = StatsOfRegistrant.group(:conference_id).count
+    StatsOfRegistrant.all.each do |stats|
+      metrics.set(
+        stats.offline_attendees,
+        labels: { conference_id: stats.conference_id }
+      )
+    end
+  end
+
+  def dreamkast_stats_of_registrants_online(metrics)
+    registrants_counts = StatsOfRegistrant.group(:conference_id).count
+    StatsOfRegistrant.all.each do |stats|
+      metrics.set(
+        stats.online_attendees,
+        labels: { conference_id: stats.conference_id }
       )
     end
   end


### PR DESCRIPTION
## About

- 参加者数の属性（オフライン/オンライン）をダッシュボードに出力するために必要なメトリクスを追加しました
- `stats_of_registrants`に値が入ると以下のようなメトリクスを出力するようになっています

```sh
# ... omit ...
# TYPE dreamkast_stats_of_registrants_offline gauge
# HELP dreamkast_stats_of_registrants_offline Stats of Registrants(Offline)
dreamkast_stats_of_registrants_offline{conference_id="1"} 50.0
dreamkast_stats_of_registrants_offline{conference_id="2"} 50.0
# TYPE dreamkast_stats_of_registrants_online gauge
# HELP dreamkast_stats_of_registrants_online Stats of Registrants(Online)
dreamkast_stats_of_registrants_online{conference_id="1"} 50.0
dreamkast_stats_of_registrants_online{conference_id="2"} 60.0
```