### PR TITLE
fix: SponsorContact削除時のFK制約違反を修正

### DIFF
--- a/app/models/sponsor_contact.rb
+++ b/app/models/sponsor_contact.rb
@@ -5,6 +5,7 @@ class SponsorContact < ApplicationRecord
   belongs_to :sponsor
   belongs_to :user, optional: true
   has_many :sponsor_contact_invite_accepts, dependent: :destroy
+  has_many :sponsor_speaker_invite_accepts, dependent: :destroy
 
   before_validation :ensure_user, on: :create
 

--- a/spec/models/sponsor_contact_spec.rb
+++ b/spec/models/sponsor_contact_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe(SponsorContact, type: :model) do
+  describe '#destroy' do
+    let!(:conference) { create(:cndt2020, :registered) }
+    let!(:sponsor) { create(:sponsor, conference:) }
+    let!(:sponsor_contact) { create(:sponsor_contact, conference:, sponsor:) }
+
+    context '紐づく SponsorSpeakerInviteAccept が存在する場合' do
+      let!(:speaker) do
+        create(:speaker, conference:, name: 'Invited', profile: 'p', company: 'c', job_title: 'j')
+      end
+      let!(:sponsor_speaker_invite) { create(:sponsor_speaker_invite, conference:, sponsor:) }
+      let!(:sponsor_speaker_invite_accept) do
+        create(:sponsor_speaker_invite_accept,
+               conference:,
+               sponsor:,
+               sponsor_contact:,
+               speaker:,
+               sponsor_speaker_invite:)
+      end
+
+      it 'FK制約違反で落ちずに削除できる' do
+        expect { sponsor_contact.destroy }.not_to(raise_error)
+        expect(SponsorContact.exists?(sponsor_contact.id)).to(be(false))
+      end
+
+      it '紐づく SponsorSpeakerInviteAccept も一緒に削除される' do
+        expect { sponsor_contact.destroy }.to(change(SponsorSpeakerInviteAccept, :count).by(-1))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- スポンサー登壇者招待の承諾時に作られた `SponsorContact` を削除しようとすると、`sponsor_speaker_invite_accepts.sponsor_contact_id` の外部キー制約違反で `ActiveRecord::InvalidForeignKey` が発生する問題を修正
- `SponsorContact` に `has_many :sponsor_speaker_invite_accepts, dependent: :destroy` を追加し、Rails が親削除前に子レコードを先に destroy するようにする

## 背景
production で以下のエラーが発生:

```
POST /:event/sponsor_dashboards/:sponsor_id/sponsor_contacts/:id
Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails
(`dreamkast`.`sponsor_speaker_invite_accepts`,
 CONSTRAINT `fk_rails_c6319e8afb` FOREIGN KEY (`sponsor_contact_id`) REFERENCES `sponsor_contacts` (`id`))
```

`SponsorContact` モデルには `has_many :sponsor_contact_invite_accepts, dependent: :destroy` はあるが、`sponsor_speaker_invite_accepts` 側の宣言が無く、DB の FK にも `on_delete: :cascade` が無かったため発生。

## Test plan
- [x] `spec/models/sponsor_contact_spec.rb` を追加し、紐づく `SponsorSpeakerInviteAccept` が存在する場合でも `SponsorContact#destroy` が FK 違反で落ちず、関連レコードも一緒に削除されることを確認
- [x] 既存の `spec/requests/sponsor_dashboards/sponsor_contacts_destroy_spec.rb` に影響がないことを確認（asset pipeline 起因の既存 failure は base commit 時点から発生しており本PRと無関係）
- [x] `bundle exec rubocop` クリーン

## Note
このPRは最小修正のみです。スポンサー登壇者招待フロー全体の設計課題（既存プロポーザル Speaker に sponsor_id が上書きされない/されても副作用がある、等）は別途対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)