### PR TITLE
fix: セルフチェックイン後の導線をリダイレクトしないようにする

### DIFF
--- a/app/views/attendee_dashboards/show.html.erb
+++ b/app/views/attendee_dashboards/show.html.erb
@@ -65,6 +65,9 @@
               <h6 class="alert-heading fw-semibold mb-3"><i class="bi bi-exclamation-triangle-fill me-2"></i>オフライン参加の方へ</h6>
               <ul class="mb-0 pl-3">
                 <li>スマートフォンで受け付け用の二次元バーコードを表示する場合は <%= link_to 'こちら', profiles_view_qr_path, class: 'alert-link' %>。</li>
+                <% if display_self_check_in_link? %>
+                  <li>セルフチェックインの結果は <%= link_to 'こちら', self_check_in_path(no_redirect: true), class: 'alert-link' %>。</li>
+                <% end %>
               </ul>
             </div>
           <% end %>
@@ -195,7 +198,7 @@
                 <%= link_to stamp_rally_check_ins_path do %><i class="bi bi-check-circle-fill"></i>スタンプラリー<% end %>
               <% end %>
               <% if display_self_check_in_link? %>
-                <%= link_to self_check_in_path do %><i class="bi bi-qr-code"></i>セルフチェックイン<% end %>
+                <%= link_to self_check_in_path(no_redirect: true) do %><i class="bi bi-qr-code"></i>セルフチェックインの結果<% end %>
               <% end %>
               <% if @conference.abbr == 'cnk' %>
                 <%= link_to "https://kaigi.cloudnativedays.jp/blog", target: :_blank, rel: "noopener noreferrer" do %><i class="bi bi-journal-text"></i>Blog記事一覧<% end %>

--- a/app/views/layouts/_cnk_header.html.erb
+++ b/app/views/layouts/_cnk_header.html.erb
@@ -26,7 +26,7 @@
           <% end %>
 
           <% if display_self_check_in_link? %>
-            <li class="nav-item"><%= link_to "セルフチェックイン", self_check_in_path, class: "nav-link js-scroll-trigger" %></li>
+            <li class="nav-item"><%= link_to "セルフチェックインの結果", self_check_in_path(no_redirect: true), class: "nav-link js-scroll-trigger" %></li>
           <% end %>
 
           <% unless controller_name == "profiles" && (action_name == "new" || action_name == "create") %>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -30,7 +30,7 @@
           <% end %>
 
           <% if display_self_check_in_link? %>
-            <li class="nav-item"><%= link_to "セルフチェックイン", self_check_in_path, class: "nav-link js-scroll-trigger" %></li>
+            <li class="nav-item"><%= link_to "セルフチェックインの結果", self_check_in_path(no_redirect: true), class: "nav-link js-scroll-trigger" %></li>
           <% end %>
 
           <% unless controller_name == "profiles" && (action_name == "new" || action_name == "create") %>


### PR DESCRIPTION
## Summary
- ダッシュボード／ヘッダーのセルフチェックイン導線に `no_redirect=true` を付与し、クリック時に 3 秒後の自動リダイレクトが走らないようにした
- 参加者ダッシュボードの「参加方法」セクション内（オフライン参加の方へ）にも導線を追加
- これらの導線はチェックイン済みユーザーにのみ表示されるため、文言を「セルフチェックインの結果」に変更

## Test plan
- [ ] セルフチェックイン済みの状態で、ヘッダー／参加者ダッシュボードのリンク／「参加方法」セクションのリンクを開き、自動でダッシュボードへリダイレクトされず「イベントダッシュボードへ」ボタンが表示されることを確認
- [ ] 各箇所のリンク文言が「セルフチェックインの結果」になっていることを確認
- [ ] `bundle exec rspec spec/requests/check_in_conferences_spec.rb` で既存スペックがパスすること
