### PR TITLE
GET /api/v1/talksでproposal_items: :proposal_item_configsをeager loadする

### DIFF
--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -8,7 +8,19 @@ class Api::V1::TalksController < ApplicationController
     conference = Conference.find_by(abbr: params[:eventAbbr])
     query = { conference_id: conference.id }
     query[:track_id] = params[:trackId] if params[:trackId]
-    @talks = Talk.includes(:conference, :conference_day, :talk_time, :talk_difficulty, :talk_category, :talks_speakers, :video, :speakers, registered_talks: :profile)
+    @talks = Talk.includes(
+      :conference,
+      :conference_day,
+      :talk_time,
+      :talk_difficulty,
+      :talk_category,
+      :talks_speakers,
+      :video,
+      :speakers,
+      :sponsor,
+      proposal_items: :proposal_item_configs,
+      registered_talks: :profile
+    )
                  .accepted_and_intermission
                  .where(query)
     if params[:conferenceDayIds]


### PR DESCRIPTION
https://mackerel.io/orgs/cloudnativedays-o11y/traces/5fc62626a622fe1d0e03553e53c13ebf のように、GET /api/v1/talksにまだN+1が起こっている。SELECT `proposal_items`.* FROM `proposal_items` WHERE `proposal_items`.`talk_id` = ? AND `proposal_items`.`label` = ? LIMIT ?をたくさん引いている。
eager loadする。