### PR TITLE
feat: セルフチェックイン成功時に先行申込者向けの特別表示を追加

### DIFF
--- a/app/javascript/stylesheets/_checkin.scss
+++ b/app/javascript/stylesheets/_checkin.scss
@@ -6,4 +6,23 @@
         background-size: 100% 100%;
         margin: 3em auto;
     }
+
+    .early-bird-badge {
+        margin: 1.5em auto;
+
+        .badge {
+            display: inline-block;
+            padding: 0.6em 1.2em;
+            font-size: 1.1em;
+            color: #fff;
+            background-color: #d4a017;
+            border-radius: 999px;
+        }
+
+        .early-bird-message {
+            margin-top: 0.8em;
+            font-weight: bold;
+            color: #d4a017;
+        }
+    }
 }

--- a/app/views/check_in_conferences/new.html.erb
+++ b/app/views/check_in_conferences/new.html.erb
@@ -14,6 +14,12 @@
           &nbsp;
         </div>
         <p>チェックインが完了しました！</p>
+        <% if @profile.early_bird? %>
+          <div class="early-bird-badge text-center">
+            <span class="badge">🎫 先行申込者</span>
+            <p class="early-bird-message">先行申込ありがとうございました！</p>
+          </div>
+        <% end %>
         <p>3秒後にイベントダッシュボードにリダイレクトします</p>
       <% end %>
     </div>

--- a/spec/requests/check_in_conferences_spec.rb
+++ b/spec/requests/check_in_conferences_spec.rb
@@ -41,6 +41,42 @@ RSpec.describe(CheckInConferencesController, type: :request) do
         expect(check_in.profile_id).to(eq(profile.id))
         expect(check_in.check_in_timestamp).to(be_present)
       end
+
+      it 'does not show the early bird badge for non early bird profiles' do
+        travel_to(Conference::EARLY_BIRD_CUTOFF + 1.day) do
+          user = User.find_by(email: 'alice@example.com')
+          Profile.find_by(user_id: user.id, conference_id: cndt2020.id).update!(created_at: Conference::EARLY_BIRD_CUTOFF + 1.day)
+          get '/cndt2020/self_check_in'
+          expect(response.body).to(include('チェックインが完了しました！'))
+          expect(response.body).not_to(include('先行申込者'))
+          expect(response.body).not_to(include('先行申込ありがとうございました！'))
+        end
+      end
+    end
+
+    context 'when logged in and has early bird profile' do
+      before do
+        travel_to(Conference::EARLY_BIRD_CUTOFF - 1.day) do
+          create(:alice, :on_cndt2020)
+        end
+        ActionDispatch::Request::Session.define_method(:original, ActionDispatch::Request::Session.instance_method(:[]))
+        allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]) do |*arg|
+          if arg[1] == :userinfo
+            session[:userinfo]
+          else
+            arg[0].send(:original, arg[1])
+          end
+        end)
+      end
+
+      it 'shows the early bird badge on a successful check-in' do
+        get '/cndt2020/self_check_in'
+
+        expect(response).to(have_http_status(:ok))
+        expect(response.body).to(include('チェックインが完了しました！'))
+        expect(response.body).to(include('先行申込者'))
+        expect(response.body).to(include('先行申込ありがとうございました！'))
+      end
     end
 
     context 'when logged in but no profile' do


### PR DESCRIPTION
## Summary
- セルフチェックイン成功時、先行申込者（`profile.created_at < Conference::EARLY_BIRD_CUTOFF`）にはチェックイン完了メッセージに加えて「🎫 先行申込者」バッジと感謝メッセージを表示
- 通常申込者の表示は従来どおり
- 早期申込判定は既存の `Profile#early_bird?` を再利用

## Changes
- `app/views/check_in_conferences/new.html.erb`: 成功表示ブロック内に `@profile.early_bird?` 分岐を追加
- `app/javascript/stylesheets/_checkin.scss`: バッジ用スタイル（金色のピル型バッジ + 強調メッセージ）
- `spec/requests/check_in_conferences_spec.rb`: 先行申込者ケース／通常申込者ケースの両方を検証するテストを追加

## Test plan
- [ ] `bundle exec rspec spec/requests/check_in_conferences_spec.rb` がパスすること
- [ ] 先行申込者でログインしセルフチェックインすると「🎫 先行申込者 / 先行申込ありがとうございました！」が表示されること
- [ ] 通常申込者でログインしセルフチェックインすると従来どおりの表示のみであること
- [ ] 未ログイン／プロフィール未登録時の挙動が変わっていないこと

> Note: ローカル環境ではグローバル yarn が project pin（yarn 4.14.1）と不一致のため `assets:precompile` が通らず、レイアウトに依存する request spec を実行できていません。CI でのテスト実行を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)