### PR TITLE
feat: スポンサー担当者がセッション Q&A に回答できるようにする

### DIFF
--- a/app/controllers/admin/session_questions_controller.rb
+++ b/app/controllers/admin/session_questions_controller.rb
@@ -35,10 +35,32 @@ class Admin::SessionQuestionsController < ApplicationController
     if @session_question.update(hidden: !@session_question.hidden)
       status = @session_question.hidden? ? '非表示' : '表示'
       flash[:notice] = "質問を#{status}にしました"
+      broadcast_question_toggled(@session_question)
     else
       flash[:alert] = '状態の変更に失敗しました'
     end
 
-    redirect_to admin_session_question_path(@session_question, event: params[:event])
+    redirect_to redirect_target_for_toggle
+  end
+
+  private
+
+  def redirect_target_for_toggle
+    return request.referer if request.referer.present? && request.referer.include?('/admin/session_questions')
+
+    admin_session_question_path(@session_question, event: params[:event])
+  end
+
+  def broadcast_question_toggled(question)
+    ActionCable.server.broadcast(
+      "qa_talk_#{question.talk_id}",
+      {
+        type: 'question_toggled',
+        question_id: question.id,
+        hidden: question.hidden
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Error broadcasting question_toggled: #{e.class} - #{e.message}"
   end
 end

--- a/app/controllers/api/v1/session_question_answers_controller.rb
+++ b/app/controllers/api/v1/session_question_answers_controller.rb
@@ -2,8 +2,8 @@ class Api::V1::SessionQuestionAnswersController < ApplicationController
   include SecuredPublicApi
   before_action :set_talk
   before_action :set_question
-  before_action :set_speaker
-  before_action :verify_speaker
+  before_action :set_answerer
+  before_action :verify_answerer
 
   skip_before_action :verify_authenticity_token
 
@@ -17,12 +17,15 @@ class Api::V1::SessionQuestionAnswersController < ApplicationController
   def create
     answer = @question.session_question_answers.build(
       conference_id: @talk.conference_id,
-      speaker_id: @speaker.id,
       body: answer_params
     )
+    if @answerer.is_a?(Speaker)
+      answer.speaker = @answerer
+    else
+      answer.sponsor_contact = @answerer
+    end
 
     if answer.save
-      # ブロードキャスト
       broadcast_answer_created(answer)
       render json: answer_json(answer), status: :created
     else
@@ -44,43 +47,53 @@ class Api::V1::SessionQuestionAnswersController < ApplicationController
     @question = @talk.session_questions.find(params[:session_question_id])
   end
 
-  def set_speaker
+  def set_answerer
     return unless current_user_model
-    @speaker = Speaker.find_by(conference_id: @talk.conference_id, user_id: current_user_model.id)
+
+    speaker = Speaker.find_by(conference_id: @talk.conference_id, user_id: current_user_model.id)
+    if speaker && @talk.speakers.include?(speaker)
+      @answerer = speaker
+      return
+    end
+
+    if @talk.sponsor_id.present?
+      sponsor_contact = SponsorContact.find_by(
+        conference_id: @talk.conference_id,
+        sponsor_id: @talk.sponsor_id,
+        user_id: current_user_model.id
+      )
+      @answerer = sponsor_contact if sponsor_contact
+    end
   end
 
-  def verify_speaker
-    unless @speaker && @talk.speakers.include?(@speaker)
-      render json: { error: 'Only speakers can answer questions' }, status: :forbidden
-      nil
-    end
+  def verify_answerer
+    return if @answerer
+
+    render json: { error: 'Only speakers or sponsor contacts of this talk can answer questions' }, status: :forbidden
   end
 
   def answer_json(answer)
     {
       id: answer.id,
       body: answer.body,
-      speaker: {
-        id: answer.speaker.id,
-        name: answer.speaker.name
+      answerer: {
+        type: answer.answerer_type,
+        name: answer.answerer_display_name
       },
       created_at: answer.created_at.iso8601
     }
   end
 
   def broadcast_answer_created(answer)
-    begin
-      ActionCable.server.broadcast(
-        "qa_talk_#{@talk.id}",
-        {
-          type: 'answer_created',
-          question_id: @question.id,
-          answer: answer_json(answer)
-        }
-      )
-    rescue StandardError => e
-      Rails.logger.error "Error broadcasting answer_created: #{e.class} - #{e.message}"
-      # ブロードキャストエラーは無視して処理を続行
-    end
+    ActionCable.server.broadcast(
+      "qa_talk_#{@talk.id}",
+      {
+        type: 'answer_created',
+        question_id: @question.id,
+        answer: answer_json(answer)
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Error broadcasting answer_created: #{e.class} - #{e.message}"
   end
 end

--- a/app/controllers/api/v1/session_question_answers_controller.rb
+++ b/app/controllers/api/v1/session_question_answers_controller.rb
@@ -8,7 +8,10 @@ class Api::V1::SessionQuestionAnswersController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def index
-    answers = @question.session_question_answers.order_by_time
+    @talk.speakers.load # answerer_display_name の per-answer N+1 を回避するため事前ロード
+    answers = @question.session_question_answers
+                       .includes(:speaker, :sponsor_contact)
+                       .order_by_time
     render json: {
       answers: answers.map { |a| answer_json(a) }
     }

--- a/app/controllers/api/v1/session_questions_controller.rb
+++ b/app/controllers/api/v1/session_questions_controller.rb
@@ -6,9 +6,17 @@ class Api::V1::SessionQuestionsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def index
+    @talk.speakers.load # answerer_display_name の per-answer N+1 を回避するため事前ロード
     questions = @talk.session_questions.visible
+                     .includes(session_question_answers: [:speaker, :sponsor_contact])
     questions = questions.order_by_votes if params[:sort] == 'votes'
     questions = questions.order_by_time if params[:sort] == 'time'
+
+    questions = questions.to_a
+    @voted_question_ids = SessionQuestionVote.where(
+      session_question_id: questions.map(&:id),
+      profile_id: @profile.id
+    ).pluck(:session_question_id).to_set
 
     render json: {
       questions: questions.map { |q| question_json(q) },
@@ -105,11 +113,17 @@ class Api::V1::SessionQuestionsController < ApplicationController
       id: question.id,
       body: question.body,
       votes_count: question.votes_count,
-      has_voted: question.session_question_votes.exists?(profile_id: @profile.id),
+      has_voted: has_voted?(question),
       created_at: question.created_at.iso8601,
       profile_id: question.profile_id,
-      answers: question.session_question_answers.order_by_time.map { |a| answer_json(a) }
+      answers: question.session_question_answers.sort_by(&:created_at).map { |a| answer_json(a) }
     }
+  end
+
+  def has_voted?(question)
+    return question.session_question_votes.exists?(profile_id: @profile.id) unless defined?(@voted_question_ids)
+
+    @voted_question_ids.include?(question.id)
   end
 
   def answer_json(answer)

--- a/app/controllers/api/v1/session_questions_controller.rb
+++ b/app/controllers/api/v1/session_questions_controller.rb
@@ -11,7 +11,8 @@ class Api::V1::SessionQuestionsController < ApplicationController
     questions = questions.order_by_time if params[:sort] == 'time'
 
     render json: {
-      questions: questions.map { |q| question_json(q) }
+      questions: questions.map { |q| question_json(q) },
+      current_user_role:
     }
   end
 
@@ -115,12 +116,30 @@ class Api::V1::SessionQuestionsController < ApplicationController
     {
       id: answer.id,
       body: answer.body,
-      speaker: {
-        id: answer.speaker.id,
-        name: answer.speaker.name
+      answerer: {
+        type: answer.answerer_type,
+        name: answer.answerer_display_name
       },
       created_at: answer.created_at.iso8601
     }
+  end
+
+  def current_user_role
+    return nil unless current_user_model
+
+    speaker = Speaker.find_by(conference_id: @talk.conference_id, user_id: current_user_model.id)
+    return 'speaker' if speaker && @talk.speakers.include?(speaker)
+
+    if @talk.sponsor_id.present?
+      sponsor_contact = SponsorContact.find_by(
+        conference_id: @talk.conference_id,
+        sponsor_id: @talk.sponsor_id,
+        user_id: current_user_model.id
+      )
+      return 'sponsor' if sponsor_contact
+    end
+
+    nil
   end
 
   def broadcast_question_created(question)

--- a/app/controllers/speaker_dashboards_controller.rb
+++ b/app/controllers/speaker_dashboards_controller.rb
@@ -224,9 +224,9 @@ class SpeakerDashboardsController < ApplicationController
           answer: {
             id: answer.id,
             body: answer.body,
-            speaker: {
-              id: answer.speaker.id,
-              name: answer.speaker.name
+            answerer: {
+              type: answer.answerer_type,
+              name: answer.answerer_display_name
             },
             created_at: answer.created_at.iso8601
           }

--- a/app/controllers/sponsor_dashboards/session_question_answers_controller.rb
+++ b/app/controllers/sponsor_dashboards/session_question_answers_controller.rb
@@ -1,0 +1,67 @@
+class SponsorDashboards::SessionQuestionAnswersController < ApplicationController
+  include SecuredSponsor
+  before_action :set_sponsor_contact
+  before_action :set_sponsor
+  before_action :authorize_sponsor_contact!
+  before_action :set_question
+
+  def create
+    answer = @question.session_question_answers.build(
+      conference_id: @question.conference_id,
+      sponsor_contact: @sponsor_contact,
+      body: params.fetch(:body, '')
+    )
+
+    if answer.save
+      broadcast_answer_created(answer)
+      flash[:notice] = '回答を投稿しました'
+    else
+      flash[:alert] = "回答の投稿に失敗しました: #{answer.errors.full_messages.join(', ')}"
+    end
+
+    redirect_to sponsor_dashboards_session_questions_path(event: current_conference.abbr, sponsor_id: @sponsor.id)
+  end
+
+  private
+
+  def set_sponsor_contact
+    return unless current_user && current_user_model
+
+    @sponsor_contact = SponsorContact.find_by(conference_id: current_conference.id, user_id: current_user_model.id)
+  end
+
+  def set_sponsor
+    @sponsor = Sponsor.find(params[:sponsor_id])
+  end
+
+  def authorize_sponsor_contact!
+    return if @sponsor_contact && @sponsor_contact.sponsor_id == @sponsor.id
+
+    render_404
+  end
+
+  def set_question
+    @question = SessionQuestion.find(params[:session_question_id])
+    return if @sponsor.talks.exists?(id: @question.talk_id)
+
+    render_404
+  end
+
+  def broadcast_answer_created(answer)
+    ActionCable.server.broadcast(
+      "qa_talk_#{answer.session_question.talk_id}",
+      {
+        type: 'answer_created',
+        question_id: @question.id,
+        answer: {
+          id: answer.id,
+          body: answer.body,
+          answerer: { type: answer.answerer_type, name: answer.answerer_display_name },
+          created_at: answer.created_at.iso8601
+        }
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Error broadcasting answer_created: #{e.class} - #{e.message}"
+  end
+end

--- a/app/controllers/sponsor_dashboards/session_questions_controller.rb
+++ b/app/controllers/sponsor_dashboards/session_questions_controller.rb
@@ -5,7 +5,34 @@ class SponsorDashboards::SessionQuestionsController < ApplicationController
   before_action :authorize_sponsor_contact!
 
   def index
-    @talks = @sponsor.talks.includes(session_questions: :session_question_answers).order(:start_time)
+    @talks = @sponsor.talks.order(:start_time)
+    talk_ids = @talks.pluck(:id)
+
+    if talk_ids.empty?
+      @all_questions = []
+      return
+    end
+
+    requested_talk_id = params[:talk_id].present? ? params[:talk_id].to_i : nil
+    filtered_talk_ids = if requested_talk_id && talk_ids.include?(requested_talk_id)
+                          [requested_talk_id]
+                        else
+                          talk_ids
+                        end
+
+    @all_questions = current_conference.session_questions
+                                       .where(talk_id: filtered_talk_ids)
+                                       .includes(:talk, :profile, :session_question_answers, :session_question_votes)
+                                       .order_by_time
+
+    if params[:unanswered] == 'true'
+      @all_questions = @all_questions
+                       .left_joins(:session_question_answers)
+                       .where(session_question_answers: { id: nil })
+                       .distinct
+    end
+
+    @all_questions = @all_questions.limit(100)
   end
 
   private

--- a/app/controllers/sponsor_dashboards/session_questions_controller.rb
+++ b/app/controllers/sponsor_dashboards/session_questions_controller.rb
@@ -35,6 +35,25 @@ class SponsorDashboards::SessionQuestionsController < ApplicationController
     @all_questions = @all_questions.limit(100)
   end
 
+  def toggle_hidden
+    question = SessionQuestion.find(params[:id])
+
+    unless @sponsor.talks.exists?(id: question.talk_id)
+      render_404
+      return
+    end
+
+    if question.update(hidden: !question.hidden)
+      status = question.hidden? ? '非表示' : '表示'
+      flash[:notice] = "質問を#{status}にしました"
+      broadcast_question_toggled(question)
+    else
+      flash[:alert] = '状態の変更に失敗しました'
+    end
+
+    redirect_to sponsor_dashboards_session_questions_path(event: current_conference.abbr, sponsor_id: @sponsor.id)
+  end
+
   private
 
   def set_sponsor_contact
@@ -51,5 +70,18 @@ class SponsorDashboards::SessionQuestionsController < ApplicationController
     return if @sponsor_contact && @sponsor_contact.sponsor_id == @sponsor.id
 
     render_404
+  end
+
+  def broadcast_question_toggled(question)
+    ActionCable.server.broadcast(
+      "qa_talk_#{question.talk_id}",
+      {
+        type: 'question_toggled',
+        question_id: question.id,
+        hidden: question.hidden
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Error broadcasting question_toggled: #{e.class} - #{e.message}"
   end
 end

--- a/app/controllers/sponsor_dashboards/session_questions_controller.rb
+++ b/app/controllers/sponsor_dashboards/session_questions_controller.rb
@@ -22,7 +22,9 @@ class SponsorDashboards::SessionQuestionsController < ApplicationController
 
     @all_questions = current_conference.session_questions
                                        .where(talk_id: filtered_talk_ids)
-                                       .includes(:talk, :profile, :session_question_answers, :session_question_votes)
+                                       .includes(:profile, :session_question_votes,
+                                                 talk: :speakers,
+                                                 session_question_answers: [:speaker, :sponsor_contact])
                                        .order_by_time
 
     if params[:unanswered] == 'true'

--- a/app/controllers/sponsor_dashboards/session_questions_controller.rb
+++ b/app/controllers/sponsor_dashboards/session_questions_controller.rb
@@ -1,0 +1,28 @@
+class SponsorDashboards::SessionQuestionsController < ApplicationController
+  include SecuredSponsor
+  before_action :set_sponsor_contact
+  before_action :set_sponsor
+  before_action :authorize_sponsor_contact!
+
+  def index
+    @talks = @sponsor.talks.includes(session_questions: :session_question_answers).order(:start_time)
+  end
+
+  private
+
+  def set_sponsor_contact
+    return unless current_user && current_user_model
+
+    @sponsor_contact = SponsorContact.find_by(conference_id: current_conference.id, user_id: current_user_model.id)
+  end
+
+  def set_sponsor
+    @sponsor = Sponsor.find(params[:sponsor_id])
+  end
+
+  def authorize_sponsor_contact!
+    return if @sponsor_contact && @sponsor_contact.sponsor_id == @sponsor.id
+
+    render_404
+  end
+end

--- a/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
+++ b/app/controllers/sponsor_dashboards/sponsor_dashboards_controller.rb
@@ -9,6 +9,7 @@ class SponsorDashboards::SponsorDashboardsController < ApplicationController
       if @sponsor.id == @sponsor_contact.sponsor_id
         @speaker = current_conference.speakers.find_by(user_id: current_user_model.id)
         @talks = @speaker ? @speaker.talks.sponsor : []
+        @unanswered_questions_count = unanswered_questions_count_for_sponsor(@sponsor)
       else
         render_404
       end
@@ -33,5 +34,18 @@ class SponsorDashboards::SponsorDashboardsController < ApplicationController
     if current_user && current_user_model
       @sponsor_contact = SponsorContact.find_by(conference_id: current_conference.id, user_id: current_user_model.id)
     end
+  end
+
+  def unanswered_questions_count_for_sponsor(sponsor)
+    talk_ids = sponsor.talks.pluck(:id)
+    return 0 if talk_ids.empty?
+
+    current_conference.session_questions
+                      .visible
+                      .where(talk_id: talk_ids)
+                      .left_joins(:session_question_answers)
+                      .where(session_question_answers: { id: nil })
+                      .distinct
+                      .count
   end
 end

--- a/app/models/session_question_answer.rb
+++ b/app/models/session_question_answer.rb
@@ -21,7 +21,7 @@ class SessionQuestionAnswer < ApplicationRecord
     if speaker_id.present?
       speaker&.name
     elsif sponsor_contact_id.present?
-      sponsor_contact&.sponsor&.name
+      'スポンサー担当者'
     end
   end
 

--- a/app/models/session_question_answer.rb
+++ b/app/models/session_question_answer.rb
@@ -18,14 +18,10 @@ class SessionQuestionAnswer < ApplicationRecord
   end
 
   def answerer_display_name
-    if speaker_id.present?
-      speaker&.name
-    elsif sponsor_contact_id.present?
-      speaker_name_for_sponsor_contact || 'スポンサー担当者'
-    else
-      # SponsorContact 削除に伴う nullify でいずれの ID も nil になった履歴レコード
-      'スポンサー担当者（退任）'
-    end
+    return speaker&.name if speaker_id.present?
+
+    # sponsor_contact_id が nil の場合は SponsorContact 削除後の nullify 済み履歴レコード
+    speaker_name_for_sponsor_contact || 'スポンサー担当者'
   end
 
   private

--- a/app/models/session_question_answer.rb
+++ b/app/models/session_question_answer.rb
@@ -1,11 +1,37 @@
 class SessionQuestionAnswer < ApplicationRecord
   belongs_to :session_question
-  belongs_to :speaker
+  belongs_to :speaker, optional: true
+  belongs_to :sponsor_contact, optional: true
   belongs_to :conference
 
   validates :body, presence: true
+  validate :exactly_one_answerer
 
   # スコープ
   scope :for_question, ->(question_id) { where(session_question_id: question_id) }
   scope :order_by_time, -> { order(created_at: :asc) }
+
+  def answerer_type
+    return 'speaker' if speaker_id.present?
+    return 'sponsor' if sponsor_contact_id.present?
+    nil
+  end
+
+  def answerer_display_name
+    if speaker_id.present?
+      speaker&.name
+    elsif sponsor_contact_id.present?
+      sponsor_contact&.sponsor&.name
+    end
+  end
+
+  private
+
+  def exactly_one_answerer
+    if speaker_id.blank? && sponsor_contact_id.blank?
+      errors.add(:base, 'speaker または sponsor_contact のいずれかが必要です')
+    elsif speaker_id.present? && sponsor_contact_id.present?
+      errors.add(:base, 'speaker と sponsor_contact は同時に指定できません')
+    end
+  end
 end

--- a/app/models/session_question_answer.rb
+++ b/app/models/session_question_answer.rb
@@ -21,11 +21,19 @@ class SessionQuestionAnswer < ApplicationRecord
     if speaker_id.present?
       speaker&.name
     elsif sponsor_contact_id.present?
-      'スポンサー担当者'
+      speaker_name_for_sponsor_contact || 'スポンサー担当者'
     end
   end
 
   private
+
+  def speaker_name_for_sponsor_contact
+    user_id = sponsor_contact&.user_id
+    talk = session_question&.talk
+    return nil unless user_id && talk
+
+    talk.speakers.find_by(user_id:)&.name
+  end
 
   def exactly_one_answerer
     if speaker_id.blank? && sponsor_contact_id.blank?

--- a/app/models/session_question_answer.rb
+++ b/app/models/session_question_answer.rb
@@ -22,6 +22,9 @@ class SessionQuestionAnswer < ApplicationRecord
       speaker&.name
     elsif sponsor_contact_id.present?
       speaker_name_for_sponsor_contact || 'スポンサー担当者'
+    else
+      # SponsorContact 削除に伴う nullify でいずれの ID も nil になった履歴レコード
+      'スポンサー担当者（退任）'
     end
   end
 

--- a/app/models/session_question_answer.rb
+++ b/app/models/session_question_answer.rb
@@ -32,7 +32,13 @@ class SessionQuestionAnswer < ApplicationRecord
     talk = session_question&.talk
     return nil unless user_id && talk
 
-    talk.speakers.find_by(user_id:)&.name
+    # talk.speakers が事前ロード済みならメモリ上で検索して N+1 を避ける
+    speaker = if talk.speakers.loaded?
+                talk.speakers.find { |s| s.user_id == user_id }
+              else
+                talk.speakers.find_by(user_id:)
+              end
+    speaker&.name
   end
 
   def exactly_one_answerer

--- a/app/models/sponsor_contact.rb
+++ b/app/models/sponsor_contact.rb
@@ -6,6 +6,7 @@ class SponsorContact < ApplicationRecord
   belongs_to :user, optional: true
   has_many :sponsor_contact_invite_accepts, dependent: :destroy
   has_many :sponsor_speaker_invite_accepts, dependent: :destroy
+  has_many :session_question_answers, dependent: :nullify
 
   before_validation :ensure_user, on: :create
 

--- a/app/views/admin/session_questions/index.html.erb
+++ b/app/views/admin/session_questions/index.html.erb
@@ -81,6 +81,16 @@
                   <%= link_to '詳細', admin_session_question_path(event: params[:event], id: question.id), class: 'btn btn-sm btn-primary' %>
                   <% if question.hidden? %>
                     <span class="badge bg-warning text-dark ms-1">非表示</span>
+                    <%= button_to '表示する',
+                        toggle_hidden_admin_session_question_path(event: params[:event], id: question.id),
+                        method: :patch,
+                        class: 'btn btn-sm btn-success ms-1' %>
+                  <% else %>
+                    <%= button_to '非表示にする',
+                        toggle_hidden_admin_session_question_path(event: params[:event], id: question.id),
+                        method: :patch,
+                        class: 'btn btn-sm btn-warning ms-1',
+                        data: { turbo_confirm: '本当に非表示にしますか？' } %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/admin/session_questions/show.html.erb
+++ b/app/views/admin/session_questions/show.html.erb
@@ -58,7 +58,7 @@
                 <div class="flex-grow-1">
                   <p class="card-text"><%= simple_format(h(answer.body)) %></p>
                   <div class="text-muted">
-                    <strong>回答者:</strong> <%= answer.speaker.name %><br>
+                    <strong>回答者:</strong> <%= answer.answerer_display_name %><br>
                     <strong>回答日時:</strong> <%= answer.created_at.strftime('%Y/%m/%d %H:%M:%S') %>
                   </div>
                 </div>

--- a/app/views/speaker_dashboard/speakers/_talk.html.erb
+++ b/app/views/speaker_dashboard/speakers/_talk.html.erb
@@ -168,7 +168,7 @@
                       <div class="mb-2 p-2" style="background-color: #f8f9fa; border-radius: 4px;">
                         <strong>A:</strong> <%= simple_format(h(answer.body)) %>
                         <div class="text-muted small mt-1">
-                          回答者: <%= answer.speaker.name %>
+                          回答者: <%= answer.answerer_display_name %>
                           <span class="ms-2"><%= answer.created_at.strftime('%Y/%m/%d %H:%M') %></span>
                         </div>
                       </div>

--- a/app/views/speaker_dashboards/_question_item.html.erb
+++ b/app/views/speaker_dashboards/_question_item.html.erb
@@ -48,7 +48,7 @@
                   <div class="flex-grow-1">
                     <strong>A:</strong> <%= simple_format(h(answer.body)) %>
                     <div class="text-muted small mt-1">
-                      回答者: <%= answer.speaker.name %>
+                      回答者: <%= answer.answerer_display_name %>
                       <span class="ms-2"><%= answer.created_at.strftime('%Y/%m/%d %H:%M') %></span>
                     </div>
                   </div>

--- a/app/views/speaker_dashboards/create_answer.turbo_stream.erb
+++ b/app/views/speaker_dashboards/create_answer.turbo_stream.erb
@@ -9,7 +9,7 @@
                 <div class="flex-grow-1">
                   <strong>A:</strong> <%= simple_format(h(answer.body)) %>
                   <div class="text-muted small mt-1">
-                    回答者: <%= answer.speaker.name %>
+                    回答者: <%= answer.answerer_display_name %>
                     <span class="ms-2"><%= answer.created_at.strftime('%Y/%m/%d %H:%M') %></span>
                   </div>
                 </div>

--- a/app/views/sponsor_dashboards/session_questions/index.html.erb
+++ b/app/views/sponsor_dashboards/session_questions/index.html.erb
@@ -9,55 +9,85 @@
       </div>
     <% end %>
 
-    <% if @talks.empty? %>
-      <p>このスポンサーに紐づくセッションがありません。</p>
-    <% else %>
-      <% @talks.each do |talk| %>
-        <div class="card my-3">
+    <div class="row speaker-dashboard-form">
+      <div class="col-12 my-4">
+        <div class="card">
           <div class="card-header">
-            <h5 class="mb-0"><%= talk.title %></h5>
+            <h4 class="mb-0">スポンサーセッションへの質問</h4>
           </div>
           <div class="card-body">
-            <% questions = talk.session_questions.visible.order_by_time %>
-            <% if questions.empty? %>
-              <p class="text-muted mb-0">まだ質問がありません。</p>
-            <% else %>
-              <% questions.each do |question| %>
-                <div class="border rounded p-3 mb-3">
+            <div class="mb-3">
+              <%= form_with url: sponsor_dashboards_session_questions_path(event: current_conference.abbr, sponsor_id: @sponsor.id), method: :get, local: true, class: 'd-flex gap-2 align-items-end flex-wrap' do |f| %>
+                <div class="form-group">
+                  <%= label_tag :talk_id, 'セッション', class: 'form-label' %>
+                  <%= select_tag :talk_id,
+                      options_from_collection_for_select(@talks, :id, :title, params[:talk_id]),
+                      { include_blank: 'すべて', class: 'form-select' } %>
+                </div>
+
+                <div class="form-group">
+                  <%= label_tag :unanswered, '状態', class: 'form-label' %>
+                  <%= select_tag :unanswered,
+                      options_for_select([
+                        ['すべて', ''],
+                        ['未回答のみ', 'true']
+                      ], params[:unanswered]),
+                      { class: 'form-select' } %>
+                </div>
+
+                <%= submit_tag 'フィルタ', class: 'btn btn-primary' %>
+                <%= link_to 'リセット', sponsor_dashboards_session_questions_path(event: current_conference.abbr, sponsor_id: @sponsor.id), class: 'btn btn-secondary' %>
+              <% end %>
+            </div>
+
+            <hr>
+
+            <% if @all_questions.present? && @all_questions.any? %>
+              <% @all_questions.each do |question| %>
+                <div class="mb-4 p-3" style="border: 1px solid #dee2e6; border-radius: 4px;">
                   <div class="mb-2">
-                    <strong>質問:</strong>
-                    <span><%= simple_format(question.body) %></span>
-                    <small class="text-muted">投稿: <%= l(question.created_at, format: :short) %></small>
+                    <strong>セッション:</strong> <%= question.talk.title %>
                   </div>
 
-                  <% answers = question.session_question_answers.order_by_time %>
-                  <% if answers.any? %>
-                    <div class="mb-2">
-                      <strong>回答:</strong>
-                      <ul class="list-unstyled ms-3">
-                        <% answers.each do |answer| %>
-                          <li class="mb-1">
-                            <span class="text-muted">[<%= answer.answerer_display_name %>]</span>
-                            <%= simple_format(answer.body) %>
-                          </li>
-                        <% end %>
-                      </ul>
+                  <div class="mb-2">
+                    <strong>Q:</strong> <%= simple_format(h(question.body)) %>
+                    <div class="text-muted small mt-1">
+                      <span>投票数: <%= question.votes_count %></span>
+                      <span class="ms-2"><%= question.created_at.strftime('%Y/%m/%d %H:%M') %></span>
+                      <% if question.session_question_answers.empty? %>
+                        <span class="badge bg-warning text-dark ms-2">未回答</span>
+                      <% end %>
+                    </div>
+                  </div>
+
+                  <% if question.session_question_answers.any? %>
+                    <div class="mt-2 ms-3">
+                      <% question.session_question_answers.order_by_time.each do |answer| %>
+                        <div class="mb-2 p-2" style="background-color: #f8f9fa; border-radius: 4px;">
+                          <strong>A:</strong> <%= simple_format(h(answer.body)) %>
+                          <div class="text-muted small mt-1">
+                            回答者: <%= answer.answerer_display_name %>
+                            <span class="ms-2"><%= answer.created_at.strftime('%Y/%m/%d %H:%M') %></span>
+                          </div>
+                        </div>
+                      <% end %>
                     </div>
                   <% end %>
 
-                  <%= form_with url: sponsor_dashboards_session_question_session_question_answers_path(event: current_conference.abbr, sponsor_id: @sponsor.id, session_question_id: question.id), method: :post, local: true do |f| %>
+                  <%= form_with url: sponsor_dashboards_session_question_session_question_answers_path(event: current_conference.abbr, sponsor_id: @sponsor.id, session_question_id: question.id), method: :post, local: true, class: 'mt-2' do |f| %>
                     <div class="mb-2">
-                      <%= f.label :body, '回答を投稿', class: 'form-label' %>
-                      <%= f.text_area :body, class: 'form-control', rows: 3, required: true %>
+                      <%= f.text_area :body, class: 'form-control form-control-sm', rows: 2, placeholder: '回答を入力してください', required: true %>
                     </div>
                     <%= f.submit '回答する', class: 'btn btn-primary btn-sm' %>
                   <% end %>
                 </div>
               <% end %>
+            <% else %>
+              <p class="text-muted">該当する質問がありません</p>
             <% end %>
           </div>
         </div>
-      <% end %>
-    <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/sponsor_dashboards/session_questions/index.html.erb
+++ b/app/views/sponsor_dashboards/session_questions/index.html.erb
@@ -79,7 +79,7 @@
 
                   <% if question.session_question_answers.any? %>
                     <div class="mt-2 ms-3">
-                      <% question.session_question_answers.order_by_time.each do |answer| %>
+                      <% question.session_question_answers.sort_by(&:created_at).each do |answer| %>
                         <div class="mb-2 p-2" style="background-color: #f8f9fa; border-radius: 4px;">
                           <strong>A:</strong> <%= simple_format(h(answer.body)) %>
                           <div class="text-muted small mt-1">

--- a/app/views/sponsor_dashboards/session_questions/index.html.erb
+++ b/app/views/sponsor_dashboards/session_questions/index.html.erb
@@ -44,18 +44,35 @@
 
             <% if @all_questions.present? && @all_questions.any? %>
               <% @all_questions.each do |question| %>
-                <div class="mb-4 p-3" style="border: 1px solid #dee2e6; border-radius: 4px;">
+                <div class="mb-4 p-3" style="border: 1px solid #dee2e6; border-radius: 4px; <%= 'opacity: 0.6;' if question.hidden? %>">
                   <div class="mb-2">
                     <strong>セッション:</strong> <%= question.talk.title %>
                   </div>
 
-                  <div class="mb-2">
-                    <strong>Q:</strong> <%= simple_format(h(question.body)) %>
-                    <div class="text-muted small mt-1">
-                      <span>投票数: <%= question.votes_count %></span>
-                      <span class="ms-2"><%= question.created_at.strftime('%Y/%m/%d %H:%M') %></span>
-                      <% if question.session_question_answers.empty? %>
-                        <span class="badge bg-warning text-dark ms-2">未回答</span>
+                  <div class="d-flex justify-content-between align-items-start mb-2">
+                    <div class="flex-grow-1">
+                      <strong>Q:</strong> <%= simple_format(h(question.body)) %>
+                      <div class="text-muted small mt-1">
+                        <span>投票数: <%= question.votes_count %></span>
+                        <span class="ms-2"><%= question.created_at.strftime('%Y/%m/%d %H:%M') %></span>
+                        <% if question.session_question_answers.empty? %>
+                          <span class="badge bg-warning text-dark ms-2">未回答</span>
+                        <% end %>
+                      </div>
+                    </div>
+                    <div class="ms-2">
+                      <% if question.hidden? %>
+                        <span class="badge bg-warning text-dark me-2">非表示</span>
+                        <%= button_to '表示する',
+                            toggle_hidden_sponsor_dashboards_session_question_path(event: current_conference.abbr, sponsor_id: @sponsor.id, id: question.id),
+                            method: :patch,
+                            class: 'btn btn-sm btn-success' %>
+                      <% else %>
+                        <%= button_to '非表示にする',
+                            toggle_hidden_sponsor_dashboards_session_question_path(event: current_conference.abbr, sponsor_id: @sponsor.id, id: question.id),
+                            method: :patch,
+                            class: 'btn btn-sm btn-warning',
+                            data: { turbo_confirm: '本当に非表示にしますか？' } %>
                       <% end %>
                     </div>
                   </div>

--- a/app/views/sponsor_dashboards/session_questions/index.html.erb
+++ b/app/views/sponsor_dashboards/session_questions/index.html.erb
@@ -1,0 +1,63 @@
+<div class="container speaker-dashboard-form wrapper">
+  <%= render 'sponsor_dashboards/sponsor_dashboards/navigator' %>
+  <div class="container-fluid right-pain">
+    <h1 class="text-center py-3 entry">セッション Q&A (<%= @sponsor.name %>)</h1>
+
+    <% flash.each do |message_type, message| %>
+      <div class="alert alert-<%= message_type == 'alert' ? 'danger' : 'info' %>" role="alert">
+        <%= message %>
+      </div>
+    <% end %>
+
+    <% if @talks.empty? %>
+      <p>このスポンサーに紐づくセッションがありません。</p>
+    <% else %>
+      <% @talks.each do |talk| %>
+        <div class="card my-3">
+          <div class="card-header">
+            <h5 class="mb-0"><%= talk.title %></h5>
+          </div>
+          <div class="card-body">
+            <% questions = talk.session_questions.visible.order_by_time %>
+            <% if questions.empty? %>
+              <p class="text-muted mb-0">まだ質問がありません。</p>
+            <% else %>
+              <% questions.each do |question| %>
+                <div class="border rounded p-3 mb-3">
+                  <div class="mb-2">
+                    <strong>質問:</strong>
+                    <span><%= simple_format(question.body) %></span>
+                    <small class="text-muted">投稿: <%= l(question.created_at, format: :short) %></small>
+                  </div>
+
+                  <% answers = question.session_question_answers.order_by_time %>
+                  <% if answers.any? %>
+                    <div class="mb-2">
+                      <strong>回答:</strong>
+                      <ul class="list-unstyled ms-3">
+                        <% answers.each do |answer| %>
+                          <li class="mb-1">
+                            <span class="text-muted">[<%= answer.answerer_display_name %>]</span>
+                            <%= simple_format(answer.body) %>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </div>
+                  <% end %>
+
+                  <%= form_with url: sponsor_dashboards_session_question_session_question_answers_path(event: current_conference.abbr, sponsor_id: @sponsor.id, session_question_id: question.id), method: :post, local: true do |f| %>
+                    <div class="mb-2">
+                      <%= f.label :body, '回答を投稿', class: 'form-label' %>
+                      <%= f.text_area :body, class: 'form-control', rows: 3, required: true %>
+                    </div>
+                    <%= f.submit '回答する', class: 'btn btn-primary btn-sm' %>
+                  <% end %>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sponsor_dashboards/sponsor_dashboards/_navigator.html.erb
+++ b/app/views/sponsor_dashboards/sponsor_dashboards/_navigator.html.erb
@@ -9,5 +9,6 @@
     <%= render 'admin/nav_item', name: 'スポンサー担当者', path: sponsor_dashboards_sponsor_contacts_path, active: controller_name == 'admin' &&  action_name == 'show' %>
     <%= render 'admin/nav_item', name: 'スポンサー登壇者', path: sponsor_dashboards_sponsor_speakers_path, active: controller_name == 'admin' &&  action_name == 'show' %>
     <%= render 'admin/nav_item', name: 'スポンサーセッション', path: sponsor_dashboards_sponsor_sessions_path, active: controller_name == 'admin' &&  action_name == 'show' %>
+    <%= render 'admin/nav_item', name: 'セッション Q&A', path: sponsor_dashboards_session_questions_path, active: controller_name == 'session_questions' %>
   </ul>
 </nav>

--- a/app/views/sponsor_dashboards/sponsor_dashboards/show.html.erb
+++ b/app/views/sponsor_dashboards/sponsor_dashboards/show.html.erb
@@ -14,6 +14,25 @@
           <%= button_to 'Log in', '/auth/auth0', {method: :post, class: "btn btn-primary btn-block btn-sm" } %>
         <% elsif @unable_found_in_sponsor_speakers %>
         <% else %>
+          <% contact_display_name = @sponsor_contact&.name.presence || @sponsor_contact&.email.presence || 'スポンサー担当者' %>
+          <div class="card notification mb-3">
+            <div class="card-header">
+              <b><%= "#{contact_display_name}様へのお知らせ" %></b>
+            </div>
+            <div class="card-body">
+              <% if @unanswered_questions_count.to_i > 0 %>
+                <div class="p-2" style="background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px;">
+                  <strong>⚠ 未回答の質問: <%= @unanswered_questions_count %>件</strong>
+                  <%= link_to '質問一覧を見る',
+                      sponsor_dashboards_session_questions_path(event: current_conference.abbr, sponsor_id: @sponsor.id, unanswered: 'true'),
+                      class: 'btn btn-sm btn-primary ms-2' %>
+                </div>
+              <% else %>
+                <p class="mb-0 text-muted">未回答の質問はありません。</p>
+              <% end %>
+            </div>
+          </div>
+
           <div class="col-12 my-4">
             <h5>スポンサー名</h5>
             <%= @sponsor.name %>

--- a/app/views/sponsor_dashboards/sponsor_dashboards/show.html.erb
+++ b/app/views/sponsor_dashboards/sponsor_dashboards/show.html.erb
@@ -14,24 +14,14 @@
           <%= button_to 'Log in', '/auth/auth0', {method: :post, class: "btn btn-primary btn-block btn-sm" } %>
         <% elsif @unable_found_in_sponsor_speakers %>
         <% else %>
-          <% contact_display_name = @sponsor_contact&.name.presence || @sponsor_contact&.email.presence || 'スポンサー担当者' %>
-          <div class="card notification mb-3">
-            <div class="card-header">
-              <b><%= "#{contact_display_name}様へのお知らせ" %></b>
+          <% if @unanswered_questions_count.to_i > 0 %>
+            <div class="alert alert-warning mb-3" role="alert">
+              <strong>⚠ 未回答の質問: <%= @unanswered_questions_count %>件</strong>
+              <%= link_to '質問一覧を見る',
+                  sponsor_dashboards_session_questions_path(event: current_conference.abbr, sponsor_id: @sponsor.id, unanswered: 'true'),
+                  class: 'btn btn-sm btn-primary ms-2' %>
             </div>
-            <div class="card-body">
-              <% if @unanswered_questions_count.to_i > 0 %>
-                <div class="p-2" style="background-color: #fff3cd; border: 1px solid #ffc107; border-radius: 4px;">
-                  <strong>⚠ 未回答の質問: <%= @unanswered_questions_count %>件</strong>
-                  <%= link_to '質問一覧を見る',
-                      sponsor_dashboards_session_questions_path(event: current_conference.abbr, sponsor_id: @sponsor.id, unanswered: 'true'),
-                      class: 'btn btn-sm btn-primary ms-2' %>
-                </div>
-              <% else %>
-                <p class="mb-0 text-muted">未回答の質問はありません。</p>
-              <% end %>
-            </div>
-          </div>
+          <% end %>
 
           <div class="col-12 my-4">
             <h5>スポンサー名</h5>

--- a/app/views/talks/partial_show/_qa_section.html.erb
+++ b/app/views/talks/partial_show/_qa_section.html.erb
@@ -75,7 +75,7 @@
                       <div class="flex-grow-1">
                         <p class="mb-1"><%= simple_format(h(answer.body)) %></p>
                         <div class="text-muted small">
-                          回答者: <%= answer.speaker.name %>
+                          回答者: <%= answer.answerer_display_name %>
                           <span class="ms-2"><%= answer.created_at.strftime('%Y/%m/%d %H:%M') %></span>
                         </div>
                       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,9 @@ Rails.application.routes.draw do
         resources :sponsor_sessions
         resources :sponsor_contact_invites, only: [:index, :new, :create, :destroy]
         resources :sponsor_speaker_invites, only: [:index, :new, :create, :destroy]
+        resources :session_questions, only: [:index] do
+          resources :session_question_answers, only: [:create]
+        end
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,9 @@ Rails.application.routes.draw do
         resources :sponsor_contact_invites, only: [:index, :new, :create, :destroy]
         resources :sponsor_speaker_invites, only: [:index, :new, :create, :destroy]
         resources :session_questions, only: [:index] do
+          member do
+            patch :toggle_hidden
+          end
           resources :session_question_answers, only: [:create]
         end
       end

--- a/db/migrate/20260428120000_add_sponsor_contact_to_session_question_answers.rb
+++ b/db/migrate/20260428120000_add_sponsor_contact_to_session_question_answers.rb
@@ -1,0 +1,9 @@
+class AddSponsorContactToSessionQuestionAnswers < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :session_question_answers, :speaker_id, true
+
+    add_column :session_question_answers, :sponsor_contact_id, :bigint
+    add_index :session_question_answers, :sponsor_contact_id
+    add_foreign_key :session_question_answers, :sponsor_contacts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_17_101147) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_28_120000) do
   create_table "admin_profiles", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "conference_id", null: false
     t.string "name"
@@ -405,15 +405,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_17_101147) do
 
   create_table "session_question_answers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "session_question_id", null: false
-    t.bigint "speaker_id", null: false
+    t.bigint "speaker_id"
     t.bigint "conference_id", null: false
     t.text "body", null: false, collation: "utf8mb4_0900_ai_ci"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "sponsor_contact_id"
     t.index ["conference_id"], name: "index_session_question_answers_on_conference_id"
     t.index ["created_at"], name: "index_session_question_answers_on_created_at"
     t.index ["session_question_id"], name: "index_session_question_answers_on_session_question_id"
     t.index ["speaker_id"], name: "index_session_question_answers_on_speaker_id"
+    t.index ["sponsor_contact_id"], name: "index_session_question_answers_on_sponsor_contact_id"
   end
 
   create_table "session_question_votes", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -851,6 +853,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_17_101147) do
   add_foreign_key "session_question_answers", "conferences"
   add_foreign_key "session_question_answers", "session_questions"
   add_foreign_key "session_question_answers", "speakers"
+  add_foreign_key "session_question_answers", "sponsor_contacts"
   add_foreign_key "session_question_votes", "profiles"
   add_foreign_key "session_question_votes", "session_questions"
   add_foreign_key "session_questions", "conferences"

--- a/docs/todo/sponsor-qa-reply-checklist.md
+++ b/docs/todo/sponsor-qa-reply-checklist.md
@@ -1,0 +1,43 @@
+# スポンサー Q&A 回答機能 実装チェックリスト
+
+スポンサー登壇者(Speaker)以外のスポンサー担当者(SponsorContact)も、視聴ページの SessionQA とスポンサーダッシュボードから Q&A に回答できるようにする。
+
+## 設計方針
+
+- (a) 表示名: SponsorContact が回答した場合は **スポンサー名** を表示。Speaker が回答した場合は従来どおり Speaker 名を表示。
+- (b) スキーマ: `session_question_answers` に `sponsor_contact_id` を追加。`speaker_id` と排他(どちらか一方が必須)。
+
+## バックエンド (Rails)
+
+- [ ] マイグレーション追加: `session_question_answers.sponsor_contact_id` (nullable, index, FK to sponsor_contacts)
+- [ ] `SessionQuestionAnswer` モデル
+  - [ ] `belongs_to :speaker, optional: true`
+  - [ ] `belongs_to :sponsor_contact, optional: true`
+  - [ ] バリデーション: `speaker_id` と `sponsor_contact_id` のいずれか一方のみ必須(排他)
+  - [ ] 表示名アクセサ(例: `answerer_display_name`)で Speaker 名 / Sponsor 名を返す
+- [ ] `Api::V1::SessionQuestionAnswersController`
+  - [ ] スポンサー担当者からの回答も受け付けられるよう認可を拡張
+  - [ ] 「該当 Talk の sponsor に紐づく SponsorContact」を回答者として許可
+  - [ ] `verify_speaker` 相当のロジックを「Speaker か SponsorContact か」で分岐
+  - [ ] レスポンス JSON に表示名と `answerer_type` を含める
+- [ ] スポンサーダッシュボード側のコントローラ/ルート
+  - [ ] `sponsor_dashboards/session_questions` のような Q&A 一覧/回答画面を追加
+  - [ ] `secured_sponsor` で SponsorContact 認証
+  - [ ] そのスポンサーの Talk(SponsorSession 含む)に紐づく質問だけ閲覧/回答可
+- [ ] RSpec
+  - [ ] モデルバリデーション(排他、必須)
+  - [ ] API: SponsorContact での回答可、無関係なスポンサー担当者は不可、Speaker は従来どおり可
+  - [ ] スポンサーダッシュボードのリクエストスペック
+
+## フロントエンド (dreamkast-ui)
+
+- [ ] SessionQA で回答フォームの表示条件を拡張: `isSpeaker || isSponsorContactOfTalk`
+- [ ] スポンサー担当者判定: profile or 別 API から「自分が回答可能な Talk」を取得
+- [ ] 回答表示: API から返る `answerer_type` / 表示名を使用(SponsorContact 回答はスポンサー名で表示)
+- [ ] スポンサーダッシュボード(該当画面があれば)に Q&A タブ追加。なければ Rails 側で完結
+
+## 仕上げ
+
+- [ ] `bundle exec rspec` 通過
+- [ ] `bundle exec rubocop --autocorrect-all` 通過
+- [ ] 動作確認: スポンサー担当者でログインし、担当スポンサーの Talk の質問に回答 → 視聴ページ側でスポンサー名表示を確認

--- a/spec/models/session_question_answer_spec.rb
+++ b/spec/models/session_question_answer_spec.rb
@@ -114,11 +114,11 @@ RSpec.describe SessionQuestionAnswer, type: :model do
       expect(answer.answerer_display_name).to eq('兼任スピーカー')
     end
 
-    it 'returns the retired sponsor contact label when both ids are nil (after nullify)' do
+    it 'returns "スポンサー担当者" when both ids are nil (after nullify)' do
       # SponsorContact が削除されて dependent: :nullify で sponsor_contact_id が nil になったケースを再現
       answer = create(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
       answer.update_columns(sponsor_contact_id: nil)
-      expect(answer.reload.answerer_display_name).to eq('スポンサー担当者（退任）')
+      expect(answer.reload.answerer_display_name).to eq('スポンサー担当者')
     end
   end
 

--- a/spec/models/session_question_answer_spec.rb
+++ b/spec/models/session_question_answer_spec.rb
@@ -113,6 +113,13 @@ RSpec.describe SessionQuestionAnswer, type: :model do
       answer = create(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
       expect(answer.answerer_display_name).to eq('兼任スピーカー')
     end
+
+    it 'returns the retired sponsor contact label when both ids are nil (after nullify)' do
+      # SponsorContact が削除されて dependent: :nullify で sponsor_contact_id が nil になったケースを再現
+      answer = create(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
+      answer.update_columns(sponsor_contact_id: nil)
+      expect(answer.reload.answerer_display_name).to eq('スポンサー担当者（退任）')
+    end
   end
 
   describe 'scopes' do

--- a/spec/models/session_question_answer_spec.rb
+++ b/spec/models/session_question_answer_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe SessionQuestionAnswer, type: :model do
       expect(answer.answerer_display_name).to eq(speaker.name)
     end
 
-    it 'returns the sponsor name when sponsor_contact is set' do
+    it 'returns "スポンサー担当者" when sponsor_contact is set' do
       answer = build(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
-      expect(answer.answerer_display_name).to eq(sponsor.name)
+      expect(answer.answerer_display_name).to eq('スポンサー担当者')
     end
   end
 

--- a/spec/models/session_question_answer_spec.rb
+++ b/spec/models/session_question_answer_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SessionQuestionAnswer, type: :model do
   let!(:profile) { create(:alice, :on_cndt2020, conference:) }
   let!(:speaker) { create(:speaker_alice, conference:) }
   let!(:question) { create(:session_question, talk:, conference:, profile:) }
+  let!(:sponsor) { create(:sponsor, conference:) }
+  let!(:sponsor_contact) { create(:sponsor_contact, conference:, sponsor:) }
 
   describe 'validations' do
     describe 'body' do
@@ -35,22 +37,71 @@ RSpec.describe SessionQuestionAnswer, type: :model do
         end
       end
     end
+
+    describe 'answerer exclusivity' do
+      it 'is valid with only speaker' do
+        answer = build(:session_question_answer, session_question: question, speaker:, sponsor_contact: nil, conference:)
+        expect(answer).to be_valid
+      end
+
+      it 'is valid with only sponsor_contact' do
+        answer = build(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
+        expect(answer).to be_valid
+      end
+
+      it 'is invalid when both speaker and sponsor_contact are set' do
+        answer = build(:session_question_answer, session_question: question, speaker:, sponsor_contact:, conference:)
+        expect(answer).not_to be_valid
+        expect(answer.errors[:base]).to include('speaker と sponsor_contact は同時に指定できません')
+      end
+
+      it 'is invalid when neither speaker nor sponsor_contact is set' do
+        answer = build(:session_question_answer, session_question: question, speaker: nil, sponsor_contact: nil, conference:)
+        expect(answer).not_to be_valid
+        expect(answer.errors[:base]).to include('speaker または sponsor_contact のいずれかが必要です')
+      end
+    end
   end
 
   describe 'associations' do
     it 'belongs to session_question' do
-      expect(subject).to respond_to(:session_question)
       expect(subject.class.reflect_on_association(:session_question)).to be_present
     end
 
-    it 'belongs to speaker' do
-      expect(subject).to respond_to(:speaker)
+    it 'belongs to speaker (optional)' do
       expect(subject.class.reflect_on_association(:speaker)).to be_present
     end
 
+    it 'belongs to sponsor_contact (optional)' do
+      expect(subject.class.reflect_on_association(:sponsor_contact)).to be_present
+    end
+
     it 'belongs to conference' do
-      expect(subject).to respond_to(:conference)
       expect(subject.class.reflect_on_association(:conference)).to be_present
+    end
+  end
+
+  describe '#answerer_type' do
+    it 'returns "speaker" when speaker is set' do
+      answer = build(:session_question_answer, session_question: question, speaker:, sponsor_contact: nil, conference:)
+      expect(answer.answerer_type).to eq('speaker')
+    end
+
+    it 'returns "sponsor" when sponsor_contact is set' do
+      answer = build(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
+      expect(answer.answerer_type).to eq('sponsor')
+    end
+  end
+
+  describe '#answerer_display_name' do
+    it 'returns the speaker name when speaker is set' do
+      answer = build(:session_question_answer, session_question: question, speaker:, sponsor_contact: nil, conference:)
+      expect(answer.answerer_display_name).to eq(speaker.name)
+    end
+
+    it 'returns the sponsor name when sponsor_contact is set' do
+      answer = build(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
+      expect(answer.answerer_display_name).to eq(sponsor.name)
     end
   end
 

--- a/spec/models/session_question_answer_spec.rb
+++ b/spec/models/session_question_answer_spec.rb
@@ -99,9 +99,19 @@ RSpec.describe SessionQuestionAnswer, type: :model do
       expect(answer.answerer_display_name).to eq(speaker.name)
     end
 
-    it 'returns "スポンサー担当者" when sponsor_contact is set' do
+    it 'returns "スポンサー担当者" when sponsor_contact is set and the user is not a speaker on the talk' do
       answer = build(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
       expect(answer.answerer_display_name).to eq('スポンサー担当者')
+    end
+
+    it 'returns the speaker name when sponsor_contact_user is also a speaker on the talk' do
+      # sponsor_contact の user を talk のスピーカーに紐付ける
+      dual_role_speaker = create(:speaker, conference:, user_id: sponsor_contact.user_id,
+                                           name: '兼任スピーカー', profile: 'p', company: 'c', job_title: 'j')
+      talk.speakers << dual_role_speaker
+
+      answer = create(:session_question_answer, session_question: question, speaker: nil, sponsor_contact:, conference:)
+      expect(answer.answerer_display_name).to eq('兼任スピーカー')
     end
   end
 

--- a/spec/requests/admin/session_questions_spec.rb
+++ b/spec/requests/admin/session_questions_spec.rb
@@ -116,5 +116,23 @@ describe Admin::SessionQuestionsController, type: :request do
         expect(response.body).to include('質問を表示にしました')
       end
     end
+
+    context 'when toggled from the index page' do
+      it 'redirects back to the index' do
+        patch "/cndt2020/admin/session_questions/#{question.id}/toggle_hidden",
+              headers: { 'HTTP_REFERER' => 'http://www.example.com/cndt2020/admin/session_questions' }
+
+        expect(response).to redirect_to('http://www.example.com/cndt2020/admin/session_questions')
+      end
+    end
+
+    it 'broadcasts question_toggled via ActionCable' do
+      expect(ActionCable.server).to receive(:broadcast).with(
+        "qa_talk_#{talk.id}",
+        hash_including(type: 'question_toggled', question_id: question.id, hidden: true)
+      )
+
+      patch "/cndt2020/admin/session_questions/#{question.id}/toggle_hidden"
+    end
   end
 end

--- a/spec/requests/api/v1/session_question_answers_controller_spec.rb
+++ b/spec/requests/api/v1/session_question_answers_controller_spec.rb
@@ -8,7 +8,6 @@ describe Api::V1::SessionQuestionAnswersController, type: :request do
   let!(:question) { create(:session_question, talk:, conference:, profile:) }
 
   before do
-    # スピーカーをトークに紐付ける
     talk.speakers << speaker
     allow(JsonWebToken).to(receive(:verify).and_return(alice_claim))
   end
@@ -31,11 +30,17 @@ describe Api::V1::SessionQuestionAnswersController, type: :request do
       expect(json['answers'].first['id']).to eq(answer1.id)
       expect(json['answers'].last['id']).to eq(answer2.id)
     end
+
+    it 'includes answerer info' do
+      get "/api/v1/talks/#{talk.id}/session_questions/#{question.id}/session_question_answers"
+      json = JSON.parse(response.body)
+      expect(json['answers'].first['answerer']).to eq('type' => 'speaker', 'name' => speaker.name)
+    end
   end
 
   describe 'POST /api/v1/talks/:talk_id/session_questions/:session_question_id/session_question_answers' do
-    context 'when user is a speaker' do
-      it 'creates an answer successfully' do
+    context 'when user is a speaker on the talk' do
+      it 'creates an answer with speaker as answerer' do
         expect {
           post "/api/v1/talks/#{talk.id}/session_questions/#{question.id}/session_question_answers",
                params: { body: 'これは回答です' },
@@ -45,7 +50,11 @@ describe Api::V1::SessionQuestionAnswersController, type: :request do
         expect(response).to have_http_status(:created)
         json = JSON.parse(response.body)
         expect(json['body']).to eq('これは回答です')
-        expect(json['speaker']['name']).to eq(speaker.name)
+        expect(json['answerer']).to eq('type' => 'speaker', 'name' => speaker.name)
+
+        answer = SessionQuestionAnswer.last
+        expect(answer.speaker_id).to eq(speaker.id)
+        expect(answer.sponsor_contact_id).to be_nil
       end
 
       it 'broadcasts via ActionCable' do
@@ -60,14 +69,44 @@ describe Api::V1::SessionQuestionAnswersController, type: :request do
       end
     end
 
-    context 'when user is not a speaker' do
+    context 'when user is a sponsor contact for the talk\'s sponsor' do
+      let!(:sponsor) { create(:sponsor, conference:) }
+      let!(:sponsor_contact) do
+        SponsorContact.create!(conference:, sponsor:, user_id: User.find_by!(sub: 'google-oauth2|alice').id)
+      end
+
+      before do
+        # alice を該当 Talk のスピーカーから外し、Speaker レコード自体も削除して
+        # SponsorContact ルートで認可されることを確認する
+        talk.speakers.delete(speaker)
+        speaker.destroy!
+        talk.update!(sponsor:)
+      end
+
+      it 'creates an answer with sponsor_contact as answerer' do
+        expect {
+          post "/api/v1/talks/#{talk.id}/session_questions/#{question.id}/session_question_answers",
+               params: { body: 'スポンサーからの回答' },
+               as: :json
+        }.to change { SessionQuestionAnswer.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)
+        expect(json['body']).to eq('スポンサーからの回答')
+        expect(json['answerer']).to eq('type' => 'sponsor', 'name' => sponsor.name)
+
+        answer = SessionQuestionAnswer.last
+        expect(answer.speaker_id).to be_nil
+        expect(answer.sponsor_contact_id).to eq(sponsor_contact.id)
+      end
+    end
+
+    context 'when user is neither a speaker on the talk nor a sponsor contact' do
       let!(:non_speaker) { create(:speaker_bob, conference:) }
 
       before do
         talk.speakers.delete(speaker)
         talk.speakers << non_speaker
-        # alice_claimはaliceのユーザーなので、speaker_aliceではない
-        allow(JsonWebToken).to(receive(:verify).and_return(alice_claim))
       end
 
       it 'returns forbidden' do
@@ -77,7 +116,29 @@ describe Api::V1::SessionQuestionAnswersController, type: :request do
 
         expect(response).to have_http_status(:forbidden)
         json = JSON.parse(response.body)
-        expect(json['error']).to include('Only speakers can answer questions')
+        expect(json['error']).to include('Only speakers or sponsor contacts')
+      end
+    end
+
+    context 'when user is a sponsor contact but for a different sponsor than the talk\'s' do
+      let!(:other_sponsor) { create(:sponsor, conference:, id: 999, name: '別のスポンサー') }
+      let!(:talk_sponsor) { create(:sponsor, conference:, id: 998, name: 'トークのスポンサー') }
+      let!(:other_contact) do
+        SponsorContact.create!(conference:, sponsor: other_sponsor, user_id: User.find_by!(sub: 'google-oauth2|alice').id)
+      end
+
+      before do
+        talk.speakers.delete(speaker)
+        speaker.destroy!
+        talk.update!(sponsor: talk_sponsor)
+      end
+
+      it 'returns forbidden' do
+        post "/api/v1/talks/#{talk.id}/session_questions/#{question.id}/session_question_answers",
+             params: { body: '無関係な回答' },
+             as: :json
+
+        expect(response).to have_http_status(:forbidden)
       end
     end
 

--- a/spec/requests/api/v1/session_question_answers_controller_spec.rb
+++ b/spec/requests/api/v1/session_question_answers_controller_spec.rb
@@ -93,7 +93,7 @@ describe Api::V1::SessionQuestionAnswersController, type: :request do
         expect(response).to have_http_status(:created)
         json = JSON.parse(response.body)
         expect(json['body']).to eq('スポンサーからの回答')
-        expect(json['answerer']).to eq('type' => 'sponsor', 'name' => sponsor.name)
+        expect(json['answerer']).to eq('type' => 'sponsor', 'name' => 'スポンサー担当者')
 
         answer = SessionQuestionAnswer.last
         expect(answer.speaker_id).to be_nil

--- a/spec/requests/sponsor_dashboards/session_questions_spec.rb
+++ b/spec/requests/sponsor_dashboards/session_questions_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe 'SponsorDashboards::SessionQuestions', type: :request do
+  let!(:conference) { create(:cndt2020, :registered) }
+  let!(:sponsor) { create(:sponsor, conference:) }
+  let!(:sponsor_contact) { create(:sponsor_alice, conference:, sponsor:) }
+  let!(:talk) { create(:talk1, conference:, sponsor:) }
+  let!(:profile) { create(:bob, :on_cndt2020, conference:) }
+  let!(:question) { create(:session_question, talk:, conference:, profile:, body: 'これは質問です') }
+
+  before do
+    allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).and_call_original)
+    allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).with(:userinfo).and_return(
+                                                                 {
+                                                                   info: { email: sponsor_contact.email, name: sponsor_contact.name },
+                                                                   extra: { raw_info: { sub: sponsor_contact.sub, 'https://cloudnativedays.jp/roles' => [] } }
+                                                                 }
+                                                               ))
+  end
+
+  describe 'GET /sponsor_dashboards/:sponsor_id/session_questions' do
+    it 'returns a successful response and lists the talk' do
+      get sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: sponsor.id)
+      expect(response).to(be_successful)
+      expect(response.body).to(include(talk.title))
+      expect(response.body).to(include('これは質問です'))
+    end
+
+    context 'when sponsor_contact does not belong to the sponsor' do
+      let!(:other_sponsor) { create(:sponsor, conference:, id: 2, name: '別スポンサー') }
+
+      it 'returns 404' do
+        get sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: other_sponsor.id)
+        expect(response).to(have_http_status(:not_found))
+      end
+    end
+  end
+
+  describe 'POST /sponsor_dashboards/:sponsor_id/session_questions/:session_question_id/session_question_answers' do
+    it 'creates an answer attributed to the sponsor_contact' do
+      expect {
+        post sponsor_dashboards_session_question_session_question_answers_path(
+          event: conference.abbr, sponsor_id: sponsor.id, session_question_id: question.id
+        ), params: { body: 'スポンサー担当者からの回答' }
+      }.to(change { SessionQuestionAnswer.count }.by(1))
+
+      answer = SessionQuestionAnswer.last
+      expect(answer.sponsor_contact_id).to(eq(sponsor_contact.id))
+      expect(answer.speaker_id).to(be_nil)
+      expect(answer.body).to(eq('スポンサー担当者からの回答'))
+      expect(response).to(redirect_to(sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: sponsor.id)))
+    end
+
+    context 'when question is not for one of this sponsor\'s talks' do
+      let!(:other_talk) { create(:talk2, conference:) }
+      let!(:other_question) { create(:session_question, talk: other_talk, conference:, profile:) }
+
+      it 'returns 404' do
+        post sponsor_dashboards_session_question_session_question_answers_path(
+          event: conference.abbr, sponsor_id: sponsor.id, session_question_id: other_question.id
+        ), params: { body: 'なりすまし' }
+        expect(response).to(have_http_status(:not_found))
+        expect(SessionQuestionAnswer.count).to(eq(0))
+      end
+    end
+
+    context 'with blank body' do
+      it 'does not create an answer' do
+        expect {
+          post sponsor_dashboards_session_question_session_question_answers_path(
+            event: conference.abbr, sponsor_id: sponsor.id, session_question_id: question.id
+          ), params: { body: '' }
+        }.not_to(change { SessionQuestionAnswer.count })
+
+        expect(flash[:alert]).to(include('回答の投稿に失敗しました'))
+      end
+    end
+  end
+end

--- a/spec/requests/sponsor_dashboards/session_questions_spec.rb
+++ b/spec/requests/sponsor_dashboards/session_questions_spec.rb
@@ -106,4 +106,41 @@ RSpec.describe 'SponsorDashboards::SessionQuestions', type: :request do
       end
     end
   end
+
+  describe 'PATCH /sponsor_dashboards/:sponsor_id/session_questions/:id/toggle_hidden' do
+    it 'hides a visible question' do
+      expect {
+        patch toggle_hidden_sponsor_dashboards_session_question_path(
+          event: conference.abbr, sponsor_id: sponsor.id, id: question.id
+        )
+      }.to(change { question.reload.hidden }.from(false).to(true))
+
+      expect(flash[:notice]).to(eq('質問を非表示にしました'))
+      expect(response).to(redirect_to(sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: sponsor.id)))
+    end
+
+    it 'unhides a hidden question' do
+      question.update!(hidden: true)
+      expect {
+        patch toggle_hidden_sponsor_dashboards_session_question_path(
+          event: conference.abbr, sponsor_id: sponsor.id, id: question.id
+        )
+      }.to(change { question.reload.hidden }.from(true).to(false))
+
+      expect(flash[:notice]).to(eq('質問を表示にしました'))
+    end
+
+    context 'when the question is for a different sponsor\'s talk' do
+      let!(:other_talk) { create(:talk2, conference:) }
+      let!(:other_question) { create(:session_question, talk: other_talk, conference:, profile:) }
+
+      it 'returns 404 and does not change state' do
+        patch toggle_hidden_sponsor_dashboards_session_question_path(
+          event: conference.abbr, sponsor_id: sponsor.id, id: other_question.id
+        )
+        expect(response).to(have_http_status(:not_found))
+        expect(other_question.reload.hidden).to(be(false))
+      end
+    end
+  end
 end

--- a/spec/requests/sponsor_dashboards/session_questions_spec.rb
+++ b/spec/requests/sponsor_dashboards/session_questions_spec.rb
@@ -19,11 +19,41 @@ RSpec.describe 'SponsorDashboards::SessionQuestions', type: :request do
   end
 
   describe 'GET /sponsor_dashboards/:sponsor_id/session_questions' do
-    it 'returns a successful response and lists the talk' do
+    it 'returns a successful response and lists the question' do
       get sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: sponsor.id)
       expect(response).to(be_successful)
       expect(response.body).to(include(talk.title))
       expect(response.body).to(include('これは質問です'))
+    end
+
+    context 'with unanswered=true filter' do
+      let!(:speaker) { create(:speaker_alice, conference:, sponsor:) }
+      let!(:answered_question) { create(:session_question, talk:, conference:, profile:, body: '回答済み質問') }
+      let!(:answer_for_answered) { create(:session_question_answer, session_question: answered_question, speaker:, conference:) }
+
+      it 'shows only unanswered questions' do
+        get sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: sponsor.id, unanswered: 'true')
+        expect(response).to(be_successful)
+        expect(response.body).to(include('これは質問です'))
+        expect(response.body).not_to(include('回答済み質問'))
+      end
+
+      it 'shows all questions when filter is off' do
+        get sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: sponsor.id)
+        expect(response.body).to(include('これは質問です'))
+        expect(response.body).to(include('回答済み質問'))
+      end
+    end
+
+    context 'with talk_id filter' do
+      let!(:other_talk) { create(:talk2, conference:, sponsor:) }
+      let!(:other_question) { create(:session_question, talk: other_talk, conference:, profile:, body: '別セッションの質問') }
+
+      it 'shows only questions for the requested talk' do
+        get sponsor_dashboards_session_questions_path(event: conference.abbr, sponsor_id: sponsor.id, talk_id: talk.id)
+        expect(response.body).to(include('これは質問です'))
+        expect(response.body).not_to(include('別セッションの質問'))
+      end
     end
 
     context 'when sponsor_contact does not belong to the sponsor' do

--- a/spec/requests/sponsor_dashboards/sponsor_dashboards_show_spec.rb
+++ b/spec/requests/sponsor_dashboards/sponsor_dashboards_show_spec.rb
@@ -102,6 +102,25 @@ describe SponsorDashboards::SponsorDashboardsController, type: :request do
             # it_should_behave_like :response_does_not_include_proposal_title, 'スポンサー1株式会社'
             # it_should_behave_like :response_includes_proposal_title_and_entry_status, 'sponsor_session', 'エントリー済み'
           end
+
+          context 'sponsor has unanswered questions' do
+            let!(:sponsor_talk) { create(:talk1, conference: cndt2020, sponsor:) }
+            let!(:profile) { create(:bob, :on_cndt2020, conference: cndt2020) }
+            let!(:unanswered) { create(:session_question, talk: sponsor_talk, conference: cndt2020, profile:, body: '未回答質問') }
+
+            it 'shows the unanswered count notice' do
+              get '/cndt2020/sponsor_dashboards/1'
+              expect(response.body).to(include('未回答の質問'))
+              expect(response.body).to(include('1件'))
+            end
+          end
+
+          context 'sponsor has no unanswered questions' do
+            it 'shows the no-unanswered notice' do
+              get '/cndt2020/sponsor_dashboards/1'
+              expect(response.body).to(include('未回答の質問はありません'))
+            end
+          end
         end
       end
     end

--- a/spec/requests/sponsor_dashboards/sponsor_dashboards_show_spec.rb
+++ b/spec/requests/sponsor_dashboards/sponsor_dashboards_show_spec.rb
@@ -116,9 +116,9 @@ describe SponsorDashboards::SponsorDashboardsController, type: :request do
           end
 
           context 'sponsor has no unanswered questions' do
-            it 'shows the no-unanswered notice' do
+            it 'does not show the unanswered notice' do
               get '/cndt2020/sponsor_dashboards/1'
-              expect(response.body).to(include('未回答の質問はありません'))
+              expect(response.body).not_to(include('⚠ 未回答の質問'))
             end
           end
         end


### PR DESCRIPTION
## Summary

スポンサー担当者 (SponsorContact) も、視聴ページ (SessionQA) とスポンサーダッシュボードからセッション Q&A に回答できるようにする。あわせてスポンサーダッシュボードと Admin の Q&A 運用機能 (フィルタ・未回答通知・非表示トグル) を拡充し、API の N+1 を解消する。

関連フロントエンド変更は別 PR: cloudnativedaysjp/dreamkast-ui#592

## 変更内容

### 回答機能の拡張

- `session_question_answers` に `sponsor_contact_id` を追加し、`speaker_id` と排他のバリデーションを追加 (`speaker_id` を nullable 化)
- `Api::V1::SessionQuestionAnswersController` で「該当 Talk のスピーカー」または「該当 Talk のスポンサーに紐づく SponsorContact」を回答者として許可
- `Api::V1::SessionQuestionsController` のレスポンスを `answer.speaker` → `answer.answerer { type, name }` 形式に変更し、`current_user_role` (`speaker` / `sponsor` / `null`) を追加
- 表示名 (`answerer_display_name`) のルール:
  - `speaker_id` 設定済み → スピーカー名
  - `sponsor_contact_id` 設定済みかつ Talk のスピーカーにも登録されている → そのスピーカー名
  - そうでない `sponsor_contact_id` 設定済み → 「スポンサー担当者」
- ERB / ActionCable の broadcast / Speaker ダッシュボード等、`answer.speaker.name` を直接参照していた箇所を `answer.answerer_display_name` に統一

### スポンサーダッシュボード

- `セッション Q&A` 画面を新規追加 (`/{event}/sponsor_dashboards/{sponsor_id}/session_questions`)
- セッションフィルタ・未回答フィルタ・「未回答」バッジ
- 質問の非表示/表示トグル + ActionCable broadcast (Speaker ダッシュボードと同等)
- TOP ページに未回答質問数の警告アラートを追加 (1 件以上で表示、リンクは未回答フィルタ付き Q&A 画面へ)

### Admin

- `Admin::SessionQuestionsController` の質問一覧から直接トグルできるようボタンを追加
- toggle 後の redirect を referer 判定 (一覧から押した → 一覧へ、詳細から押した → 詳細へ)
- ActionCable broadcast を追加し視聴ページに即時反映

### パフォーマンス

- `SessionQuestions#index` の N+1 を解消
  - `:speaker, :sponsor_contact` を eager load
  - `talk.speakers` を事前 load し `find` で参照
  - `has_voted` を一括取得 (Set#include?)

## Test plan

- [x] `bundle exec rspec spec/models/session_question_answer_spec.rb spec/requests/api/v1/session_question_answers_controller_spec.rb spec/requests/api/v1/session_questions_controller_spec.rb spec/requests/sponsor_dashboards/ spec/requests/speaker_dashboards/ spec/requests/admin/session_questions_spec.rb`
- [x] `bundle exec rubocop` (該当ファイルで no offenses)
- [ ] スポンサー担当者でログイン → `スポンサーダッシュボード > セッション Q&A` から担当スポンサーセッションの質問に回答できる / 非表示にできる
- [ ] スポンサー担当者でログイン → 視聴ページ Q&A タブから担当スポンサーセッションの質問に回答できる
- [ ] スポンサー担当者かつ Talk スピーカー → スピーカー名で表示される
- [ ] Speaker でログイン → 従来通り回答できる (スピーカー名表示)
- [ ] 無関係なユーザー → 回答 API が 403 を返す / UI に回答ボタンが表示されない
- [ ] スポンサーダッシュボード TOP → 未回答 1 件以上で警告アラートが出る、0 件で出ない
- [ ] Admin の質問一覧から非表示/表示トグルが動作し、視聴ページにリアルタイム反映する
- [ ] dreamkast-ui 側の対応 PR (#592) と同時にデプロイする

🤖 Generated with [Claude Code](https://claude.com/claude-code)