### PR TITLE
feat: Adminダッシュボードに環境ラベルを表示

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,2 +1,12 @@
 module AdminHelper
+  def admin_env_label
+    case ENV['DREAMKAST_NAMESPACE']
+    when 'dreamkast'
+      { name: 'Production', css_class: 'env-label-production' }
+    when 'dreamkast-staging'
+      { name: 'Staging', css_class: 'env-label-staging' }
+    else
+      { name: 'Dev', css_class: 'env-label-dev' }
+    end
+  end
 end

--- a/app/javascript/stylesheets/_admin.scss
+++ b/app/javascript/stylesheets/_admin.scss
@@ -149,6 +149,13 @@ a:focus {
     }
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .env-label-production,
+    .env-label-staging {
+        animation: none;
+    }
+}
+
 #sidebar ul.components {
     padding: 20px 0;
     border-bottom: 1px solid #999999;

--- a/app/javascript/stylesheets/_admin.scss
+++ b/app/javascript/stylesheets/_admin.scss
@@ -92,6 +92,61 @@ a:focus {
 #sidebar .sidebar-header {
     padding: 20px;
     background: #999999;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+
+    h3 {
+        margin-bottom: 0;
+    }
+}
+
+.env-label {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 0.75em;
+    font-weight: bold;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.env-label-production {
+    color: #5a4500;
+    background: linear-gradient(135deg, #fff3a0 0%, #ffd700 45%, #b8860b 100%);
+    box-shadow: 0 0 4px #ffd700, 0 0 8px rgba(255, 215, 0, 0.6);
+    animation: env-label-glow-gold 2s ease-in-out infinite;
+}
+
+.env-label-staging {
+    color: #333;
+    background: linear-gradient(135deg, #f5f5f5 0%, #c0c0c0 45%, #808080 100%);
+    box-shadow: 0 0 4px #d0d0d0, 0 0 8px rgba(192, 192, 192, 0.6);
+    animation: env-label-glow-silver 2s ease-in-out infinite;
+}
+
+.env-label-dev {
+    color: #fff;
+    background: #555555;
+    border: 1px solid #777777;
+}
+
+@keyframes env-label-glow-gold {
+    0%, 100% {
+        box-shadow: 0 0 4px #ffd700, 0 0 8px rgba(255, 215, 0, 0.6);
+    }
+    50% {
+        box-shadow: 0 0 8px #ffd700, 0 0 16px rgba(255, 215, 0, 0.9);
+    }
+}
+
+@keyframes env-label-glow-silver {
+    0%, 100% {
+        box-shadow: 0 0 4px #d0d0d0, 0 0 8px rgba(192, 192, 192, 0.6);
+    }
+    50% {
+        box-shadow: 0 0 8px #ffffff, 0 0 16px rgba(220, 220, 220, 0.9);
+    }
 }
 
 #sidebar ul.components {

--- a/app/views/admin/_navigator.html.erb
+++ b/app/views/admin/_navigator.html.erb
@@ -1,6 +1,8 @@
 <nav id="sidebar">
   <div class="sidebar-header">
     <h3><%= @conference.abbr %></h3>
+    <% env = admin_env_label %>
+    <span class="env-label <%= env[:css_class] %>"><%= env[:name] %></span>
   </div>
 
   <ul class="list-unstyled components">

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe(AdminHelper, type: :helper) do
+  describe '#admin_env_label' do
+    subject { helper.admin_env_label }
+
+    context 'when DREAMKAST_NAMESPACE is "dreamkast"' do
+      before { stub_const('ENV', ENV.to_hash.merge('DREAMKAST_NAMESPACE' => 'dreamkast')) }
+
+      it 'returns Production label' do
+        expect(subject).to eq({ name: 'Production', css_class: 'env-label-production' })
+      end
+    end
+
+    context 'when DREAMKAST_NAMESPACE is "dreamkast-staging"' do
+      before { stub_const('ENV', ENV.to_hash.merge('DREAMKAST_NAMESPACE' => 'dreamkast-staging')) }
+
+      it 'returns Staging label' do
+        expect(subject).to eq({ name: 'Staging', css_class: 'env-label-staging' })
+      end
+    end
+
+    context 'when DREAMKAST_NAMESPACE is some other value' do
+      before { stub_const('ENV', ENV.to_hash.merge('DREAMKAST_NAMESPACE' => 'dreamkast-dev-dk-123-dk')) }
+
+      it 'returns Dev label' do
+        expect(subject).to eq({ name: 'Dev', css_class: 'env-label-dev' })
+      end
+    end
+
+    context 'when DREAMKAST_NAMESPACE is not set' do
+      before do
+        env_without_namespace = ENV.to_hash.except('DREAMKAST_NAMESPACE')
+        stub_const('ENV', env_without_namespace)
+      end
+
+      it 'returns Dev label' do
+        expect(subject).to eq({ name: 'Dev', css_class: 'env-label-dev' })
+      end
+    end
+  end
+end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe(AdminHelper, type: :helper) do
   describe '#admin_env_label' do
     subject { helper.admin_env_label }
 
+    before { allow(ENV).to receive(:[]).and_call_original }
+
     context 'when DREAMKAST_NAMESPACE is "dreamkast"' do
-      before { stub_const('ENV', ENV.to_hash.merge('DREAMKAST_NAMESPACE' => 'dreamkast')) }
+      before { allow(ENV).to receive(:[]).with('DREAMKAST_NAMESPACE').and_return('dreamkast') }
 
       it 'returns Production label' do
         expect(subject).to eq({ name: 'Production', css_class: 'env-label-production' })
@@ -13,7 +15,7 @@ RSpec.describe(AdminHelper, type: :helper) do
     end
 
     context 'when DREAMKAST_NAMESPACE is "dreamkast-staging"' do
-      before { stub_const('ENV', ENV.to_hash.merge('DREAMKAST_NAMESPACE' => 'dreamkast-staging')) }
+      before { allow(ENV).to receive(:[]).with('DREAMKAST_NAMESPACE').and_return('dreamkast-staging') }
 
       it 'returns Staging label' do
         expect(subject).to eq({ name: 'Staging', css_class: 'env-label-staging' })
@@ -21,7 +23,7 @@ RSpec.describe(AdminHelper, type: :helper) do
     end
 
     context 'when DREAMKAST_NAMESPACE is some other value' do
-      before { stub_const('ENV', ENV.to_hash.merge('DREAMKAST_NAMESPACE' => 'dreamkast-dev-dk-123-dk')) }
+      before { allow(ENV).to receive(:[]).with('DREAMKAST_NAMESPACE').and_return('dreamkast-dev-dk-123-dk') }
 
       it 'returns Dev label' do
         expect(subject).to eq({ name: 'Dev', css_class: 'env-label-dev' })
@@ -29,10 +31,7 @@ RSpec.describe(AdminHelper, type: :helper) do
     end
 
     context 'when DREAMKAST_NAMESPACE is not set' do
-      before do
-        env_without_namespace = ENV.to_hash.except('DREAMKAST_NAMESPACE')
-        stub_const('ENV', env_without_namespace)
-      end
+      before { allow(ENV).to receive(:[]).with('DREAMKAST_NAMESPACE').and_return(nil) }
 
       it 'returns Dev label' do
         expect(subject).to eq({ name: 'Dev', css_class: 'env-label-dev' })


### PR DESCRIPTION
## Summary
- `DREAMKAST_NAMESPACE` に応じてAdminダッシュボードのサイドバーヘッダに環境ラベルを表示
  - `dreamkast` → 金色に光る **Production**
  - `dreamkast-staging` → 銀色に光る **Staging**
  - その他・未設定 → **Dev**
- 本番環境での操作ミスを抑止するのが目的
- `AdminHelper#admin_env_label` に判定ロジックを集約、RSpecで4ケースをカバー

## Test plan
- [ ] `bundle exec rspec spec/helpers/admin_helper_spec.rb` がパスする
- [ ] `DREAMKAST_NAMESPACE=dreamkast` でAdmin画面に金色の Production ラベルが光って表示される
- [ ] `DREAMKAST_NAMESPACE=dreamkast-staging` でAdmin画面に銀色の Staging ラベルが光って表示される
- [ ] 環境変数未設定 / その他の値で Dev ラベルが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)