### PR TITLE
migrate aws-credential from access-key to using GitHub OIDC

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -10,11 +10,9 @@ jobs:
     uses: cloudnativedaysjp/reusable-workflows/.github/workflows/wc-build-image.yml@main
     permissions:
       contents: read
+      id-token: write
     with:
       image_name: dreamkast-ecs
       platforms: amd64
       aws_region: us-west-2
       run-trivy: true
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -6,14 +6,12 @@ on:
 
 jobs:
   build:
-    uses: cloudnativedaysjp/reusable-workflows/.github/workflows/build-image.yml@main
+    uses: cloudnativedaysjp/reusable-workflows/.github/workflows/wc-build-image.yml@main
     permissions:
       contents: read
+      id-token: write
     with:
       image_name: dreamkast-ecs
       platforms: amd64
       aws_region: ap-northeast-1
       run-trivy: false
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/make-swagger-artifacts.yml
+++ b/.github/workflows/make-swagger-artifacts.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: 30
 
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
+          role-to-assume: arn:aws:iam::607167088920:role/github-actions-dreamkast
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/reviewapp-cleanup.yml
+++ b/.github/workflows/reviewapp-cleanup.yml
@@ -7,11 +7,10 @@ on:
 jobs:
   cleanup:
     uses: cloudnativedaysjp/reusable-workflows/.github/workflows/wc-cleanup-ecs-reviewapps.yml@main
-    permissions: {}
+    permissions:
+      id-token: write
     with:
       prefix: dk-
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/reviewapp.yml
+++ b/.github/workflows/reviewapp.yml
@@ -15,11 +15,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      id-token: write
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   update-comment:
     needs: [reviewapp]


### PR DESCRIPTION
* related PR: https://github.com/cloudnativedaysjp/reusable-workflows/pull/25