### PR TITLE
fix: presentation_method 未設定の conference でも録画ボタンを表示

### DIFF
--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -13,6 +13,7 @@ class Admin::TracksController < ApplicationController
              .where(conference_day_id: @conference.conference_days.find_by(date: @date).id, track_id: @track.id)
              .order('conference_day_id ASC, start_time ASC, track_id ASC').includes(:video, :speakers, :conference_day, :track)
     @proposal_item_config_cache = ProposalItemConfig.where(conference_id: @conference.id).index_by(&:id)
+    @has_presentation_method = @proposal_item_config_cache.values.any? { |c| c.label == 'presentation_method' }
 
     respond_to do |format|
       format.html

--- a/app/views/admin/tracks/partial/_record_button.html.erb
+++ b/app/views/admin/tracks/partial/_record_button.html.erb
@@ -1,4 +1,4 @@
-<% if talk.abstract != 'intermission' && talk.live?(config_cache: @proposal_item_config_cache) %>
+<% if talk.abstract != 'intermission' && (!@has_presentation_method || talk.live?(config_cache: @proposal_item_config_cache)) %>
   <% if already_recorded?(talk) %>
     <div class="btn btn-primary">録画済み</div>
   <% else %>


### PR DESCRIPTION
## Summary
- カンファレンスに `presentation_method` の `proposal_item_config` が無い場合、`talk.live?` が常に false を返し、`admin/tracks` の Recording 列に「録画する」リンクが一切表示されない不具合を修正
- `Admin::TracksController#index` で cache 済みの `ProposalItemConfig` から `presentation_method` の有無を判定（追加 SQL なし）
- `_record_button.html.erb` の表示条件で、`presentation_method` 設定が無いときは `live?` チェックをスキップ

## 挙動
| `presentation_method` config | `talk.live?` | 表示 |
|---|---|---|
| あり | true | 録画する / 録画済み |
| あり | false（事前収録など） | 表示なし |
| **なし** | (判定スキップ) | **常に表示**（intermission 以外） |

## Test plan
- [ ] `presentation_method` を持たない conference の `/admin/<event>/tracks` を開き、Recording 列に「録画する」リンクが表示されること
- [ ] `presentation_method` を持つ conference では従来通り、`オンライン登壇` / `現地登壇` の talk のみリンクが表示されること
- [ ] `intermission` の talk では引き続きリンクが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)