### PR TITLE
refactor: Sponsor#speakers の判定改修 + destroy セマンティクス見直し + 1:1 制約強制

### DIFF
--- a/app/controllers/sponsor_dashboards/sponsor_speakers_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_speakers_controller.rb
@@ -70,24 +70,24 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
   end
 
   # DELETE /:event/sponsor_dashboards/:sponsor_id/speakers/:id
+  # Speaker 本体は削除せず、このスポンサーとの紐付け（sponsor_id と
+  # SponsorSpeakerInviteAccept）のみを解除する。Speaker は他のスポンサーや
+  # 通常プロポーザルからも参照されうるため。
   def destroy
     @sponsor = Sponsor.find(params[:sponsor_id])
     @speaker = Speaker.find(params[:id])
     authorize([:sponsor_dashboards, @speaker])
 
-    # スポンサーセッションと紐付いているかチェック
-    if @speaker.talks.present?
-      flash.now[:alert] = 'スポンサーセッションと紐付いているため削除できません'
-      return
+    ActiveRecord::Base.transaction do
+      @sponsor.sponsor_speaker_invite_accepts.where(speaker_id: @speaker.id).destroy_all
+      @speaker.update!(sponsor_id: nil) if @speaker.sponsor_id == @sponsor.id
     end
 
-    if @speaker.destroy
-      @sponsor_speakers = @sponsor.speakers
-      @sponsor_speaker_invites = @sponsor.sponsor_speaker_invites
-      flash.now[:notice] = 'スポンサー登壇者を削除しました'
-    else
-      flash.now[:alert] = 'スポンサー登壇者の削除に失敗しました'
-    end
+    @sponsor_speakers = @sponsor.speakers
+    @sponsor_speaker_invites = @sponsor.sponsor_speaker_invites
+    flash.now[:notice] = 'スポンサー登壇者から外しました'
+  rescue ActiveRecord::RecordInvalid
+    flash.now[:alert] = 'スポンサー登壇者の削除に失敗しました'
   end
 
   private

--- a/app/controllers/sponsor_dashboards/sponsor_speakers_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_speakers_controller.rb
@@ -70,9 +70,10 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
   end
 
   # DELETE /:event/sponsor_dashboards/:sponsor_id/speakers/:id
-  # Speaker 本体は削除せず、このスポンサーとの紐付け（sponsor_id と
-  # SponsorSpeakerInviteAccept）のみを解除する。Speaker は他のスポンサーや
-  # 通常プロポーザルからも参照されうるため。
+  # スポンサーとのみ紐付いている Speaker（Talk を持たない = 純粋なスポンサー
+  # 登壇者招待で作られた Speaker）は本体ごと削除する。Talk を持つ Speaker
+  # （CFP 経由でプロポーザルを出している等）は本体を残し、このスポンサーとの
+  # 紐付け（sponsor_id と SponsorSpeakerInviteAccept）のみを解除する。
   def destroy
     @sponsor = Sponsor.find(params[:sponsor_id])
     @speaker = Speaker.find(params[:id])
@@ -80,7 +81,11 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
 
     ActiveRecord::Base.transaction do
       @sponsor.sponsor_speaker_invite_accepts.where(speaker_id: @speaker.id).destroy_all
-      @speaker.update!(sponsor_id: nil) if @speaker.sponsor_id == @sponsor.id
+      if @speaker.talks.empty?
+        @speaker.destroy!
+      elsif @speaker.sponsor_id == @sponsor.id
+        @speaker.update!(sponsor_id: nil)
+      end
     end
 
     @sponsor_speakers = @sponsor.speakers

--- a/app/controllers/sponsor_speaker_invite_accepts_controller.rb
+++ b/app/controllers/sponsor_speaker_invite_accepts_controller.rb
@@ -73,7 +73,8 @@ class SponsorSpeakerInviteAcceptsController < ApplicationController
       end
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error(e)
-      render(:new, alert: e.message)
+      flash.now[:alert] = e.record.errors.full_messages.join(', ')
+      render(:new)
     end
   end
 

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -8,9 +8,15 @@ class Sponsor < ApplicationRecord
   has_many :sponsors_sponsor_types, dependent: :delete_all
   has_many :sponsor_types, through: :sponsors_sponsor_types
   has_many :talks
-  has_many :speakers
   has_many :stamp_rally_check_point_booths
   has_many :sponsor_speaker_invites, dependent: :delete_all
+  has_many :sponsor_speaker_invite_accepts, dependent: :destroy
+
+  def speakers
+    Speaker.where(sponsor_id: id)
+           .or(Speaker.where(id: sponsor_speaker_invite_accepts.select(:speaker_id)))
+           .distinct
+  end
 
   def booth_sponsor?
     sponsor_types.each do |type|

--- a/app/models/sponsor_speaker_invite_accept.rb
+++ b/app/models/sponsor_speaker_invite_accept.rb
@@ -4,4 +4,11 @@ class SponsorSpeakerInviteAccept < ApplicationRecord
   belongs_to :sponsor_contact
   belongs_to :speaker
   belongs_to :sponsor_speaker_invite, dependent: :destroy
+
+  # 1 Speaker は 1 Conference 内で高々 1 Sponsor にしか紐付かない
+  validates :speaker_id,
+            uniqueness: {
+              scope: :conference_id,
+              message: 'はすでに別スポンサーの登壇者として登録されています'
+            }
 end

--- a/app/policies/sponsor_dashboards/speaker_policy.rb
+++ b/app/policies/sponsor_dashboards/speaker_policy.rb
@@ -19,6 +19,12 @@ class SponsorDashboards::SpeakerPolicy < ApplicationPolicy
   private
 
   def belongs_to_my_sponsor?
-    speaker.present? && record.sponsor_id == speaker.sponsor_id
+    return false unless speaker
+
+    # 経路1: 直接紐付く Speaker（legacy）
+    return true if record.sponsor_id == speaker.sponsor_id
+
+    # 経路2: SponsorSpeakerInviteAccept 経由（既存プロポーザル由来など）
+    SponsorSpeakerInviteAccept.where(speaker_id: record.id, sponsor_id: speaker.sponsor_id).exists?
   end
 end

--- a/db/migrate/20260417101147_add_unique_index_on_speaker_to_sponsor_speaker_invite_accepts.rb
+++ b/db/migrate/20260417101147_add_unique_index_on_speaker_to_sponsor_speaker_invite_accepts.rb
@@ -1,0 +1,10 @@
+class AddUniqueIndexOnSpeakerToSponsorSpeakerInviteAccepts < ActiveRecord::Migration[7.0]
+  # 1 Speaker は 1 Conference 内で高々 1 Sponsor にしか紐付かない（Speaker : Sponsor = 1:1）
+  # という不変条件を DB レベルでも強制する
+  def change
+    add_index :sponsor_speaker_invite_accepts,
+              [:conference_id, :speaker_id],
+              unique: true,
+              name: 'idx_spk_inv_accepts_on_conf_speaker_uniq'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_02_22_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_17_101147) do
   create_table "admin_profiles", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.string "name"
@@ -565,6 +565,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_22_000001) do
     t.bigint "speaker_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["conference_id", "speaker_id"], name: "idx_spk_inv_accepts_on_conf_speaker_uniq", unique: true
     t.index ["conference_id", "sponsor_id", "speaker_id", "sponsor_contact_id"], name: "idx_spk_inv_accepts_on_conf_spsr_speaker_contact", unique: true
     t.index ["conference_id"], name: "index_sponsor_speaker_invite_accepts_on_conference_id"
     t.index ["speaker_id"], name: "index_sponsor_speaker_invite_accepts_on_speaker_id"

--- a/spec/models/sponsor_speaker_invite_accept_spec.rb
+++ b/spec/models/sponsor_speaker_invite_accept_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe(SponsorSpeakerInviteAccept, type: :model) do
+  describe 'Speaker : Sponsor の 1:1 制約' do
+    let!(:conference) { create(:cndt2020, :registered) }
+    let!(:sponsor_a) { create(:sponsor, id: 1, conference:, abbr: 'sponsor_a') }
+    let!(:sponsor_b) { create(:sponsor, id: 2, conference:, abbr: 'sponsor_b') }
+    let!(:sponsor_a_contact) { create(:sponsor_contact, conference:, sponsor: sponsor_a) }
+    let!(:sponsor_b_contact) { create(:sponsor_contact, conference:, sponsor: sponsor_b) }
+    let!(:speaker) { create(:speaker, conference:, name: 'n', profile: 'p', company: 'c', job_title: 'j') }
+    let!(:invite_a) { create(:sponsor_speaker_invite, conference:, sponsor: sponsor_a) }
+    let!(:invite_b) { create(:sponsor_speaker_invite, conference:, sponsor: sponsor_b) }
+    let!(:first_accept) do
+      create(:sponsor_speaker_invite_accept,
+             conference:, sponsor: sponsor_a, sponsor_contact: sponsor_a_contact,
+             speaker:, sponsor_speaker_invite: invite_a)
+    end
+
+    it '同じ (conference, speaker) で別 sponsor の 2つ目の InviteAccept は作成できない' do
+      duplicate = SponsorSpeakerInviteAccept.new(
+        conference:, sponsor: sponsor_b, sponsor_contact: sponsor_b_contact,
+        speaker:, sponsor_speaker_invite: invite_b
+      )
+
+      expect(duplicate).not_to(be_valid)
+      expect(duplicate.errors[:speaker_id]).to(include(match(/別スポンサー/)))
+    end
+
+    it '別 conference の場合は作成できる' do
+      another_conference = create(:cndo2021, :registered)
+      another_sponsor = create(:sponsor, id: 99, conference: another_conference, abbr: 'other')
+      another_contact = create(:sponsor_contact, conference: another_conference, sponsor: another_sponsor)
+      another_speaker = create(:speaker, conference: another_conference, name: 'n', profile: 'p', company: 'c', job_title: 'j', user_id: speaker.user_id)
+      another_invite = create(:sponsor_speaker_invite, conference: another_conference, sponsor: another_sponsor)
+
+      another_accept = SponsorSpeakerInviteAccept.new(
+        conference: another_conference, sponsor: another_sponsor, sponsor_contact: another_contact,
+        speaker: another_speaker, sponsor_speaker_invite: another_invite
+      )
+
+      expect(another_accept).to(be_valid)
+    end
+  end
+end

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe(Sponsor, type: :model) do
+  describe '#speakers' do
+    let!(:conference) { create(:cndt2020, :registered) }
+    let!(:sponsor) { create(:sponsor, conference:) }
+    let(:speaker_attrs) { { conference:, name: 'n', profile: 'p', company: 'c', job_title: 'j' } }
+
+    context 'Speaker が sponsor_id で紐付いている場合（互換性維持）' do
+      let!(:speaker) { create(:speaker, **speaker_attrs, sponsor:) }
+
+      it '@sponsor.speakers に含まれる' do
+        expect(sponsor.speakers).to(include(speaker))
+      end
+    end
+
+    context 'Speaker が SponsorSpeakerInviteAccept のみで紐付いている場合（既存プロポーザル由来など）' do
+      let!(:speaker) { create(:speaker, **speaker_attrs, sponsor: nil) }
+      let!(:sponsor_contact) { create(:sponsor_contact, conference:, sponsor:) }
+      let!(:invite) { create(:sponsor_speaker_invite, conference:, sponsor:) }
+      let!(:invite_accept) do
+        create(:sponsor_speaker_invite_accept,
+               conference:, sponsor:, sponsor_contact:, speaker:, sponsor_speaker_invite: invite)
+      end
+
+      it '@sponsor.speakers に含まれる' do
+        expect(sponsor.speakers).to(include(speaker))
+      end
+    end
+
+    context 'Speaker が sponsor_id と SponsorSpeakerInviteAccept の両方で紐付いている場合' do
+      let!(:speaker) { create(:speaker, **speaker_attrs, sponsor:) }
+      let!(:sponsor_contact) { create(:sponsor_contact, conference:, sponsor:) }
+      let!(:invite) { create(:sponsor_speaker_invite, conference:, sponsor:) }
+      let!(:invite_accept) do
+        create(:sponsor_speaker_invite_accept,
+               conference:, sponsor:, sponsor_contact:, speaker:, sponsor_speaker_invite: invite)
+      end
+
+      it '@sponsor.speakers に重複せず1件だけ含まれる' do
+        expect(sponsor.speakers.where(id: speaker.id).count).to(eq(1))
+      end
+    end
+
+    context '別スポンサーの Speaker は含まれない' do
+      let!(:other_sponsor) { create(:sponsor, conference:, id: 2, abbr: 'sponsor2') }
+      let!(:other_speaker) { create(:speaker, **speaker_attrs, sponsor: other_sponsor) }
+
+      it '@sponsor.speakers に含まれない' do
+        expect(sponsor.speakers).not_to(include(other_speaker))
+      end
+    end
+  end
+end

--- a/spec/requests/sponsor_dashboards/sponsor_speakers_destroy_spec.rb
+++ b/spec/requests/sponsor_dashboards/sponsor_speakers_destroy_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe(SponsorDashboards::SponsorSpeakersController, type: :request) do
+  describe 'DELETE #destroy のセマンティクス' do
+    let!(:conference) { create(:cndt2020, :registered) }
+    let!(:sponsor) { create(:sponsor, conference:) }
+    let!(:sponsor_contact) { create(:sponsor_alice, conference:, sponsor:) }
+    let(:speaker_attrs) { { conference:, name: 'n', profile: 'p', company: 'c', job_title: 'j' } }
+
+    before do
+      allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).and_call_original)
+      allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).with(:userinfo).and_return(
+                                                                   {
+                                                                     info: { email: sponsor_contact.email, name: sponsor_contact.name },
+                                                                     extra: { raw_info: { sub: sponsor_contact.sub, 'https://cloudnativedays.jp/roles' => [] } }
+                                                                   }
+                                                                 ))
+    end
+
+    context 'sponsor_id で紐付く Speaker の場合（legacy）' do
+      let!(:speaker) { create(:speaker, **speaker_attrs, sponsor:) }
+
+      it 'Speaker 本体は削除されず、sponsor_id が nil にクリアされる' do
+        delete sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor.id, id: speaker.id),
+               headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(Speaker.exists?(speaker.id)).to(be(true))
+        expect(speaker.reload.sponsor_id).to(be_nil)
+        expect(sponsor.speakers).not_to(include(speaker))
+      end
+    end
+
+    context 'SponsorSpeakerInviteAccept 経由で紐付く Speaker の場合（既存プロポーザル由来）' do
+      let!(:speaker) { create(:speaker, **speaker_attrs, sponsor: nil) }
+      let!(:invite) { create(:sponsor_speaker_invite, conference:, sponsor:) }
+      let!(:invite_accept) do
+        create(:sponsor_speaker_invite_accept,
+               conference:, sponsor:, sponsor_contact:, speaker:, sponsor_speaker_invite: invite)
+      end
+
+      it 'Speaker 本体は削除されず、invite_accept のみ削除される' do
+        delete sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor.id, id: speaker.id),
+               headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(Speaker.exists?(speaker.id)).to(be(true))
+        expect(SponsorSpeakerInviteAccept.exists?(invite_accept.id)).to(be(false))
+        expect(sponsor.speakers).not_to(include(speaker))
+      end
+    end
+
+    context '通常プロポーザルの Talk を持つ Speaker の場合' do
+      let!(:speaker) { create(:speaker, **speaker_attrs, sponsor:) }
+      let!(:talk) { create(:talk1) }
+
+      before { speaker.talks << talk }
+
+      it 'Speaker 本体も Talk も削除されず、sponsor_id が nil にクリアされる' do
+        delete sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor.id, id: speaker.id),
+               headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(Speaker.exists?(speaker.id)).to(be(true))
+        expect(Talk.exists?(talk.id)).to(be(true))
+        expect(speaker.reload.sponsor_id).to(be_nil)
+      end
+    end
+  end
+end

--- a/spec/requests/sponsor_dashboards/sponsor_speakers_destroy_spec.rb
+++ b/spec/requests/sponsor_dashboards/sponsor_speakers_destroy_spec.rb
@@ -17,20 +17,18 @@ RSpec.describe(SponsorDashboards::SponsorSpeakersController, type: :request) do
                                                                  ))
     end
 
-    context 'sponsor_id で紐付く Speaker の場合（legacy）' do
+    context 'スポンサーとのみ紐付く Speaker の場合（sponsor_id, talks なし）' do
       let!(:speaker) { create(:speaker, **speaker_attrs, sponsor:) }
 
-      it 'Speaker 本体は削除されず、sponsor_id が nil にクリアされる' do
+      it 'Speaker 本体も削除される' do
         delete sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor.id, id: speaker.id),
                headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
-        expect(Speaker.exists?(speaker.id)).to(be(true))
-        expect(speaker.reload.sponsor_id).to(be_nil)
-        expect(sponsor.speakers).not_to(include(speaker))
+        expect(Speaker.exists?(speaker.id)).to(be(false))
       end
     end
 
-    context 'SponsorSpeakerInviteAccept 経由で紐付く Speaker の場合（既存プロポーザル由来）' do
+    context 'スポンサーとのみ紐付く Speaker の場合（invite_accept のみ, talks なし）' do
       let!(:speaker) { create(:speaker, **speaker_attrs, sponsor: nil) }
       let!(:invite) { create(:sponsor_speaker_invite, conference:, sponsor:) }
       let!(:invite_accept) do
@@ -38,28 +36,28 @@ RSpec.describe(SponsorDashboards::SponsorSpeakersController, type: :request) do
                conference:, sponsor:, sponsor_contact:, speaker:, sponsor_speaker_invite: invite)
       end
 
-      it 'Speaker 本体は削除されず、invite_accept のみ削除される' do
+      it 'Speaker 本体も invite_accept も削除される' do
         delete sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor.id, id: speaker.id),
                headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
-        expect(Speaker.exists?(speaker.id)).to(be(true))
+        expect(Speaker.exists?(speaker.id)).to(be(false))
         expect(SponsorSpeakerInviteAccept.exists?(invite_accept.id)).to(be(false))
-        expect(sponsor.speakers).not_to(include(speaker))
       end
     end
 
-    context '通常プロポーザルの Talk を持つ Speaker の場合' do
+    context 'CFP 経由の Speaker（Proposal 付き Talk あり）の場合' do
       let!(:speaker) { create(:speaker, **speaker_attrs, sponsor:) }
-      let!(:talk) { create(:talk1) }
+      let!(:talk) { create(:talk1, :registered) }
 
       before { speaker.talks << talk }
 
-      it 'Speaker 本体も Talk も削除されず、sponsor_id が nil にクリアされる' do
+      it 'Speaker も Talk も Proposal も残り、sponsor_id のみ nil にクリアされる' do
         delete sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor.id, id: speaker.id),
                headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
         expect(Speaker.exists?(speaker.id)).to(be(true))
         expect(Talk.exists?(talk.id)).to(be(true))
+        expect(talk.reload.proposal).to(be_present)
         expect(speaker.reload.sponsor_id).to(be_nil)
       end
     end

--- a/spec/requests/sponsor_speaker_invite_accepts_spec.rb
+++ b/spec/requests/sponsor_speaker_invite_accepts_spec.rb
@@ -135,5 +135,35 @@ RSpec.describe(SponsorSpeakerInviteAcceptsController, type: :request) do
         expect(response).to(have_http_status('200'))
       end
     end
+
+    context '既に別スポンサーに登壇者として紐付いているユーザーが承諾する場合' do
+      let!(:existing_user) { User.find_or_create_by!(sub: 'auth0|123') { |u| u.email = 'invited@example.com' } }
+      let!(:other_sponsor) { create(:sponsor, id: 99, conference:, abbr: 'other') }
+      let!(:other_sponsor_contact) { create(:sponsor_contact, conference:, sponsor: other_sponsor, user_id: existing_user.id) }
+      let!(:existing_speaker) do
+        create(:speaker, conference:, email: 'invited@example.com', sub: 'auth0|123',
+                         user_id: existing_user.id, name: 'Existing', profile: 'p', company: 'c', job_title: 'j')
+      end
+      let!(:other_invite) { create(:sponsor_speaker_invite, conference:, sponsor: other_sponsor, email: 'invited@example.com') }
+      let!(:existing_accept) do
+        create(:sponsor_speaker_invite_accept,
+               conference:, sponsor: other_sponsor, sponsor_contact: other_sponsor_contact,
+               speaker: existing_speaker, sponsor_speaker_invite: other_invite)
+      end
+
+      it '新しい InviteAccept は作成されない' do
+        expect {
+          post(sponsor_speaker_invite_accepts_path(event: conference.abbr), params: valid_attributes)
+        }.not_to(change(SponsorSpeakerInviteAccept, :count))
+
+        expect(response).to(have_http_status('200'))
+      end
+
+      it 'フォームに「別スポンサーの登壇者として登録されています」エラーが表示される' do
+        post(sponsor_speaker_invite_accepts_path(event: conference.abbr), params: valid_attributes)
+
+        expect(response.body).to(include('別スポンサーの登壇者として登録されています'))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
スポンサー登壇者の **読み取り／書き込みパスの整合性** を改善する3つの変更をまとめたPR。

1. `Sponsor#speakers` を `SponsorSpeakerInviteAccept` 経由でも拾うように変更（既存プロポーザル由来 Speaker が「担当者だけ」になる問題を修正）
2. `SponsorSpeakersController#destroy` のセマンティクスを見直し
   - **スポンサーとのみ紐付く Speaker（Talk なし）は本体ごと削除**
   - **CFP 経由等で Talk を持つ Speaker は本体を残し、紐付けのみ解除**
3. Speaker : Sponsor = 1:1 の不変条件を validation + DB unique index で強制

## 背景 / 各変更の詳細

### 1. `Sponsor#speakers` の判定改修
スポンサー登壇者招待の承諾フォームには `sponsor_id` の hidden field が無く、既存 Speaker が再利用される場合に `sponsor_id` が更新されない。結果、「スポンサー担当者一覧」には現れるが「スポンサー登壇者一覧」には現れない事象が発生していた。

- `sponsor_id` カラム自体は **互換性のため維持**（書き込みパスは変更なし）
- 読み出しパス (`Sponsor#speakers`) のみ変更し、両方の紐付け経路を union (distinct) で拾う
  - 経路1: 従来通り `Speaker.sponsor_id`
  - 経路2: `SponsorSpeakerInviteAccept` による紐付け

### 2. destroy セマンティクス見直し
従来の `#destroy` は `@speaker.destroy` で Speaker 本体を消していた。これは #1 の変更と相まって、**招待で紐付いただけの既存プロポーザル由来の Speaker まで丸ごと消えてしまう危険**があった。

新ルール:
```ruby
ActiveRecord::Base.transaction do
  @sponsor.sponsor_speaker_invite_accepts.where(speaker_id: @speaker.id).destroy_all
  if @speaker.talks.empty?
    @speaker.destroy!                                    # 純スポンサー登壇者 → 本体も削除
  elsif @speaker.sponsor_id == @sponsor.id
    @speaker.update!(sponsor_id: nil)                    # Talk を持つ Speaker → 紐付けのみ解除
  end
end
```

- **Talk を持たない Speaker**（スポンサー登壇者招待で作られただけ）→ Speaker 本体も削除。残しておく理由がない
- **Talk を持つ Speaker**（CFP 経由のプロポーザル、またはスポンサーセッション既設定）→ Speaker 本体・Talk・Proposal は残し、このスポンサーとの紐付け（sponsor_id と SponsorSpeakerInviteAccept）のみを解除

通常プロポーザル Talk でも出ていた「スポンサーセッションと紐付いているため削除できません」の誤解を招くエラーメッセージも削除。

また、`SponsorDashboards::SpeakerPolicy`（#2789 で導入）を拡張し、`sponsor_id` 直結だけでなく `SponsorSpeakerInviteAccept` 経由の Speaker も「自スポンサー所属」と判定するようにした（invite_accept のみで紐付く Speaker の削除が 403 になる問題への対応）。

### 3. Speaker : Sponsor の 1:1 制約を強制
Phase 2 で追加した `SponsorSpeakerInviteAccept` 経由の紐付けが、`Speaker.belongs_to :sponsor`（1 Speaker : 1 Sponsor）の不変条件を壊しうる穴を持っていた（同一 Speaker が複数 Sponsor の invite_accept を持てる状態）。

- model に `validates :speaker_id, uniqueness: { scope: :conference_id }` を追加し、承諾時にバリデーションで弾く
- DB にも `(conference_id, speaker_id)` の unique index を追加（競合対策）
- 既に別スポンサーの登壇者として登録されているユーザーが承諾を試みた場合、フォームに「別スポンサーの登壇者として登録されています」と表示
- 付随して、`render(:new, alert: ...)` が flash を設定していなかった pre-existing バグも修正

production DB には `(conference_id, speaker_id)` の重複は存在しないことを確認済み（マイグレーション実行可能）。

## Test plan
TDD (t-wada style) で赤→緑の順に進めて実装。

- [x] `spec/models/sponsor_spec.rb` 追加（Sponsor#speakers の新定義）
- [x] `spec/models/sponsor_speaker_invite_accept_spec.rb` 追加（1:1 制約）
- [x] `spec/requests/sponsor_dashboards/sponsor_speakers_destroy_spec.rb` 追加（destroy セマンティクス3ケース）
  - スポンサーとのみ紐付く Speaker（sponsor_id, talks なし）→ 本体も削除
  - スポンサーとのみ紐付く Speaker（invite_accept のみ, talks なし）→ 本体も削除
  - CFP 経由の Speaker（Proposal 付き Talk あり）→ Speaker/Talk/Proposal 残し紐付けのみ解除
- [x] `spec/requests/sponsor_speaker_invite_accepts_spec.rb` 追加（1:1 制約のエラー表示）
- [x] 全 221 examples パス、rubocop クリーン

## 関連PR / マージ順
- ベース: #2786 (FK 制約修正) ✅ merged
- 姉妹: #2789 (権限ガード) ✅ merged
- 本PR: main に向けてマージ予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)