### PR TITLE
fix: スポンサー登壇者管理画面に権限ガードを追加

### DIFF
--- a/app/controllers/sponsor_dashboards/sponsor_speakers_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_speakers_controller.rb
@@ -4,6 +4,13 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
 
   skip_before_action :logged_in_using_omniauth?, only: [:new]
 
+  # ApplicationController の user_not_authorized は html テンプレートを
+  # 前提にしているため、turbo_stream 等の非 html リクエストでは
+  # ActionView::MissingTemplate となる。format 非依存で 403 を返す。
+  rescue_from Pundit::NotAuthorizedError do
+    head(:forbidden)
+  end
+
   def index
     @conference = Conference.find_by(abbr: params[:event])
     @sponsor = Sponsor.find(params[:sponsor_id]) if params[:sponsor_id]
@@ -26,7 +33,7 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
     @sponsor = Sponsor.find(params[:sponsor_id]) if params[:sponsor_id]
 
     @speaker = Speaker.find_by(conference_id: @conference.id, id: params[:id])
-    # authorize(@speaker)
+    authorize([:sponsor_dashboards, @speaker])
   end
 
   # POST /:event/speaker_dashboard/:sponsor_id/speakers
@@ -52,6 +59,7 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
   def update
     @sponsor = Sponsor.find(params[:sponsor_id])
     @speaker = Speaker.find(params[:id])
+    authorize([:sponsor_dashboards, @speaker])
 
     if @speaker.update(speaker_params)
       flash.now[:notice] = 'スポンサー登壇者を更新しました'
@@ -65,6 +73,7 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
   def destroy
     @sponsor = Sponsor.find(params[:sponsor_id])
     @speaker = Speaker.find(params[:id])
+    authorize([:sponsor_dashboards, @speaker])
 
     # スポンサーセッションと紐付いているかチェック
     if @speaker.talks.present?
@@ -94,10 +103,10 @@ class SponsorDashboards::SponsorSpeakersController < ApplicationController
     end
   end
 
+  # スポンサー管理画面の context では pundit_user として SponsorContact を返し、
+  # SponsorDashboards::SpeakerPolicy で「自スポンサー所属の Speaker か」を判定する
   def pundit_user
-    if current_user && current_user_model
-      Speaker.find_by(conference_id: @conference.id, user_id: current_user_model.id)
-    end
+    @sponsor_contact
   end
 
   def expected_participant_params

--- a/app/policies/sponsor_dashboards/speaker_policy.rb
+++ b/app/policies/sponsor_dashboards/speaker_policy.rb
@@ -1,0 +1,24 @@
+class SponsorDashboards::SpeakerPolicy < ApplicationPolicy
+  # record: 対象の Speaker
+  # speaker: pundit_user（このコントローラでは SponsorContact を入れる）
+  #
+  # スポンサー管理者が、自分の担当スポンサーに属する Speaker のみ編集・削除できることを保証する。
+
+  def edit?
+    belongs_to_my_sponsor?
+  end
+
+  def update?
+    edit?
+  end
+
+  def destroy?
+    edit?
+  end
+
+  private
+
+  def belongs_to_my_sponsor?
+    speaker.present? && record.sponsor_id == speaker.sponsor_id
+  end
+end

--- a/spec/requests/sponsor_dashboards/sponsor_speakers_spec.rb
+++ b/spec/requests/sponsor_dashboards/sponsor_speakers_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe(SponsorDashboards::SponsorSpeakersController, type: :request) do
+  let!(:conference) { create(:cndt2020, :registered) }
+  let!(:sponsor_a) { create(:sponsor, id: 1, conference:, abbr: 'sponsor_a') }
+  let!(:sponsor_b) { create(:sponsor, id: 2, conference:, abbr: 'sponsor_b') }
+  let!(:sponsor_a_contact) { create(:sponsor_alice, conference:, sponsor: sponsor_a) }
+  let(:speaker_attrs) { { conference:, name: 'n', profile: 'p', company: 'c', job_title: 'j' } }
+
+  before do
+    allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).and_call_original)
+    allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).with(:userinfo).and_return(
+                                                                 {
+                                                                   info: { email: sponsor_a_contact.email, name: sponsor_a_contact.name },
+                                                                   extra: { raw_info: { sub: sponsor_a_contact.sub, 'https://cloudnativedays.jp/roles' => [] } }
+                                                                 }
+                                                               ))
+  end
+
+  describe '別スポンサー所属の Speaker への操作は拒否される' do
+    let!(:sponsor_b_speaker) { create(:speaker, **speaker_attrs, sponsor: sponsor_b) }
+
+    it 'GET #edit は 403 を返す' do
+      get edit_sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor_a.id, id: sponsor_b_speaker.id)
+      expect(response).to(have_http_status(:forbidden))
+    end
+
+    it 'PATCH #update は 403 を返し Speaker は変更されない' do
+      original_name = sponsor_b_speaker.name
+      patch sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor_a.id, id: sponsor_b_speaker.id),
+            params: { speaker: { name: 'hacked' } }
+      expect(response).to(have_http_status(:forbidden))
+      expect(sponsor_b_speaker.reload.name).to(eq(original_name))
+    end
+
+    it 'DELETE #destroy は 403 を返し Speaker は削除されない' do
+      delete sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor_a.id, id: sponsor_b_speaker.id),
+             headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+      expect(response).to(have_http_status(:forbidden))
+      expect(Speaker.exists?(sponsor_b_speaker.id)).to(be(true))
+    end
+  end
+
+  describe '自スポンサー所属の Speaker への操作は許可される' do
+    let!(:sponsor_a_speaker) { create(:speaker, **speaker_attrs, sponsor: sponsor_a) }
+
+    it 'GET #edit は 200 を返す' do
+      get edit_sponsor_dashboards_sponsor_speaker_path(event: conference.abbr, sponsor_id: sponsor_a.id, id: sponsor_a_speaker.id)
+      expect(response).to(have_http_status(:ok))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
`SponsorDashboards::SponsorSpeakersController` の `#edit` / `#update` / `#destroy` に Pundit ベースの権限ガードを追加し、他スポンサーの Speaker を触れないようにする。

## 背景 / 問題
従来は、ログイン中のスポンサーA の担当者が、URL 直打ちでスポンサーB 所属の Speaker を編集・更新・削除できてしまう状態だった。

## 変更

### 新規 Policy: `SponsorDashboards::SpeakerPolicy`
```ruby
class SponsorDashboards::SpeakerPolicy < ApplicationPolicy
  def edit?;    belongs_to_my_sponsor?; end
  def update?;  edit?; end
  def destroy?; edit?; end

  private

  def belongs_to_my_sponsor?
    speaker.present? && record.sponsor_id == speaker.sponsor_id
  end
end
```

### コントローラ
- `pundit_user` を SponsorContact を返すように変更（このコントローラの context は sponsor admin）
- edit / update / destroy で `authorize([:sponsor_dashboards, @speaker])` を呼び出す
- Pundit::NotAuthorizedError 発生時は 403 を返す（turbo_stream リクエストでも動くよう `head(:forbidden)` を使用）

### 未認可時の挙動
- `Pundit::NotAuthorizedError` → `head :forbidden` (403)
- ApplicationController の `user_not_authorized` は `render template: 'errors/error_403'` (html 前提) だが、本コントローラは turbo_stream レスポンスを扱うため format 非依存の `head(:forbidden)` で返す

## Test plan
TDD (t-wada style) で Red → Green の順に実装。

- [x] `spec/requests/sponsor_dashboards/sponsor_speakers_spec.rb` 追加
  - 別スポンサー所属の Speaker への edit/update/destroy は 403
  - 自スポンサー所属の Speaker の edit は 200
- [x] `spec/requests/sponsor_dashboards/` 全 52 件パス
- [x] `bundle exec rubocop` クリーン

## Note
- ベースは #2786 (Phase 1: FK 制約修正)。#2786 マージ後に base を `main` に切り替えます
- 元々 #2787 と同じ PR に入れていたが、権限ガードだけ先行マージできるよう分離
- 既存の `SpeakerPolicy` は「登壇者本人の self-edit」用で context が異なるため、今回は namespaced policy として `SponsorDashboards::SpeakerPolicy` を新設
- Pundit の namespaced policy 呼び出し規約 `authorize([:sponsor_dashboards, @speaker])` を利用

🤖 Generated with [Claude Code](https://claude.com/claude-code)