### PR TITLE
GET /api/v1/talks で profile をクエリーする回数を減らす

### DIFF
--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -8,10 +8,9 @@ class Api::V1::TalksController < ApplicationController
     conference = Conference.find_by(abbr: params[:eventAbbr])
     query = { conference_id: conference.id }
     query[:track_id] = params[:trackId] if params[:trackId]
-    @talks = Talk
-      .includes(:conference, :conference_day, :talk_time, :talk_difficulty, :talk_category, :talks_speakers, :video, :speakers, registered_talks: :profile)
-      .accepted_and_intermission
-      .where(query)
+    @talks = Talk.includes(:conference, :conference_day, :talk_time, :talk_difficulty, :talk_category, :talks_speakers, :video, :speakers, registered_talks: :profile)
+                 .accepted_and_intermission
+                 .where(query)
     if params[:conferenceDayIds]
       @talks = @talks.where(params[:conferenceDayIds].split(',').map { |id| "conference_day_id = #{id}" }.join(' OR '))
     end


### PR DESCRIPTION
GET /api/v1/talks で SELECT `profiles`.* FROM `profiles` WHERE `profiles`.`id` = ? LIMIT ? を多数回クエリーしている。`talk.offline_participation_size`, `talk.online_participation_size` がこのクエリーを呼んでゐる。

https://github.com/cloudnativedaysjp/dreamkast/blob/1349712ee8c803e481f864304f23b676f06c5abb/app/views/api/v1/talks/index.json.jbuilder#L28-L29
https://github.com/cloudnativedaysjp/dreamkast/blob/1349712ee8c803e481f864304f23b676f06c5abb/app/models/talk.rb#L436-L442

talk.registered_talks の profile を eager load しておく。