### PR TITLE
fix: 日程未設定セッションがあってもダッシュボードでエラーにならないようにする

### DIFF
--- a/app/views/attendee_dashboards/show.html.erb
+++ b/app/views/attendee_dashboards/show.html.erb
@@ -133,10 +133,11 @@
         <h3 class="dashboard-section-title">聴講予定セッション</h3>
         <div id="registered-talk-list">
           <% @profile.talks.each do |talk| %>
+            <% next if talk.conference_day.nil? %>
             <div class="dashboard-talk-card">
               <div class="d-flex justify-content-between align-items-start mb-2">
                  <div class="dashboard-talk-meta">
-                    <%= talk.conference_day.date.strftime("%m/%d") %> <span class="mx-1">|</span> Track <%= talk.track.name %> <span class="mx-1">|</span> <%= talk.start_time.strftime("%H:%M") %>-<%= talk.end_time.strftime("%H:%M") %>
+                    <%= talk.conference_day.date.strftime("%m/%d") %> <span class="mx-1">|</span> Track <%= talk.track&.name %> <span class="mx-1">|</span> <%= talk.start_time&.strftime("%H:%M") %>-<%= talk.end_time&.strftime("%H:%M") %>
                  </div>
                  <div class="d-flex">
                   <% if talk.talk_difficulty.present? && talk.talk_difficulty_id != 4 && talk.talk_category_id != 18 %>


### PR DESCRIPTION
## Summary
- タイムテーブルから外された (`conference_day_id` が nil の) セッションが聴講予定セッションに登録されたままだと、ダッシュボード表示時に `undefined method 'date' for nil` で500エラーになっていた問題を修正
- 該当セッションはカード自体を `next` でスキップ
- 念のため `track` / `start_time` / `end_time` も `&.` で安全アクセスに変更

## Background
中止になったセッションをタイムテーブルから外した影響で、すでに「聴講予定」に登録していたユーザーのダッシュボードが落ちる状態だった。

\`\`\`
/app/app/views/attendee_dashboards/show.html.erb:139:in 'block in _app_views_attendee_dashboards_show_html_erb...': undefined method 'date' for nil (ActionView::Template::Error)
\`\`\`

## Test plan
- [ ] `conference_day_id` が nil の talk を `registered_talks` に持つユーザーでダッシュボードを開き、500 にならず、該当セッションがリストに出ないことを確認
- [ ] 通常の日程設定済みセッションは従来通り日付・トラック・時間が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)