### PR TITLE
fix: reusable workflowで未定義のplatforms入力を削除

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -13,6 +13,5 @@ jobs:
       id-token: write
     with:
       image_name: dreamkast-ecs
-      platforms: amd64
       aws_region: us-west-2
       run-trivy: true

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -12,6 +12,5 @@ jobs:
       id-token: write
     with:
       image_name: dreamkast-ecs
-      platforms: amd64
       aws_region: ap-northeast-1
       run-trivy: false


### PR DESCRIPTION
## Summary
- `wc-build-image.yml@main` が受け付けない `platforms: amd64` 入力を `build-branch.yml` / `build-tag.yml` から削除
- 参照先 reusable workflow は matrix で amd64/arm64 を内部ビルドする仕様のため、入力そのものが無効だった

## Test plan
- [ ] ブランチ push で `build-branch.yml` が正常に起動しイメージがビルドされること
- [ ] タグ push で `build-tag.yml` が正常に起動しイメージがビルドされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)