### PR TITLE
talk.registered_talks.profileをN+1引く箇所でeager loadする

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -14,12 +14,12 @@ class AdminController < ApplicationController
   end
 
   def statistics
-    @talks = @conference.talks.includes(:registered_talks).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference.talks.includes(registered_talks: :profile).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
   end
 
   def export_statistics
     f = Tempfile.create('statistics.csv')
-    @conference = Conference.includes(talks: [:registered_talks]).find_by(abbr: params[:event])
+    @conference = Conference.includes(talks: [registered_talks: :profile]).find_by(abbr: params[:event])
     CSV.open(f.path, 'wb') do |csv|
       csv << %w[id item online_participation_size offline_participation_size]
       @conference.talks.accepted.each do |talk|


### PR DESCRIPTION
https://mackerel.io/orgs/cloudnativedays-o11y/traces/458f05b2d082d89fa1751aa12452c47d のように、`GET /:event/admin/statistics` から <code>SELECT `profiles`.* FROM `profiles` WHERE `profiles`.`id` = ? LIMIT ?</code> を一万回以上実行している。(のをたまたまみつけた)

`talk.offline_participation_size` と `talk.online_participation_size` とが、`talk.registered_talks` の `profile.participation` を更に読んで使っている。これをeager loadしておく。
https://github.com/cloudnativedaysjp/dreamkast/blob/8efb284244f64682648947cfb3a5323f72422bc3/app/views/admin/statistics.erb#L27-L28
https://github.com/cloudnativedaysjp/dreamkast/blob/8efb284244f64682648947cfb3a5323f72422bc3/app/models/talk.rb#L436-L442

export_statisticsにもほぼ同じ処理があったのでeager loadしておいた。