### PR TITLE
admin/sponsorsページをHotwire化

### DIFF
--- a/app/controllers/admin/sponsors_controller.rb
+++ b/app/controllers/admin/sponsors_controller.rb
@@ -33,12 +33,10 @@ class Admin::SponsorsController < ApplicationController
     @sponsor_types = conference.sponsor_types
     @sponsor_form = SponsorForm.new(sponsor_params, sponsor: Sponsor.new(conference:))
 
-    respond_to do |format|
-      if @sponsor_form.save
-        format.html { redirect_to(admin_sponsors_path(event: params[:event]), notice: 'Sponsor was successfully created.') }
-      else
-        format.html { redirect_to(new_admin_sponsor_path(event: params[:event]), notice: 'Failed to create sponsor.') }
-      end
+    if @sponsor_form.save
+      flash.now[:notice] = "スポンサー #{@sponsor_form.sponsor.name} を登録しました"
+    else
+      render(:new, status: :unprocessable_entity)
     end
   end
 
@@ -47,40 +45,24 @@ class Admin::SponsorsController < ApplicationController
     @sponsor_types = conference.sponsor_types
     @sponsor_form = SponsorForm.new(sponsor_params, sponsor: @sponsor)
 
-    respond_to do |format|
-      if @sponsor_form.save
-        format.html { redirect_to(admin_sponsor_url(event: params[:event], id: params[:id]), notice: 'Sponsor was successfully updated.') }
-      else
-        format.html { render(:edit) }
-      end
+    if @sponsor_form.save
+      flash.now.notice = "スポンサー #{@sponsor.name} を更新しました"
+    else
+      render(:edit, status: :unprocessable_entity)
     end
   end
 
   def destroy
     @sponsor = Sponsor.find(params[:id])
 
-    respond_to do |format|
-      if @sponsor.destroy
-        format.html { redirect_to(admin_sponsors_path(event: params[:event]), notice: 'Sponsor was successfully destroyed.') }
-      else
-        format.html { redirect_to(admin_sponsor_url(event: params[:event], id: params[:id]), notice: 'Failed destroying sponsor.') }
-      end
+    if @sponsor.destroy
+      flash.now.notice = "スポンサー #{@sponsor.name} を削除しました"
+    else
+      flash.now.alert = "スポンサー #{@sponsor.name} の削除に失敗しました"
     end
   end
 
   private
-
-
-  helper_method :sponsors_url
-
-  def sponsors_url
-    case action_name
-    when 'new'
-      "/#{params[:event]}/admin/sponsors"
-    when 'edit', 'update'
-      "/#{params[:event]}/admin/sponsors/#{params[:id]}"
-    end
-  end
 
   def sponsor_params
     params.require(:sponsor).permit(:id,

--- a/app/forms/sponsor_form.rb
+++ b/app/forms/sponsor_form.rb
@@ -54,8 +54,6 @@ class SponsorForm
 
   private
 
-  attr_reader :sponsor
-
   def default_attributes
     {
       name: sponsor.name,

--- a/app/views/admin/sponsors/_form.html.erb
+++ b/app/views/admin/sponsors/_form.html.erb
@@ -1,29 +1,39 @@
-<%= form_with(url: sponsors_url, model: @sponsor_form) do |form| %>
+<%= turbo_frame_tag @sponsor_form.sponsor do %>
+  <%= form_with(model: [:admin, @sponsor_form.sponsor],
+                url: @sponsor_form.sponsor.new_record? ? admin_sponsors_path(event: params[:event]) : admin_sponsor_path(@sponsor_form.sponsor, event: params[:event]),
+                data: { action: "turbo:submit-end->modal#close" }) do |form| %>
+    <% if @sponsor_form.sponsor.errors.any? %>
+      <ul>
+        <% @sponsor_form.sponsor.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    <% end %>
   <div class="row py-2" data-controller="sponsor">
     <div class="mb-3">
       <%= form.label :name, "スポンサー名*", class: "form-label" %>
-      <%= form.text_field :name, class: "form-control" %>
+      <%= form.text_field :name, class: "form-control", value: @sponsor_form.name %>
     </div>
 
     <div class="mb-3">
       <%= form.label :abbr, "スポンサー略称*", class: "form-label" %>
-      <%= form.text_field :abbr, class: "form-control" %>
+      <%= form.text_field :abbr, class: "form-control", value: @sponsor_form.abbr %>
     </div>
 
     <div class="mb-3">
       <%= form.label :description, "スポンサー概要", class: "form-label" %>
-      <%= form.text_area :description, class: "form-control", rows: "3" %>
+      <%= form.text_area :description, class: "form-control", rows: "3", value: @sponsor_form.description %>
     </div>
 
     <div class="mb-3">
       <%= form.label :url, "スポンサーUrl", class: "form-label" %>
-      <%= form.text_field :url, class: "form-control" %>
+      <%= form.text_field :url, class: "form-control", value: @sponsor_form.url %>
     </div>
 
     <div class="mb-3">
       <%= form.label :sponsor_types, "スポンサー種別*", class: "form-label" %><br>
       <% @sponsor_types.each do |sponsor_type| %>
-        <%= check_box_tag "sponsor[sponsor_types][]", sponsor_type.id, @sponsor.sponsor_types.map(&:id).include?(sponsor_type.id), class: 'form-check-input' %>
+        <%= check_box_tag "sponsor[sponsor_types][]", sponsor_type.id, @sponsor_form.sponsor.sponsor_types.map(&:id).include?(sponsor_type.id), class: 'form-check-input' %>
         <%= label sponsor_type.name.to_sym, sponsor_type.name, {class: 'form-check-label'} %><br>
       <% end %>
     </div>
@@ -32,8 +42,8 @@
   <div class="mb-3">
     <%= form.label :attachment_logo_image, "スポンサーロゴ" %><br>
     <%= form.file_field :attachment_logo_image %>
-    <% if @sponsor.sponsor_attachment_logo_image %>
-      <%= image_tag @sponsor.sponsor_attachment_logo_image.file_url, class: "img-fluid" if @sponsor.sponsor_attachment_logo_image.file.present? %>
+    <% if @sponsor_form.sponsor.sponsor_attachment_logo_image %>
+      <%= image_tag @sponsor_form.sponsor.sponsor_attachment_logo_image.file_url, class: "img-fluid" if @sponsor_form.sponsor.sponsor_attachment_logo_image.file.present? %>
     <% end %>
   </div>
 
@@ -42,4 +52,5 @@
       <%= form.submit class: "btn btn-primary btn-sm me-2" %>
     </div>
   </div>
+  <% end %>
 <% end %>

--- a/app/views/admin/sponsors/_sponsor_row.html.erb
+++ b/app/views/admin/sponsors/_sponsor_row.html.erb
@@ -1,0 +1,25 @@
+<%= turbo_frame_tag sponsor do %>
+  <div class="row py-2 border-top">
+    <div class="col-2 my-auto">
+      <%= sponsor.abbr %>
+    </div>
+    <div class="col-2 my-auto">
+      <%= link_to sponsor.name, admin_sponsor_path(id: sponsor.id) %>
+    </div>
+    <div class="col-2 my-auto">
+      <%= sponsor.sponsor_types.map(&:name).join(', ') %>
+    </div>
+    <div class="col-2 my-auto">
+      <%= sponsor.talks.size %>
+    </div>
+    <div class="col-2 my-auto">
+      <%= sponsor.url %>
+    </div>
+    <div class="col-2 my-auto">
+      <div class="d-flex justify-content-end">
+        <%= link_to "編集", edit_admin_sponsor_path(event: sponsor.conference.abbr, id: sponsor.id), class: "btn btn-sm btn-outline-primary me-2", data: { turbo_frame: "modal" } %>
+        <%= link_to "削除", admin_sponsor_path(event: sponsor.conference.abbr, id: sponsor.id), class: "btn btn-sm btn-outline-danger", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/sponsors/create.turbo_stream.erb
+++ b/app/views/admin/sponsors/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.append "sponsors", partial: "admin/sponsors/sponsor_row", locals: { sponsor: @sponsor_form.sponsor } %>
+<%= turbo_stream.append 'flashes', partial: 'application/flash' %>

--- a/app/views/admin/sponsors/destroy.turbo_stream.erb
+++ b/app/views/admin/sponsors/destroy.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.remove @sponsor %>
+<%= turbo_stream.append 'flashes', partial: 'application/flash' %>

--- a/app/views/admin/sponsors/edit.html.erb
+++ b/app/views/admin/sponsors/edit.html.erb
@@ -1,13 +1,3 @@
-<%= render 'admin/layout' do %>
-  <div class="row mb-3">
-    <div class="col-10 mb-3 d-flex align-items-center">
-      <h2>Sponsors > <%= @sponsor.name %></h2>
-    </div>
-  </div>
-
-  <div class="row justify-content-md-center">
-    <div class="registration-form py-3 px-md-5 w-100">
-      <%= render 'form', sponsor_form: @sponsor_form %>
-    </div>
-  </div>
+<%= render "layouts/modal", title: "編集" do %>
+  <%= render "form", sponsor_form: @sponsor_form %>
 <% end %>

--- a/app/views/admin/sponsors/index.html.erb
+++ b/app/views/admin/sponsors/index.html.erb
@@ -1,34 +1,35 @@
+<% provide(:title, 'スポンサー一覧') %>
 <%= render 'admin/layout' do %>
   <div class="row">
-    <h2>Sponsors</h2>
+    <h2>スポンサー</h2>
   </div>
 
-  <div class="row mb-2">
-    <%= link_to 'Add Sponsor', new_admin_sponsor_url, class: "btn btn-primary" %>
-  </div>
+  <%= turbo_frame_tag "sponsor_list" do %>
+    <div class="col-4 d-flex">
+      <%= link_to "登録",
+                  new_admin_sponsor_path,
+                  class: "btn btn-outline-primary",
+                  data: { turbo_frame: "modal" }
+      %>
+    </div>
 
-  <div class="row">
-    <table class="table table-striped">
-      <thead>
-      <tr>
-        <th scope="col">Abbr</th>
-        <th scope="col">Name</th>
-        <th scope="col">Type</th>
-        <th scope="col">登録済みセッション数</th>
-        <th scope="col">Url</th>
-      </tr>
-      </thead>
-      <tbody>
+    <div class="row py-2 border-top">
+      <div class="col-2 my-auto">Abbr</div>
+      <div class="col-2 my-auto">Name</div>
+      <div class="col-2 my-auto">Type</div>
+      <div class="col-2 my-auto">登録済みセッション数</div>
+      <div class="col-2 my-auto">Url</div>
+      <div class="col-2 my-auto"></div>
+    </div>
+    
+    <div id="sponsors">
       <% @sponsors.each do |sponsor| %>
-        <tr>
-          <td><%= sponsor.abbr %></td>
-          <td><%= link_to sponsor.name, admin_sponsor_path(id: sponsor.id) %></td>
-          <td><%= sponsor.sponsor_types.map(&:name).join(', ') %></td>
-          <td><%= sponsor.talks.size %></td>
-          <td><%= sponsor.url %></td>
-        </tr>
+        <%= render 'admin/sponsors/sponsor_row', sponsor: sponsor %>
       <% end %>
-      </tbody>
-    </table>
-  </div>
+    </div>
+  <% end %>
+
+  <%= turbo_frame_tag "modal" %>
+  <div id="flashes" class="position-fixed bottom-0 end-0" style="margin: 0.75rem"></div>
+
 <% end %>

--- a/app/views/admin/sponsors/new.html.erb
+++ b/app/views/admin/sponsors/new.html.erb
@@ -1,10 +1,3 @@
-<%= render 'admin/layout' do %>
-  <div class="row">
-    <h2>スポンサーを追加</h2>
-  </div>
-  <div class="row">
-    <div class="registration-form py-3 px-md-5 w-100">
-      <%= render 'form', sponsor_form: @sponsor_form %>
-    </div>
-  </div>
+<%= render "layouts/modal", title: "登録" do %>
+  <%= render "form", sponsor_form: @sponsor_form %>
 <% end %>

--- a/app/views/admin/sponsors/update.turbo_stream.erb
+++ b/app/views/admin/sponsors/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace @sponsor, partial: "admin/sponsors/sponsor_row", locals: { sponsor: @sponsor } %>
+<%= turbo_stream.append 'flashes', partial: 'application/flash' %>


### PR DESCRIPTION
- Refactor Admin::SponsorsController to use Hotwire patterns
- Update create/update/destroy actions to use flash.now and turbo_stream responses
- Convert index page to use turbo_frame with modal support
- Update new/edit pages to use modal-based interface
- Add turbo_stream templates for CRUD operations
- Create sponsor_row partial for list display
- Fix SponsorForm sponsor method visibility issue
- Add real-time flash message support

🤖 Generated with [Claude Code](https://claude.ai/code)