### PR TITLE
fix: my_profile API で start_time/end_time が nil のセッションでエラーにならないようにする

### DIFF
--- a/app/views/api/v1/profiles/my_profile.json.jbuilder
+++ b/app/views/api/v1/profiles/my_profile.json.jbuilder
@@ -8,8 +8,8 @@ json.registeredTalks(@profile.registered_talks&.includes([talk: [:speakers, :con
     talkId: registered_talk.talk.id,
     talkTitle: registered_talk.talk.title,
     talkSpeakers: registered_talk.talk.speakers.map { |speaker| { name: speaker.name, twitterId: speaker.twitter_id } },
-    talkStartTime: registered_talk.talk.start_time.rfc3339,
-    talkEndTime: registered_talk.talk.end_time.rfc3339,
+    talkStartTime: registered_talk.talk.start_time&.rfc3339,
+    talkEndTime: registered_talk.talk.end_time&.rfc3339,
     trackName: registered_talk.talk.track.name,
     roomName: registered_talk.talk.track.room.name,
     conferenceDay: registered_talk.talk.conference_day.date


### PR DESCRIPTION
## Summary
- `/api/v1/profiles/my_profile` の Jbuilder で `talk.start_time` / `talk.end_time` が nil の場合に `undefined method 'rfc3339' for nil` が発生していたのを修正
- Talk モデルで `start_time` / `end_time` のバリデーションが無効化されており nil を取り得るため、safe navigation (`&.`) で nil 安全にした

## Test plan
- [ ] `start_time` / `end_time` が nil の Talk を含む `RegisteredTalk` を持つユーザで `/api/v1/profiles/my_profile` を叩いてもエラーにならないこと
- [ ] 通常の Talk については従来通り rfc3339 形式の時刻が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)