### PR TITLE
fix: shorten cache life

### DIFF
--- a/app/models/media_package_v2_origin_endpoint.rb
+++ b/app/models/media_package_v2_origin_endpoint.rb
@@ -106,8 +106,9 @@ class MediaPackageV2OriginEndpoint < ApplicationRecord
     distr.distribution_config.origins.items = new_origins
 
     return unless distr.distribution_config.cache_behaviors.items.any? { |behavior| behavior.target_origin_id == origin_endpoint_name }
+    original_cache_behaviors = distr.distribution_config.cache_behaviors.items
     new_cache_behaviors = distr.distribution_config.cache_behaviors.items.reject { |behavior| behavior.target_origin_id == origin_endpoint_name }
-    distr.distribution_config.cache_behaviors.quantity -= 1
+    distr.distribution_config.cache_behaviors.quantity -= original_cache_behaviors.size - new_cache_behaviors.size
     distr.distribution_config.cache_behaviors.items = new_cache_behaviors
 
 
@@ -143,44 +144,76 @@ class MediaPackageV2OriginEndpoint < ApplicationRecord
       }
     }
 
-    new_cache_behavior = {
-      path_pattern: "/out/v1/#{origin_endpoint_name}/*",
-      target_origin_id: origin_endpoint_name.to_s,
-      trusted_signers: {
-        enabled: false,
-        quantity: 0
-      },
-      trusted_key_groups: {
-        enabled: false,
-        quantity: 0
-      },
-      viewer_protocol_policy: 'https-only',
-      allowed_methods: {
-        quantity: 2,
-        items: %w[HEAD GET],
-        cached_methods: {
+    new_cache_behaviors = [
+      {
+        path_pattern: "/out/v1/#{origin_endpoint_name}/*.m3u8",
+        target_origin_id: origin_endpoint_name.to_s,
+        trusted_signers: {
+          enabled: false,
+          quantity: 0
+        },
+        trusted_key_groups: {
+          enabled: false,
+          quantity: 0
+        },
+        viewer_protocol_policy: 'https-only',
+        allowed_methods: {
           quantity: 2,
-          items: %w[HEAD GET]
-        }
+          items: %w[HEAD GET],
+          cached_methods: {
+            quantity: 2,
+            items: %w[HEAD GET]
+          }
+        },
+        smooth_streaming: false,
+        compress: true,
+        lambda_function_associations: {
+          quantity: 0
+        },
+        function_associations: {
+          quantity: 0
+        },
+        field_level_encryption_id: '',
+        cache_policy_id: cache_policy('manifest').id
       },
-      smooth_streaming: false,
-      compress: true,
-      lambda_function_associations: {
-        quantity: 0
-      },
-      function_associations: {
-        quantity: 0
-      },
-      field_level_encryption_id: '',
-      cache_policy_id: cache_policy.id
-    }
-
+      {
+        path_pattern: "/out/v1/#{origin_endpoint_name}/*",
+        target_origin_id: origin_endpoint_name.to_s,
+        trusted_signers: {
+          enabled: false,
+          quantity: 0
+        },
+        trusted_key_groups: {
+          enabled: false,
+          quantity: 0
+        },
+        viewer_protocol_policy: 'https-only',
+        allowed_methods: {
+          quantity: 2,
+          items: %w[HEAD GET],
+          cached_methods: {
+            quantity: 2,
+            items: %w[HEAD GET]
+          }
+        },
+        smooth_streaming: false,
+        compress: true,
+        lambda_function_associations: {
+          quantity: 0
+        },
+        function_associations: {
+          quantity: 0
+        },
+        field_level_encryption_id: '',
+        cache_policy_id: cache_policy('segment').id
+      }
+    ]
     new_origins = distr.distribution_config.origins.items << new_origin
     distr.distribution_config.origins.quantity += 1
     distr.distribution_config.origins.items = new_origins
 
-    new_cache_behaviors = distr.distribution_config.cache_behaviors.items << new_cache_behavior
-    distr.distribution_config.cache_behaviors.quantity += 1
+    new_cache_behaviors = distr.distribution_config.cache_behaviors.items.concat(new_cache_behaviors)
+    distr.distribution_config.cache_behaviors.quantity += new_cache_behaviors.size
     distr.distribution_config.cache_behaviors.items = new_cache_behaviors
 
     cloudfront_client.update_distribution({
@@ -190,7 +223,7 @@ class MediaPackageV2OriginEndpoint < ApplicationRecord
                                           })
   end
 
-  def cache_policy
+  def cache_policy(type)
     marker = nil
     cache_policies = []
     loop do
@@ -200,15 +233,15 @@ class MediaPackageV2OriginEndpoint < ApplicationRecord
       marker = resp.cache_policy_list.next_marker
     end
 
-    cache_policies.find { |policy| policy.cache_policy.cache_policy_config.name == cache_policy_name }.cache_policy
+    cache_policies.find { |policy| policy.cache_policy.cache_policy_config.name == cache_policy_name(type) }.cache_policy
   end
 
-  def cache_policy_name
+  def cache_policy_name(type)
     case env_name
     when 'production'
-      'MediaPackageV2_prd'
+      "MediaPackageV2_#{type}_prd"
     else
-      'MediaPackageV2_stg'
+      "MediaPackageV2_#{type}_stg"
     end
   end
 end


### PR DESCRIPTION
CloudFrontのキャッシュ有効期間を短くする。キャッシュポリシーは https://github.com/cloudnativedaysjp/terraform/pull/234 で作成済み。手元では前日同時間に流したデータが翌日混ざることはなかったが、本当にこれで直るのかはあまり自信がない…