### PR TITLE
feat: Admin Users 画面にページネーションを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,8 @@ gem 'ulid'
 
 gem 'acts_as_list'
 
+gem 'kaminari'
+
 # PDF tool
 gem 'ferrum'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,18 @@ GEM
     json_schema (0.21.0)
     jwt (3.0.0)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -820,6 +832,7 @@ DEPENDENCIES
   image_processing (~> 1.12.2)
   jbuilder (~> 2.11)
   jsbundling-rails
+  kaminari
   listen (~> 3.2)
   mysql2 (~> 0.5.6)
   nokogiri (= 1.18.9)

--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -2,7 +2,11 @@ class Admin::ProfilesController < ApplicationController
   include SecuredAdmin
 
   def index
-    @profiles = Profile.where(conference_id: @conference.id).page(params[:page]).per(50)
+    @profiles = Profile.where(conference_id: @conference.id)
+                       .includes(:check_in_conferences)
+                       .order(:id)
+                       .page(params[:page])
+                       .per(50)
   end
 
   def export_profiles

--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -2,7 +2,7 @@ class Admin::ProfilesController < ApplicationController
   include SecuredAdmin
 
   def index
-    @profiles = Profile.where(conference_id: @conference.id)
+    @profiles = Profile.where(conference_id: @conference.id).page(params[:page]).per(50)
   end
 
   def export_profiles

--- a/app/views/admin/profiles/index.html.erb
+++ b/app/views/admin/profiles/index.html.erb
@@ -42,6 +42,10 @@
         <% end %>
         </tbody>
       </table>
+      <div class="d-flex justify-content-between align-items-center">
+        <div><%= page_entries_info @profiles %></div>
+        <%= paginate @profiles %>
+      </div>
       </div>
     <% end %>
 <% end %>

--- a/app/views/admin/profiles/index.html.erb
+++ b/app/views/admin/profiles/index.html.erb
@@ -46,6 +46,6 @@
         <div><%= page_entries_info @profiles %></div>
         <%= paginate @profiles %>
       </div>
-      </div>
     <% end %>
+  </div>
 <% end %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t('views.pagination.first').to_s), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item disabled">
+  <span class="page-link"><%= raw(t('views.pagination.truncate').to_s) %></span>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t('views.pagination.last').to_s), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t('views.pagination.next').to_s), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item<%= ' active' if page.current? %>">
+  <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,18 @@
+<%# Bootstrap 5 themed Kaminari paginator %>
+<%= paginator.render do -%>
+  <nav aria-label="Page navigation">
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t('views.pagination.previous').to_s), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -139,12 +139,31 @@ ja:
         one: "%{model}にエラーが発生しました"
         other: "%{model}に%{count}個のエラーが発生しました"
   helpers:
+    page_entries_info:
+      entry:
+        zero: 件
+        one: 件
+        other: 件
+      one_page:
+        display_entries:
+          zero: "%{entry_name}は見つかりませんでした"
+          one: "1件の%{entry_name}を表示しています"
+          other: "%{count}件の%{entry_name}を表示しています"
+      more_pages:
+        display_entries: "全%{total}件中 %{first}-%{last}件目を表示"
     select:
       prompt: 選択してください
     submit:
       create: 登録する
       submit: 保存する
       update: 更新する
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前へ"
+      next: "次へ &rsaquo;"
+      truncate: "&hellip;"
   number:
     currency:
       format:


### PR DESCRIPTION
## Summary
- Admin の Users 画面 (`/admin/<conference>/users`) で全プロファイルを一括取得していたため、参加者数が多いカンファレンスで描画が重くなる問題を解消
- `kaminari` を導入し、`Admin::ProfilesController#index` に 1 ページ 50 件のページネーションを追加
- Bootstrap 5 互換の Kaminari テンプレートを `app/views/kaminari/` に同梱（プロジェクトの既存 UI ライブラリに合わせるため）
- ページネーションリンクは `turbo_frame_tag 'profiles'` の内側に配置されるため、ページ切り替えはフレーム内更新で動作

## Test plan
- [ ] `/admin/<conference>/users` にアクセスし、テーブル下にページネーションリンクが表示されること
- [ ] `?page=2` 等で2ページ目以降に遷移できること
- [ ] CSV エクスポートボタンが従来通り動作すること
- [ ] チェックイン操作 (turbo-frame 更新) が回帰していないこと
- [ ] `bundle exec rspec` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)