### PR TITLE
refactor: admin Navigation を機能ドメインでグルーピング

### DIFF
--- a/app/javascript/stylesheets/_admin.scss
+++ b/app/javascript/stylesheets/_admin.scss
@@ -121,6 +121,17 @@ a:focus {
     background: #333333;
 }
 
+#sidebar ul li.nav-header {
+    padding: 16px 10px 4px;
+    margin-top: 8px;
+    font-size: 0.75em;
+    font-weight: bold;
+    letter-spacing: 0.05em;
+    color: #d0d0d0;
+    text-transform: uppercase;
+    border-top: 1px solid #777777;
+}
+
 .admin-conference-form {
     .privacy-policy {
         width: 100%;

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -27,7 +27,7 @@
 
     <li class="nav-header">配信・収録</li>
     <%= render 'admin/nav_item', name: 'Streaming AWS Resources', path: admin_streamings_path, active: action_name == 'streaming' %>
-    <%= render 'admin/nav_item', name: 'HarvestJobs', path: admin_harvest_jobs_path, active: action_name == 'media_package_harvest_job' %>
+    <%= render 'admin/nav_item', name: 'HarvestJobs', path: admin_harvest_jobs_path, active: controller_name == 'harvest_jobs' %>
 
     <li class="nav-header">スポンサー・参加者企画</li>
     <%= render 'admin/nav_item', name: 'Sponsors', path: admin_sponsors_path, active: controller_name == 'sponsors' || action_name == 'show_sponsor' %>

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -5,26 +5,38 @@
 
   <ul class="list-unstyled components">
     <%= render 'admin/nav_item', name: 'Admin Top', path: admin_path, active: controller_name == 'admin' &&  action_name == 'show' %>
+
+    <li class="nav-header">告知</li>
     <%= render 'admin/nav_item', name: 'Announcements', path: admin_announcements_path, active: action_name == 'announcements' %>
-    <%= render 'admin/nav_item', name: 'Users', path: admin_users_path, active: action_name == 'users' %>
+    <%= render 'admin/nav_item', name: 'SpeakerAnnouncements', path: admin_speaker_announcements_path, active:  controller_name == 'speaker_announcements' %>
+
+    <li class="nav-header">CFP・スピーカー</li>
+    <%= render 'admin/nav_item', name: 'Proposals', path: admin_proposals_path, active: controller_name == 'proposals' %>
     <%= render 'admin/nav_item', name: 'Speakers', path: admin_speakers_path, active:  controller_name == 'speakers' || action_name == 'check_in_statuses' %>
     <%= render 'admin/nav_item', name: 'KeynoteSpeakerInvitations', path: admin_keynote_speaker_invitations_path, active:  controller_name == 'keynote_speaker_invitations' %>
     <%= render 'admin/nav_item', name: 'スピーカーの会場受付状況', path: admin_speaker_check_in_statuses_path, active:  controller_name == 'speakers' || action_name == 'edit_speaker' %>
-    <%= render 'admin/nav_item', name: 'SpeakerAnnouncements', path: admin_speaker_announcements_path, active:  controller_name == 'speaker_announcements' %>
-    <%= render 'admin/nav_item', name: 'Proposals', path: admin_proposals_path, active: controller_name == 'proposals' %>
-    <%= render 'admin/nav_item', name: 'Rooms', path: admin_rooms_path, active: controller_name == 'rooms'%>
+
+    <li class="nav-header">セッション・タイムテーブル</li>
     <%= render 'admin/nav_item', name: 'Talks', path: admin_talks_path, active: controller_name == 'talks' %>
     <%= render 'admin/nav_item', name: 'Session Questions', path: admin_session_questions_path, active: controller_name == 'session_questions' %>
     <%= render 'admin/nav_item', name: 'ビデオファイル提出状況', path: admin_videos_path, active: controller_name == 'videos' %>
     <%= render 'admin/nav_item', name: 'TimeTable', path: admin_timetables_path, active: controller_name == 'timetables' %>
     <%= render 'admin/nav_item', name: 'Tracks', path: admin_tracks_path, active: controller_name == 'tracks'%>
+    <%= render 'admin/nav_item', name: 'Rooms', path: admin_rooms_path, active: controller_name == 'rooms'%>
+    <%= render 'admin/nav_item', name: 'Session stats', path: admin_statistics_path, active: action_name == 'statistics' %>
+
+    <li class="nav-header">配信・収録</li>
     <%= render 'admin/nav_item', name: 'Streaming AWS Resources', path: admin_streamings_path, active: action_name == 'streaming' %>
     <%= render 'admin/nav_item', name: 'HarvestJobs', path: admin_harvest_jobs_path, active: action_name == 'media_package_harvest_job' %>
-    <%= render 'admin/nav_item', name: 'Statistics', path: admin_statistics_path, active: action_name == 'statistics' %>
+
+    <li class="nav-header">スポンサー・参加者企画</li>
     <%= render 'admin/nav_item', name: 'Sponsors', path: admin_sponsors_path, active: controller_name == 'sponsors' || action_name == 'show_sponsor' %>
     <%= render 'admin/nav_item', name: 'Stamp Rally Checkpoints', path: admin_stamp_rally_check_points_path, active: controller_name == 'stamp_rally_check_points' || controller_name == 'qr_code_for_stamp_rallies' || action_name == 'show_sponsor' %>
-    <%= render 'admin/nav_item', name: 'Debug', path: admin_debug_path, active: action_name == 'debug' %>
+
+    <li class="nav-header">ユーザー・運営設定</li>
+    <%= render 'admin/nav_item', name: 'Users', path: admin_users_path, active: action_name == 'users' %>
     <%= render 'admin/nav_item', name: 'Edit Admin Profile', path: edit_admin_admin_profile_path(id: @admin_profile), active: action_name == 'administrators' %>
     <%= render 'admin/nav_item', name: 'Edit Team Page', path: admin_team_path, active: controller_name == 'teams' %>
+    <%= render 'admin/nav_item', name: 'Debug', path: admin_debug_path, active: action_name == 'debug' %>
   </ul>
 </nav>

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -35,7 +35,7 @@
 
     <li class="nav-header">ユーザー・運営設定</li>
     <%= render 'admin/nav_item', name: 'Users', path: admin_users_path, active: action_name == 'users' %>
-    <%= render 'admin/nav_item', name: 'Edit Admin Profile', path: edit_admin_admin_profile_path(id: @admin_profile), active: action_name == 'administrators' %>
+    <%= render 'admin/nav_item', name: 'Edit Admin Profile', path: edit_admin_admin_profile_path(id: @admin_profile), active: controller_name == 'admin_profiles' && action_name.in?(%w[edit update]) %>
     <%= render 'admin/nav_item', name: 'Edit Team Page', path: admin_team_path, active: controller_name == 'teams' %>
     <%= render 'admin/nav_item', name: 'Debug', path: admin_debug_path, active: action_name == 'debug' %>
   </ul>

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -26,7 +26,7 @@
     <%= render 'admin/nav_item', name: 'Session stats', path: admin_statistics_path, active: action_name == 'statistics' %>
 
     <li class="nav-header">配信・収録</li>
-    <%= render 'admin/nav_item', name: 'Streaming AWS Resources', path: admin_streamings_path, active: action_name == 'streaming' %>
+    <%= render 'admin/nav_item', name: 'Streaming AWS Resources', path: admin_streamings_path, active: controller_name == 'streamings' %>
     <%= render 'admin/nav_item', name: 'HarvestJobs', path: admin_harvest_jobs_path, active: controller_name == 'harvest_jobs' %>
 
     <li class="nav-header">スポンサー・参加者企画</li>

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -12,9 +12,9 @@
 
     <li class="nav-header">CFP・スピーカー</li>
     <%= render 'admin/nav_item', name: 'Proposals', path: admin_proposals_path, active: controller_name == 'proposals' %>
-    <%= render 'admin/nav_item', name: 'Speakers', path: admin_speakers_path, active:  controller_name == 'speakers' || action_name == 'check_in_statuses' %>
+    <%= render 'admin/nav_item', name: 'Speakers', path: admin_speakers_path, active: controller_name == 'speakers' && action_name != 'check_in_statuses' %>
     <%= render 'admin/nav_item', name: 'KeynoteSpeakerInvitations', path: admin_keynote_speaker_invitations_path, active:  controller_name == 'keynote_speaker_invitations' %>
-    <%= render 'admin/nav_item', name: 'スピーカーの会場受付状況', path: admin_speaker_check_in_statuses_path, active:  controller_name == 'speakers' || action_name == 'edit_speaker' %>
+    <%= render 'admin/nav_item', name: 'スピーカーの会場受付状況', path: admin_speaker_check_in_statuses_path, active: controller_name == 'speaker_check_in_statuses' || (controller_name == 'speakers' && action_name == 'check_in_statuses') %>
 
     <li class="nav-header">セッション・タイムテーブル</li>
     <%= render 'admin/nav_item', name: 'Talks', path: admin_talks_path, active: controller_name == 'talks' %>

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -7,7 +7,7 @@
     <%= render 'admin/nav_item', name: 'Admin Top', path: admin_path, active: controller_name == 'admin' &&  action_name == 'show' %>
 
     <li class="nav-header">告知</li>
-    <%= render 'admin/nav_item', name: 'Announcements', path: admin_announcements_path, active: action_name == 'announcements' %>
+    <%= render 'admin/nav_item', name: 'Announcements', path: admin_announcements_path, active: controller_name == 'announcements' %>
     <%= render 'admin/nav_item', name: 'SpeakerAnnouncements', path: admin_speaker_announcements_path, active:  controller_name == 'speaker_announcements' %>
 
     <li class="nav-header">CFP・スピーカー</li>

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -34,7 +34,7 @@
     <%= render 'admin/nav_item', name: 'Stamp Rally Checkpoints', path: admin_stamp_rally_check_points_path, active: controller_name == 'stamp_rally_check_points' || controller_name == 'qr_code_for_stamp_rallies' || action_name == 'show_sponsor' %>
 
     <li class="nav-header">ユーザー・運営設定</li>
-    <%= render 'admin/nav_item', name: 'Users', path: admin_users_path, active: action_name == 'users' %>
+    <%= render 'admin/nav_item', name: 'Users', path: admin_users_path, active: controller_name == 'profiles' %>
     <%= render 'admin/nav_item', name: 'Edit Admin Profile', path: edit_admin_admin_profile_path(id: @admin_profile), active: controller_name == 'admin_profiles' && action_name.in?(%w[edit update]) %>
     <%= render 'admin/nav_item', name: 'Edit Team Page', path: admin_team_path, active: controller_name == 'teams' %>
     <%= render 'admin/nav_item', name: 'Debug', path: admin_debug_path, active: action_name == 'debug' %>

--- a/app/views/admin/statistics.erb
+++ b/app/views/admin/statistics.erb
@@ -1,7 +1,7 @@
 <%= render 'layout' do %>
   <div class="row">
     <div class="col-12 form-group">
-      <h2>Statistics</h2>
+      <h2>Session stats</h2>
     </div>
     <div class="col-12 form-group">
       <h3>Export to CSV</h3>


### PR DESCRIPTION
## Summary
- admin サイドバーの 22 項目を 7 グループに整理(告知 / CFP・スピーカー / セッション・タイムテーブル / 配信・収録 / スポンサー・参加者企画 / ユーザー・運営設定)
- グループ見出し+区切り線スタイルのみで折りたたみは無し。常に全項目を表示
- `Statistics` を `Session stats` にリネームしてセッション・タイムテーブルグループへ移動(ルート/コントローラ名は据え置き、表示ラベルのみ変更)
- 加えて、admin statistics ページにセッションごとのチェックイン数・オンライン視聴数を表示する変更を含む(先行コミット)

## Test plan
- [ ] admin にログインしサイドバーが提案順で表示されること
- [ ] 各グループ見出しがリンクと区別された見た目で、クリックしても遷移しないこと
- [ ] 各メニューを開いた際の active 表示が壊れていないこと
- [ ] Session stats のリンクが従来の statistics ページを開けること
- [ ] チェックイン数・オンライン視聴数が statistics ページに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)