### PR TITLE
chore(deps): Bundler バージョンを 4.0.5 に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -871,4 +871,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   2.5.22
+  4.0.5


### PR DESCRIPTION
## Summary

- Gemfile.lock の `BUNDLED WITH` を 2.5.22 から 4.0.5 に更新

## Background

Ruby 3.4.8 と Bundler 2.5.22 の間に互換性問題があり、devbox 環境で `private method 'default_stubs' called for Gem::Specification:Class` エラーが発生していました。

Bundler を 4.0.5 に更新することで、この問題を解決します。

## Test plan

- [x] devbox run setup が正常に完了することを確認
- [ ] CI が成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)