### PR TITLE
feat: admin statistics にセッションごとのチェックイン数とオンライン視聴数を表示

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -14,7 +14,7 @@ class AdminController < ApplicationController
   end
 
   def statistics
-    @talks = @conference.talks.includes(registered_talks: :profile).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference.talks.includes(:check_in_talks, registered_talks: :profile).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
   end
 
   def export_statistics

--- a/app/views/admin/statistics.erb
+++ b/app/views/admin/statistics.erb
@@ -17,6 +17,8 @@
           <th scope="col">Title</th>
           <th scope="col">登録者数(現地)</th>
           <th scope="col">登録者数(オンライン)</th>
+          <th scope="col">チェックイン数</th>
+          <th scope="col">オンライン視聴数(ダミー)</th>
         </tr>
         </thead>
         <tbody>
@@ -26,6 +28,8 @@
             <td><%= talk.title %></td>
             <td><%= talk.offline_participation_size %></td>
             <td><%= talk.online_participation_size %></td>
+            <td><%= talk.check_in_talks.size %></td>
+            <td><%= (talk.id * 37) % 500 + 50 %></td>
           </tr>
         <% end %>
         </tbody>


### PR DESCRIPTION
## Summary
- admin の statistics ページの Talks テーブルに「チェックイン数」「オンライン視聴数(ダミー)」の2列を追加
- チェックイン数は `talk.check_in_talks.size` で取得し、N+1 を避けるため `AdminController#statistics` の `includes` に `:check_in_talks` を追加
- オンライン視聴数は実装が未着手のため、列見出しに `(ダミー)` と明示した上で `talk.id` ベースの仮値を表示

## Test plan
- [ ] `/<event>/admin/statistics` を開き、Talks テーブルに「チェックイン数」と「オンライン視聴数(ダミー)」の列が表示されること
- [ ] チェックイン数が `CheckInTalk` のレコード数と一致すること
- [ ] オンライン視聴数欄にダミー値（数字）が表示されていること
- [ ] `bundle exec rspec spec/requests/admin/statistics_spec.rb` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)