### PR TITLE
GET /api/v1/:event/my_profileでundefined method `id' for nilエラーを防ぐ

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -154,11 +154,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_profile
-    @profile = if current_user && (set_conference.opened? || set_conference.registered? || set_conference.closed?)
-                 Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id) || GuestProfile.new
-               else
-                 GuestProfile.new
-               end
+    @profile = (if current_user && (set_conference.opened? || set_conference.registered? || set_conference.closed?)
+                  Profile.find_by(email: current_user[:info][:email], conference_id: set_conference.id)
+                end) || GuestProfile.new
   end
 
   def set_speaker


### PR DESCRIPTION
GET /api/v1/:event/my_profile の処理で undefined method `id' for nil エラーが頻繁に起こっている。エラーが起こっているものの中ではもっともエラー回数が多い。

トレースの例 : https://mackerel.io/orgs/cloudnativedays-o11y/traces/48f142cb7050bf26b47faddcc52add65
<details><summary>undefined method `id' for nil</summary>

```
/app/app/views/api/v1/profiles/my_profile.json.jbuilder:1:in `_app_views_api_v__profiles_my_profile_json_jbuilder___云々_云々: undefined method `id' for nil (ActionView::Template::Error)
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:278:in `public_send'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:278:in `_run'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:284:in `block in render'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:583:in `instrument_render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:272:in `render'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:66:in `block (2 levels) in render_template'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:60:in `block in render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:80:in `render_with_layout'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:59:in `render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:11:in `render'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:58:in `render_template_to_object'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:31:in `render_to_object'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:136:in `block in _render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:305:in `in_rendering_context'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:135:in `_render_template'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/streaming.rb:179:in `_render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:122:in `render_to_body'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:186:in `render_to_body'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/renderers.rb:140:in `render_to_body'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/rendering.rb:28:in `render'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:167:in `render'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:31:in `block (2 levels) in render'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/benchmark.rb:17:in `realtime'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:31:in `block in render'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:100:in `cleanup_view_runtime'
	from /usr/local/bundle/gems/activerecord-8.0.2/lib/active_record/railties/controller_runtime.rb:46:in `cleanup_view_runtime'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:30:in `render'
	from /app/app/controllers/api/v1/profiles_controller.rb:8:in `my_profile'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/basic_implicit_render.rb:8:in `send_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/base.rb:226:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:193:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/callbacks.rb:261:in `block in process_action'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in `block in run_callbacks'
	from /usr/local/bundle/gems/turbo-rails-2.0.5/lib/turbo-rails.rb:24:in `with_request_id'
	from /usr/local/bundle/gems/turbo-rails-2.0.5/app/controllers/concerns/turbo/request_id_tracking.rb:10:in `turbo_tracking_request_id'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `block in run_callbacks'
	from /usr/local/bundle/gems/actiontext-8.0.2/lib/action_text/rendering.rb:25:in `with_renderer'
	from /usr/local/bundle/gems/actiontext-8.0.2/lib/action_text/engine.rb:71:in `block (4 levels) in <class:Engine>'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `instance_exec'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `block in run_callbacks'
	from /usr/local/bundle/gems/sentry-rails-5.25.0/lib/sentry/rails/controller_transaction.rb:34:in `block in sentry_around_action'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/hub.rb:135:in `with_child_span'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry-ruby.rb:536:in `with_child_span'
	from /usr/local/bundle/gems/sentry-rails-5.25.0/lib/sentry/rails/controller_transaction.rb:18:in `sentry_around_action'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `block in run_callbacks'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in `run_callbacks'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/callbacks.rb:260:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rescue.rb:27:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:76:in `block in process_action'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:75:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
	from /usr/local/bundle/gems/activerecord-8.0.2/lib/active_record/railties/controller_runtime.rb:39:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/base.rb:163:in `process'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:40:in `process'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal.rb:252:in `dispatch'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal.rb:335:in `dispatch'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:50:in `serve'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:53:in `block in serve'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:126:in `each'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:126:in `find_routes'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:34:in `serve'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:908:in `call'
	from /usr/local/bundle/gems/prometheus-client-4.0.0/lib/prometheus/middleware/exporter.rb:33:in `call'
	from /usr/local/bundle/gems/omniauth-2.1.3/lib/omniauth/strategy.rb:202:in `call!'
	from /usr/local/bundle/gems/omniauth-2.1.3/lib/omniauth/strategy.rb:169:in `call'
	from /usr/local/bundle/gems/omniauth-2.1.3/lib/omniauth/builder.rb:44:in `call'
	from /app/app/middlewares/rescue_from_invalid_authenticity_token.rb:8:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/tempfile_reaper.rb:20:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/etag.rb:29:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/conditional_get.rb:31:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/head.rb:15:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/http/permissions_policy.rb:38:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/http/content_security_policy.rb:38:in `call'
	from /usr/local/bundle/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:274:in `context'
	from /usr/local/bundle/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:268:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/cookies.rb:706:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:100:in `run_callbacks'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/callbacks.rb:30:in `call'
	from /usr/local/bundle/gems/sentry-rails-5.25.0/lib/sentry/rails/rescued_exception_interceptor.rb:14:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/rack/capture_exceptions.rb:30:in `block (2 levels) in call'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/hub.rb:309:in `with_session_tracking'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry-ruby.rb:430:in `with_session_tracking'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/rack/capture_exceptions.rb:21:in `block in call'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/hub.rb:89:in `with_scope'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry-ruby.rb:410:in `with_scope'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/rack/capture_exceptions.rb:20:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/rack/logger.rb:41:in `call_app'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/rack/logger.rb:29:in `call'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/rack/silence_request.rb:28:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
	from /usr/local/bundle/gems/rack-timeout-0.7.0/lib/rack/timeout/core.rb:154:in `block in call'
	from /usr/local/bundle/gems/rack-timeout-0.7.0/lib/rack/timeout/support/timeout.rb:19:in `timeout'
	from /usr/local/bundle/gems/rack-timeout-0.7.0/lib/rack/timeout/core.rb:153:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/request_id.rb:34:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/method_override.rb:28:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/runtime.rb:24:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/executor.rb:16:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/static.rb:27:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/sendfile.rb:114:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/assume_ssl.rb:24:in `call'
	from /usr/local/bundle/gems/rack-cors-3.0.0/lib/rack/cors.rb:102:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/events.rb:116:in `call'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/engine.rb:535:in `call'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/configuration.rb:279:in `call'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/request.rb:99:in `block in handle_request'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/thread_pool.rb:390:in `with_force_shutdown'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/request.rb:98:in `handle_request'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/server.rb:472:in `process_client'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/server.rb:254:in `block in run'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/thread_pool.rb:167:in `block in spawn_thread'
/app/app/views/api/v1/profiles/my_profile.json.jbuilder:1:in `_app_views_api_v__profiles_my_profile_json_jbuilder___3292902948030115407_120080': undefined method `id' for nil (NoMethodError)
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:278:in `public_send'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:278:in `_run'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:284:in `block in render'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:583:in `instrument_render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/template.rb:272:in `render'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:66:in `block (2 levels) in render_template'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:60:in `block in render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:80:in `render_with_layout'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:59:in `render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/template_renderer.rb:11:in `render'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:58:in `render_template_to_object'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:31:in `render_to_object'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:136:in `block in _render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/base.rb:305:in `in_rendering_context'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:135:in `_render_template'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/streaming.rb:179:in `_render_template'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:122:in `render_to_body'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:186:in `render_to_body'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/renderers.rb:140:in `render_to_body'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/rendering.rb:28:in `render'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:167:in `render'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:31:in `block (2 levels) in render'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/benchmark.rb:17:in `realtime'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:31:in `block in render'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:100:in `cleanup_view_runtime'
	from /usr/local/bundle/gems/activerecord-8.0.2/lib/active_record/railties/controller_runtime.rb:46:in `cleanup_view_runtime'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:30:in `render'
	from /app/app/controllers/api/v1/profiles_controller.rb:8:in `my_profile'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/basic_implicit_render.rb:8:in `send_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/base.rb:226:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:193:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/callbacks.rb:261:in `block in process_action'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in `block in run_callbacks'
	from /usr/local/bundle/gems/turbo-rails-2.0.5/lib/turbo-rails.rb:24:in `with_request_id'
	from /usr/local/bundle/gems/turbo-rails-2.0.5/app/controllers/concerns/turbo/request_id_tracking.rb:10:in `turbo_tracking_request_id'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `block in run_callbacks'
	from /usr/local/bundle/gems/actiontext-8.0.2/lib/action_text/rendering.rb:25:in `with_renderer'
	from /usr/local/bundle/gems/actiontext-8.0.2/lib/action_text/engine.rb:71:in `block (4 levels) in <class:Engine>'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `instance_exec'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `block in run_callbacks'
	from /usr/local/bundle/gems/sentry-rails-5.25.0/lib/sentry/rails/controller_transaction.rb:34:in `block in sentry_around_action'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/hub.rb:135:in `with_child_span'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry-ruby.rb:536:in `with_child_span'
	from /usr/local/bundle/gems/sentry-rails-5.25.0/lib/sentry/rails/controller_transaction.rb:18:in `sentry_around_action'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `block in run_callbacks'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in `run_callbacks'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/callbacks.rb:260:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/rescue.rb:27:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:76:in `block in process_action'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:75:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
	from /usr/local/bundle/gems/activerecord-8.0.2/lib/active_record/railties/controller_runtime.rb:39:in `process_action'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/abstract_controller/base.rb:163:in `process'
	from /usr/local/bundle/gems/actionview-8.0.2/lib/action_view/rendering.rb:40:in `process'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal.rb:252:in `dispatch'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_controller/metal.rb:335:in `dispatch'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:50:in `serve'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:53:in `block in serve'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:126:in `each'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:126:in `find_routes'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:34:in `serve'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:908:in `call'
	from /usr/local/bundle/gems/prometheus-client-4.0.0/lib/prometheus/middleware/exporter.rb:33:in `call'
	from /usr/local/bundle/gems/omniauth-2.1.3/lib/omniauth/strategy.rb:202:in `call!'
	from /usr/local/bundle/gems/omniauth-2.1.3/lib/omniauth/strategy.rb:169:in `call'
	from /usr/local/bundle/gems/omniauth-2.1.3/lib/omniauth/builder.rb:44:in `call'
	from /app/app/middlewares/rescue_from_invalid_authenticity_token.rb:8:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/tempfile_reaper.rb:20:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/etag.rb:29:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/conditional_get.rb:31:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/head.rb:15:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/http/permissions_policy.rb:38:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/http/content_security_policy.rb:38:in `call'
	from /usr/local/bundle/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:274:in `context'
	from /usr/local/bundle/gems/rack-session-2.1.1/lib/rack/session/abstract/id.rb:268:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/cookies.rb:706:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
	from /usr/local/bundle/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:100:in `run_callbacks'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/callbacks.rb:30:in `call'
	from /usr/local/bundle/gems/sentry-rails-5.25.0/lib/sentry/rails/rescued_exception_interceptor.rb:14:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/rack/capture_exceptions.rb:30:in `block (2 levels) in call'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/hub.rb:309:in `with_session_tracking'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry-ruby.rb:430:in `with_session_tracking'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/rack/capture_exceptions.rb:21:in `block in call'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/hub.rb:89:in `with_scope'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry-ruby.rb:410:in `with_scope'
	from /usr/local/bundle/gems/sentry-ruby-5.25.0/lib/sentry/rack/capture_exceptions.rb:20:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/rack/logger.rb:41:in `call_app'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/rack/logger.rb:29:in `call'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/rack/silence_request.rb:28:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
	from /usr/local/bundle/gems/rack-timeout-0.7.0/lib/rack/timeout/core.rb:154:in `block in call'
	from /usr/local/bundle/gems/rack-timeout-0.7.0/lib/rack/timeout/support/timeout.rb:19:in `timeout'
	from /usr/local/bundle/gems/rack-timeout-0.7.0/lib/rack/timeout/core.rb:153:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/request_id.rb:34:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/method_override.rb:28:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/runtime.rb:24:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/executor.rb:16:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/static.rb:27:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/sendfile.rb:114:in `call'
	from /usr/local/bundle/gems/actionpack-8.0.2/lib/action_dispatch/middleware/assume_ssl.rb:24:in `call'
	from /usr/local/bundle/gems/rack-cors-3.0.0/lib/rack/cors.rb:102:in `call'
	from /usr/local/bundle/gems/rack-3.1.16/lib/rack/events.rb:116:in `call'
	from /usr/local/bundle/gems/railties-8.0.2/lib/rails/engine.rb:535:in `call'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/configuration.rb:279:in `call'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/request.rb:99:in `block in handle_request'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/thread_pool.rb:390:in `with_force_shutdown'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/request.rb:98:in `handle_request'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/server.rb:472:in `process_client'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/server.rb:254:in `block in run'
	from /usr/local/bundle/gems/puma-6.6.0/lib/puma/thread_pool.rb:167:in `block in spawn_thread'
```
</details>

my_profile の view が、`@profile` が nil である場合にこのエラーが起こるようになっている。
常に GuestProfile にフォールバックしてよいのではないか?