### PR TITLE
fix: ALB 502 を防ぐため Puma の persistent_timeout を設定

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,6 +30,11 @@ threads threads_count, threads_count
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch('PORT', 3000)
 
+# ALB の idle timeout (デフォルト 60s) より長くしておく。
+# Puma 側が先に keep-alive コネクションを閉じると、ALB が再利用しようとした
+# 瞬間に RST となり HTTP 502 (target status code = -) が発生するため。
+persistent_timeout ENV.fetch('PUMA_PERSISTENT_TIMEOUT', 75).to_i
+
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 


### PR DESCRIPTION
## Summary
- 本番 ALB で時々発生する **HTTP 502 / target status code = `-`** のスパイクを修正
- `config/puma.rb` に `persistent_timeout` を追加(デフォルト 75 秒、`PUMA_PERSISTENT_TIMEOUT` で上書き可)

## 背景 / 原因
- Puma の `persistent_timeout` のデフォルトは **20 秒**
- ALB の idle timeout のデフォルトは **60 秒**
- ALB は idle になった keep-alive コネクションを最大 60 秒再利用するが、Puma 側が 20 秒で先に閉じるため、ALB がリクエストを書き込んだ瞬間に RST が返り **502** になる
- バックエンドは応答すらしていないので、ALB のログでは target status code が `-` として記録される
- これは負荷問題ではなく **コネクション単位のレースコンディション**で、ECS タスク数を増やしても緩和しない

## 対策
- `persistent_timeout` を ALB の idle timeout (60s) より長い 75 秒に設定し、コネクションの切断を必ず ALB 側から行わせる
- ALB の idle timeout を変更したい場合は環境変数 `PUMA_PERSISTENT_TIMEOUT` で上書き可能

## Test plan
- [ ] デプロイ後、CloudWatch / o11y ダッシュボードで ALB 5XX (target = `-`) のスパイクが消えることを確認
- [ ] アプリケーションのリクエスト処理に異常がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)