### PR TITLE
feat: SpeakerによるQA質問の非表示モデレーションを追加

### DIFF
--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -140,6 +140,7 @@ class SpeakerDashboardsController < ApplicationController
     if @question.update(hidden: !@question.hidden)
       status = @question.hidden? ? '非表示' : '表示'
       flash.now[:notice] = "質問を#{status}にしました"
+      broadcast_question_toggled(@question)
       respond_to do |format|
         format.turbo_stream
         format.html { redirect_to speaker_dashboard_questions_path(event: @conference.abbr) }
@@ -252,6 +253,24 @@ class SpeakerDashboardsController < ApplicationController
       )
     rescue StandardError => e
       Rails.logger.error "Error broadcasting answer_deleted: #{e.class} - #{e.message}"
+      # ブロードキャストエラーは無視して処理を続行
+    end
+  end
+
+  def broadcast_question_toggled(question)
+    begin
+      talk = question.talk
+
+      ActionCable.server.broadcast(
+        "qa_talk_#{talk.id}",
+        {
+          type: 'question_toggled',
+          question_id: question.id,
+          hidden: question.hidden
+        }
+      )
+    rescue StandardError => e
+      Rails.logger.error "Error broadcasting question_toggled: #{e.class} - #{e.message}"
       # ブロードキャストエラーは無視して処理を続行
     end
   end

--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -121,6 +121,35 @@ class SpeakerDashboardsController < ApplicationController
     end
   end
 
+  def toggle_question_hidden
+    @talk = @speaker.talks.find_by(id: params[:talk_id])
+    unless @talk
+      flash[:alert] = 'このセッションの登壇者ではありません'
+      redirect_to speaker_dashboard_path(event: @conference.abbr)
+      return
+    end
+
+    @question = @talk.session_questions.find(params[:id])
+
+    unless @talk.speakers.include?(@speaker)
+      flash[:alert] = 'このセッションの登壇者ではありません'
+      redirect_to speaker_dashboard_path(event: @conference.abbr)
+      return
+    end
+
+    if @question.update(hidden: !@question.hidden)
+      status = @question.hidden? ? '非表示' : '表示'
+      flash.now[:notice] = "質問を#{status}にしました"
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to speaker_dashboard_questions_path(event: @conference.abbr) }
+      end
+    else
+      flash[:alert] = '状態の変更に失敗しました'
+      redirect_to speaker_dashboard_questions_path(event: @conference.abbr)
+    end
+  end
+
   def talks
     @talks = @speaker ? @speaker.talks.not_sponsor : []
     @speaker_announcements = @conference.speaker_announcements.find_by_speaker(@speaker.id) unless @speaker.nil?
@@ -145,7 +174,6 @@ class SpeakerDashboardsController < ApplicationController
                             end
 
         @all_questions = @conference.session_questions
-                                    .visible
                                     .where(talk_id: filtered_talk_ids)
                                     .includes(:talk, :profile, :session_question_answers, :session_question_votes)
                                     .order_by_time

--- a/app/views/speaker_dashboards/_question_item.html.erb
+++ b/app/views/speaker_dashboards/_question_item.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag "question_#{question.id}" do %>
-  <div class="mb-4 p-3" style="border: 1px solid #dee2e6; border-radius: 4px;" id="question_<%= question.id %>">
+  <div class="mb-4 p-3" style="border: 1px solid #dee2e6; border-radius: 4px; <%= 'opacity: 0.6;' if question.hidden? %>">
     <div class="mb-2">
-      <strong>セッション:</strong> 
+      <strong>セッション:</strong>
       <%= link_to question.talk.title, talk_path(id: question.talk.id, event: @conference&.abbr || event_name), target: '_blank' %>
     </div>
-    
+
     <div class="d-flex justify-content-between align-items-start mb-2">
       <div class="flex-grow-1">
         <strong>Q:</strong> <%= simple_format(h(question.body)) %>
@@ -12,6 +12,29 @@
           <span>投票数: <%= question.votes_count %></span>
           <span class="ms-2"><%= question.created_at.strftime('%Y/%m/%d %H:%M') %></span>
         </div>
+      </div>
+      <div class="ms-2">
+        <% if question.hidden? %>
+          <span class="badge bg-warning text-dark me-2">非表示</span>
+          <%= button_to '表示する',
+              speaker_dashboard_talk_session_question_toggle_hidden_path(
+                talk_id: question.talk.id,
+                id: question.id,
+                event: @conference&.abbr || event_name
+              ),
+              method: :patch,
+              class: 'btn btn-sm btn-success' %>
+        <% else %>
+          <%= button_to '非表示にする',
+              speaker_dashboard_talk_session_question_toggle_hidden_path(
+                talk_id: question.talk.id,
+                id: question.id,
+                event: @conference&.abbr || event_name
+              ),
+              method: :patch,
+              class: 'btn btn-sm btn-warning',
+              data: { turbo_confirm: '本当に非表示にしますか？' } %>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/speaker_dashboards/toggle_question_hidden.turbo_stream.erb
+++ b/app/views/speaker_dashboards/toggle_question_hidden.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "question_#{@question.id}" do %>
+  <%= render 'speaker_dashboards/question_item', question: @question %>
+<% end %>
+
+<%= turbo_stream_flash %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,7 @@ Rails.application.routes.draw do
     get '/speaker_dashboard/questions' => 'speaker_dashboards#questions', as: 'speaker_dashboard_questions'
     post '/speaker_dashboard/talks/:talk_id/session_questions/:session_question_id/answers' => 'speaker_dashboards#create_answer', as: 'speaker_dashboard_talk_session_question_answer'
     delete '/speaker_dashboard/talks/:talk_id/session_questions/:session_question_id/answers/:id' => 'speaker_dashboards#destroy_answer', as: 'speaker_dashboard_talk_session_question_answer_delete'
+    patch '/speaker_dashboard/talks/:talk_id/session_questions/:id/toggle_hidden' => 'speaker_dashboards#toggle_question_hidden', as: 'speaker_dashboard_talk_session_question_toggle_hidden'
     namespace :speaker_dashboard do
       resources :speakers, only: [:new, :edit, :create, :update]
       resources :video_registrations, only: [:new, :create, :edit, :update]

--- a/spec/requests/speaker_dashboards/qa_spec.rb
+++ b/spec/requests/speaker_dashboards/qa_spec.rb
@@ -214,6 +214,16 @@ describe SpeakerDashboardsController, type: :request do
 
         expect(response).to have_http_status(:ok)
       end
+
+      it 'broadcasts via ActionCable when toggling' do
+        expect(ActionCable.server).to receive(:broadcast).with(
+          "qa_talk_#{talk.id}",
+          hash_including(type: 'question_toggled', question_id: question.id, hidden: true)
+        )
+
+        patch "/cndt2020/speaker_dashboard/talks/#{talk.id}/session_questions/#{question.id}/toggle_hidden",
+              headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+      end
     end
 
     context 'when the speaker is not associated with the talk' do

--- a/spec/requests/speaker_dashboards/qa_spec.rb
+++ b/spec/requests/speaker_dashboards/qa_spec.rb
@@ -62,10 +62,9 @@ describe SpeakerDashboardsController, type: :request do
       expect(response.body).to include(question2.body)
     end
 
-    it 'excludes hidden questions' do
+    it 'includes hidden questions so speakers can moderate them' do
       get '/cndt2020/speaker_dashboard/questions'
-      # すべての質問が同じbodyを持つ可能性があるため、IDで判定する
-      expect(response.body).not_to include("question_#{hidden_question.id}")
+      expect(response.body).to include("question_#{hidden_question.id}")
     end
 
     context 'with unanswered filter' do
@@ -187,6 +186,62 @@ describe SpeakerDashboardsController, type: :request do
         expect(response).to redirect_to('/cndt2020/speaker_dashboard')
         follow_redirect!
         expect(response.body).to include('このセッションの登壇者ではありません')
+      end
+    end
+  end
+
+  describe 'PATCH /:event/speaker_dashboard/talks/:talk_id/session_questions/:id/toggle_hidden' do
+    let!(:question) { create(:session_question, talk:, conference:, profile:) }
+
+    context 'when toggling own talk question' do
+      it 'hides a visible question' do
+        expect {
+          patch "/cndt2020/speaker_dashboard/talks/#{talk.id}/session_questions/#{question.id}/toggle_hidden",
+                headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+        }.to change { question.reload.hidden }.from(false).to(true)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include('text/vnd.turbo-stream.html')
+      end
+
+      it 'unhides a hidden question' do
+        question.update!(hidden: true)
+
+        expect {
+          patch "/cndt2020/speaker_dashboard/talks/#{talk.id}/session_questions/#{question.id}/toggle_hidden",
+                headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+        }.to change { question.reload.hidden }.from(true).to(false)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the speaker is not associated with the talk' do
+      let!(:other_talk) { create(:talk2, conference:) }
+      let!(:other_question) { create(:session_question, talk: other_talk, conference:, profile:) }
+
+      it 'does not change hidden state and redirects' do
+        expect {
+          patch "/cndt2020/speaker_dashboard/talks/#{other_talk.id}/session_questions/#{other_question.id}/toggle_hidden"
+        }.not_to(change { other_question.reload.hidden })
+
+        expect(response).to redirect_to('/cndt2020/speaker_dashboard')
+        expect(flash[:alert]).to eq('このセッションの登壇者ではありません')
+      end
+    end
+
+    context 'when talk_id and question belong to different talks' do
+      let!(:other_talk) { create(:talk2, conference:) }
+      let!(:other_question) { create(:session_question, talk: other_talk, conference:, profile:) }
+
+      before { other_talk.speakers << speaker }
+
+      it 'does not change hidden state when question does not belong to the talk' do
+        expect {
+          patch "/cndt2020/speaker_dashboard/talks/#{talk.id}/session_questions/#{other_question.id}/toggle_hidden"
+        }.not_to(change { other_question.reload.hidden })
+
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Speakerが自セッションに紐づくQA質問を非表示／再表示できるように（Admin同等の `toggle_hidden` を Speaker Dashboard に追加）
- `speaker_dashboards#questions` から `.visible` スコープを外し、非表示質問もスピーカー視点で一覧に含めて dim表示 + バッジ + トグルボタンを提示
- 権限チェックは既存の回答系アクションと同じパターン（`@speaker.talks.find_by` と `@talk.session_questions.find` のスコープチェック）を流用。自セッションでなければリダイレクト、talk不一致なら404
- 物理削除はAdminにも無いため付与しない

## Test plan
- [x] `bundle exec rspec spec/requests/speaker_dashboards/qa_spec.rb` — 追加した4テスト含め該当範囲はパス（失敗2件は main でも再現する既存issue）
- [x] `bundle exec rubocop app/controllers/speaker_dashboards_controller.rb config/routes.rb spec/requests/speaker_dashboards/qa_spec.rb` — no offenses
- [ ] Speaker Dashboard で自セッションの質問を非表示/再表示できることを確認
- [ ] 他セッションの質問への toggle_hidden が拒否されることを確認
- [ ] 非表示化後、公開API (`GET /api/v1/talks/:id/session_questions`) の応答から該当質問が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)