### PR TITLE
Dockerfile.devで起動したコンテナ内でbundle installできるようaptパッケージを追加する

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,14 @@
 FROM public.ecr.aws/docker/library/ruby:3.3.6-slim
 WORKDIR /app
-RUN apt-get update && apt-get -y install libmariadb3 libvips42 shared-mime-info git vim curl wget
+RUN apt-get update \
+    && apt-get -y install \
+    build-essential \
+    curl \
+    default-libmysqlclient-dev \
+    git \
+    libmariadb3 \
+    libvips42 \
+    shared-mime-info \
+    vim \
+    wget
 ENV RUBY_YJIT_ENABLE=1


### PR DESCRIPTION
Dockerfile.devでビルドしたコンテナ内でbundle installできたら便利だったので、できるようにした。build-essentialとdefault-libmysqlclient-devを追加し、以下のコマンドが通るようになる。

```sh
docker buildx build -f Dockerfile.dev -t dreamkast-dev .
docker run -it -v $(pwd):/app --rm dreamkast-dev bash
bundle install
```

※dreamkast リポジトリを検索した限りでは Dockerfile.dev は今使われていない。