### PR TITLE
fix: view_qr で Profile が未登録の場合は登録ページにリダイレクトする

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -124,6 +124,7 @@ class ProfilesController < ApplicationController
   end
 
   def view_qr
+    redirect_to("/#{params[:event]}/registration") and return if @profile.nil?
   end
 
   def entry_sheet


### PR DESCRIPTION
## Summary
- `GET /:event/profiles/view_qr` で `@profile` が `nil` の場合に `/:event/registration` へリダイレクトするよう修正
- `Secured` concern の `redirect_to_registration` は `controller_name == 'profiles'` のときスキップされるため、`ProfilesController#view_qr` 内で明示的に nil チェック → リダイレクトを行う

## Test plan
- [ ] 未登録ユーザーで `/:event/profiles/view_qr` にアクセスし、`/:event/registration` にリダイレクトされること
- [ ] 登録済みユーザーで `/:event/profiles/view_qr` にアクセスし、従来通り QR ビューが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)