### PR TITLE
fix: Admin ダッシュボードのチェックイン数を現地参加のユニーク人数で集計する

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -21,7 +21,7 @@ class AdminController < ApplicationController
   end
 
   def statistics
-    @talks = @conference.talks.includes(:check_in_talks, registered_talks: :profile).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference.talks.includes(registered_talks: :profile).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
     @online_viewers_by_talk = OnlineViewerStats.new(@conference).viewer_counts_by_talk || {}
     @check_in_counts_by_talk = CheckInTalk.where(talk_id: @talks.map(&:id))
                                           .group(:talk_id)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,7 +6,11 @@ class AdminController < ApplicationController
     @current = Video.on_air(current_conference)
     @offline_registrants_count = current_conference.profiles.offline.count
     @online_registrants_count = current_conference.profiles.online.count
-    @checked_in_count = current_conference.check_in_conferences.count
+    @checked_in_count = current_conference.check_in_conferences
+                                          .joins(:profile)
+                                          .merge(Profile.offline)
+                                          .distinct
+                                          .count(:profile_id)
     @online_viewers_count = OnlineViewerStats.new(current_conference).unique_viewers_count
   end
 
@@ -19,6 +23,10 @@ class AdminController < ApplicationController
   def statistics
     @talks = @conference.talks.includes(:check_in_talks, registered_talks: :profile).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
     @online_viewers_by_talk = OnlineViewerStats.new(@conference).viewer_counts_by_talk || {}
+    @check_in_counts_by_talk = CheckInTalk.where(talk_id: @talks.map(&:id))
+                                          .group(:talk_id)
+                                          .distinct
+                                          .count(:profile_id)
   end
 
   def export_statistics

--- a/app/views/admin/statistics.erb
+++ b/app/views/admin/statistics.erb
@@ -28,7 +28,7 @@
             <td><%= talk.title %></td>
             <td><%= talk.offline_participation_size %></td>
             <td><%= talk.online_participation_size %></td>
-            <td><%= talk.check_in_talks.size %></td>
+            <td><%= @check_in_counts_by_talk[talk.id] || 0 %></td>
             <td><%= @online_viewers_by_talk[talk.id] || 'N/A' %></td>
           </tr>
         <% end %>

--- a/spec/requests/admin/statistics_spec.rb
+++ b/spec/requests/admin/statistics_spec.rb
@@ -34,6 +34,25 @@ describe AdminController, type: :request do
             expect(response).to(be_successful)
             expect(response).to(have_http_status('200'))
           end
+
+          context 'when check_in_talks contain duplicates for the same profile' do
+            before do
+              create(:talk1, :accepted)
+              alice = Profile.find_by(first_name: 'Alice')
+              talk = Talk.find(1)
+              CheckInTalk.create!(profile: alice, talk:, check_in_timestamp: Time.current)
+              CheckInTalk.create!(profile: alice, talk:, check_in_timestamp: Time.current)
+            end
+
+            it 'counts unique profiles per talk' do
+              get admin_statistics_path(event: 'cndt2020')
+              expect(response).to(have_http_status('200'))
+              doc = Nokogiri::HTML.parse(response.body)
+              row = doc.css('table.talks_table tbody tr').first
+              # columns: ID, Title, 登録者数(現地), 登録者数(オンライン), チェックイン数, オンライン視聴数
+              expect(row.css('td')[4].text.strip).to(eq('1'))
+            end
+          end
         end
       end
     end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -50,6 +50,26 @@ describe AdminController, type: :request do
             expect(response).to(be_successful)
             expect(response).to(have_http_status('200'))
           end
+
+          context 'when check_in_conferences contain duplicates and online participants' do
+            before do
+              create(:bob, :on_cndt2020, participation: 'offline')
+              conference = Conference.find_by(abbr: 'cndt2020')
+              alice = Profile.find_by(first_name: 'Alice')
+              bob = Profile.find_by(first_name: 'Bob')
+              CheckInConference.create!(profile: bob, conference:, check_in_timestamp: Time.current)
+              CheckInConference.create!(profile: bob, conference:, check_in_timestamp: Time.current)
+              CheckInConference.create!(profile: alice, conference:, check_in_timestamp: Time.current)
+            end
+
+            it 'counts unique offline profiles only' do
+              get admin_path(event: 'cndt2020')
+              expect(response).to(have_http_status('200'))
+              doc = Nokogiri::HTML.parse(response.body)
+              count_card = doc.css('.bg-success .card-text').text.strip
+              expect(count_card).to(eq('1'))
+            end
+          end
         end
 
         context 'user is not admin' do


### PR DESCRIPTION
## Summary
- Admin トップ (`/<event>/admin`) の「チェックインした人数」を、現地参加者のユニーク人数で集計するように修正
- 同じ理由で水増しされていた Admin Statistics ページのセッション別チェックイン数も distinct な人数ベースに揃える

## 背景
`check_in_conferences` には `(conference_id, profile_id)` の unique 制約が無く、`CheckInConference` を作成するパス (セルフチェックイン / Admin 手動チェックイン / 受付スキャナ API) のいずれも重複チェックを行わない。このため、同じ人が複数回チェックインした場合にもレコードが増え続け、`current_conference.check_in_conferences.count` は「人数」ではなく「チェックイン操作の総回数」を表示していた。

並びの「現地参加登録者数」が `profiles.offline.count` であることに合わせ、チェックイン人数も `Profile.offline` で現地参加者に限定する。

## 変更
- `app/controllers/admin_controller.rb#show`: `check_in_conferences.joins(:profile).merge(Profile.offline).distinct.count(:profile_id)`
- `app/controllers/admin_controller.rb#statistics`: `@check_in_counts_by_talk` を `CheckInTalk.where(talk_id: ...).group(:talk_id).distinct.count(:profile_id)` で算出
- `app/views/admin/statistics.erb`: `talk.check_in_talks.size` を `@check_in_counts_by_talk[talk.id] || 0` に置換

## スコープ外 (フォローアップ候補)
- `check_in_conferences` / `check_in_talks` への `(conference_id, profile_id)` / `(talk_id, profile_id)` の unique index 追加
- 書き込みパスの `find_or_create_by!` 化
- 既存重複データのクレンジング (どのレコードを残すかは運用判断が必要)

## Test plan
- [ ] `docker compose up -d` 後に `bundle exec rspec spec/requests/admin_spec.rb` が通る
- [ ] Admin として `/<event>/admin` にアクセスし「チェックインした人数」が以下と一致する
  ```ruby
  c.check_in_conferences.joins(:profile).merge(Profile.offline).distinct.count(:profile_id)
  ```
- [ ] 同じ profile を Admin 画面から複数回チェックインしてもトップのカウントが増えないこと
- [ ] `/<event>/admin/statistics` のセッション別チェックイン数が `CheckInTalk.where(talk_id: t.id).distinct.count(:profile_id)` と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)