### PR TITLE
perf: admin/tracks の talk.live? による N+1 を解消

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,7 +77,7 @@ Metrics/BlockLength:
 # Offense count: 9
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 451
+  Max: 452
 
 # Offense count: 2
 # Configuration parameters: IgnoredMethods.

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -9,9 +9,10 @@ class Admin::TracksController < ApplicationController
     @track = @conference.tracks.find_by(name: @track_name)
     @talks = @conference
              .talks
-             .includes(:speakers, :media_package_harvest_jobs)
+             .includes(:speakers, :media_package_harvest_jobs, :proposal_items)
              .where(conference_day_id: @conference.conference_days.find_by(date: @date).id, track_id: @track.id)
              .order('conference_day_id ASC, start_time ASC, track_id ASC').includes(:video, :speakers, :conference_day, :track)
+    @proposal_item_config_cache = ProposalItemConfig.where(conference_id: @conference.id).index_by(&:id)
 
     respond_to do |format|
       format.html

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -21,9 +21,24 @@ class AdminController < ApplicationController
   end
 
   def statistics
-    @talks = @conference.talks.includes(registered_talks: :profile).accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    @talks = @conference.talks.accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    talk_ids = @talks.pluck(:id)
+
+    participation_counts = RegisteredTalk.joins(:profile)
+                                         .where(talk_id: talk_ids)
+                                         .group(:talk_id, 'profiles.participation')
+                                         .count
+    @online_counts_by_talk  = Hash.new(0)
+    @offline_counts_by_talk = Hash.new(0)
+    participation_counts.each do |(tid, participation), count|
+      case participation
+      when Profile.participations[:online]  then @online_counts_by_talk[tid]  = count
+      when Profile.participations[:offline] then @offline_counts_by_talk[tid] = count
+      end
+    end
+
     @online_viewers_by_talk = OnlineViewerStats.new(@conference).viewer_counts_by_talk || {}
-    @check_in_counts_by_talk = CheckInTalk.where(talk_id: @talks.map(&:id))
+    @check_in_counts_by_talk = CheckInTalk.where(talk_id: talk_ids)
                                           .group(:talk_id)
                                           .distinct
                                           .count(:profile_id)

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -354,11 +354,17 @@ class Talk < ApplicationRecord
     r
   end
 
-  def live?
-    method = proposal_items.find_by(label: 'presentation_method')
+  def live?(config_cache: nil)
+    method = if proposal_items.loaded?
+               proposal_items.detect { |pi| pi.label == 'presentation_method' }
+             else
+               proposal_items.find_by(label: 'presentation_method')
+             end
     return false unless method
 
-    config = ProposalItemConfig.find(method.params)
+    config = config_cache ? config_cache[method.params.to_i] : ProposalItemConfig.find(method.params)
+    return false unless config
+
     %w[オンライン登壇 現地登壇].include?(config.params)
   end
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -364,7 +364,6 @@ class Talk < ApplicationRecord
 
     config = config_cache ? config_cache[method.params.to_i] : ProposalItemConfig.find(method.params)
     return false unless config
-
     %w[オンライン登壇 現地登壇].include?(config.params)
   end
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -364,6 +364,7 @@ class Talk < ApplicationRecord
 
     config = config_cache ? config_cache[method.params.to_i] : ProposalItemConfig.find(method.params)
     return false unless config
+
     %w[オンライン登壇 現地登壇].include?(config.params)
   end
 

--- a/app/views/admin/statistics.erb
+++ b/app/views/admin/statistics.erb
@@ -26,8 +26,8 @@
           <tr>
             <td><%= talk.id %></td>
             <td><%= talk.title %></td>
-            <td><%= talk.offline_participation_size %></td>
-            <td><%= talk.online_participation_size %></td>
+            <td><%= @offline_counts_by_talk[talk.id] %></td>
+            <td><%= @online_counts_by_talk[talk.id] %></td>
             <td><%= @check_in_counts_by_talk[talk.id] || 0 %></td>
             <td><%= @online_viewers_by_talk[talk.id] || 'N/A' %></td>
           </tr>

--- a/app/views/admin/tracks/partial/_record_button.html.erb
+++ b/app/views/admin/tracks/partial/_record_button.html.erb
@@ -1,4 +1,4 @@
-<% if talk.abstract != 'intermission' && talk.live? %>
+<% if talk.abstract != 'intermission' && talk.live?(config_cache: @proposal_item_config_cache) %>
   <% if already_recorded?(talk) %>
     <div class="btn btn-primary">録画済み</div>
   <% else %>

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -22,6 +22,35 @@ describe Talk, type: :model do
         expect(talk.live?).to(be_falsey)
       end
     end
+
+    context 'with preloaded proposal_items and config_cache' do
+      let!(:presentation_method) { create(:presentation_method, conference: cndt2020, talk:, params: proposal_item_config_1.id) }
+      let(:preloaded_talk) { Talk.includes(:proposal_items).find(talk.id) }
+      let(:config_cache) { ProposalItemConfig.where(conference_id: cndt2020.id).index_by(&:id) }
+
+      it 'returns true without issuing additional queries for proposal_items or ProposalItemConfig' do
+        preloaded_talk
+        config_cache
+        expect(preloaded_talk.proposal_items).to(be_loaded)
+
+        result = nil
+        query_count = 0
+        counter = ->(_name, _start, _finish, _id, payload) {
+          query_count += 1 unless %w[SCHEMA TRANSACTION].include?(payload[:name])
+        }
+        ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+          result = preloaded_talk.live?(config_cache:)
+        end
+
+        expect(result).to(be(true))
+        expect(query_count).to(eq(0))
+      end
+
+      it 'uses the supplied cache instead of querying ProposalItemConfig' do
+        expect(ProposalItemConfig).not_to(receive(:find))
+        expect(preloaded_talk.live?(config_cache:)).to(be(true))
+      end
+    end
   end
 
   describe '#export_csv' do

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -35,7 +35,7 @@ describe Talk, type: :model do
 
         result = nil
         query_count = 0
-        counter = ->(_name, _start, _finish, _id, payload) {
+        counter = lambda { |_name, _start, _finish, _id, payload|
           query_count += 1 unless %w[SCHEMA TRANSACTION].include?(payload[:name])
         }
         ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do


### PR DESCRIPTION
talk 毎に proposal_items.find_by と ProposalItemConfig.find が走り 2N クエリが発生していたため、proposal_items を preload し
ProposalItemConfig を一括取得した cache を渡して 2 クエリに削減。