### PR TITLE
fix: The workflow is not valid. .github/workflows/gitops-prd.yml (Lin…

### DIFF
--- a/.github/workflows/gitops-prd.yml
+++ b/.github/workflows/gitops-prd.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   gitops-ecs:
     uses: cloudnativedaysjp/reusable-workflows/.github/workflows/wc-update-ecs-manifest.yml@main
-    permissions: {}
+    permissions:
+      id-token: write
     with:
       target-image: dreamkast_ecs
       environment: prod

--- a/.github/workflows/gitops-stg.yml
+++ b/.github/workflows/gitops-stg.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   gitops-ecs:
     uses: cloudnativedaysjp/reusable-workflows/.github/workflows/wc-update-ecs-manifest.yml@main
-    permissions: {}
+    permissions:
+      id-token: write
     with:
       target-image: dreamkast_ecs
       environment: stg


### PR DESCRIPTION
…e: 9, Col: 3): Error calling workflow 'cloudnativedaysjp/reusable-workflows/.github/workflows/wc-update-ecs-manifest.yml@main'. The nested job 'gitops' is requesting 'id-token: write', but is only allowed 'id-token: none'.