### PR TITLE
feat: Admin Top に参加者数のスタッツカードを追加

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -5,6 +5,11 @@ class AdminController < ApplicationController
     @session = session
     @conference = Conference.find_by(abbr: event_name)
     @current = Video.on_air(@conference)
+    @offline_registrants_count = @conference.profiles.offline.count
+    @online_registrants_count = @conference.profiles.online.count
+    @checked_in_count = @conference.check_in_conferences.count
+    # TODO: 実際のオンライン視聴者数を取得できるようになったら置き換える
+    @online_viewers_count = 1234
   end
 
   def destroy_user

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -6,6 +6,45 @@
   <% end %>
 
   <h2><%= @conference.name %></h2>
+
+  <div class="row mb-4">
+    <div class="col-md-3">
+      <div class="card text-white bg-primary">
+        <div class="card-body">
+          <h6 class="card-title">現地参加登録者数</h6>
+          <p class="card-text display-6 mb-0"><%= number_with_delimiter(@offline_registrants_count) %></p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card text-white bg-info">
+        <div class="card-body">
+          <h6 class="card-title">オンライン参加登録者数</h6>
+          <p class="card-text display-6 mb-0"><%= number_with_delimiter(@online_registrants_count) %></p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card text-white bg-success">
+        <div class="card-body">
+          <h6 class="card-title">チェックインした人数</h6>
+          <p class="card-text display-6 mb-0"><%= number_with_delimiter(@checked_in_count) %></p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card text-white bg-secondary">
+        <div class="card-body">
+          <h6 class="card-title">
+            オンライン視聴した人数
+            <span class="badge bg-warning text-dark ms-1">ダミー</span>
+          </h6>
+          <p class="card-text display-6 mb-0"><%= number_with_delimiter(@online_viewers_count) %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <table class="table table-striped">
     <thead>
     <tr>


### PR DESCRIPTION
現地参加登録者数・オンライン参加登録者数・チェックイン人数を
Admin ダッシュボードのトップに表示する。オンライン視聴者数は
データソースが未整備のため、暫定でダミー値を表示する。