### PR TITLE
fix: admin/statistics の登録者数(現地/オンライン)が常に 0 になる問題を修正

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -24,18 +24,7 @@ class AdminController < ApplicationController
     @talks = @conference.talks.accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
     talk_ids = @talks.pluck(:id)
 
-    participation_counts = RegisteredTalk.joins(:profile)
-                                         .where(talk_id: talk_ids)
-                                         .group(:talk_id, 'profiles.participation')
-                                         .count
-    @online_counts_by_talk  = Hash.new(0)
-    @offline_counts_by_talk = Hash.new(0)
-    participation_counts.each do |(tid, participation), count|
-      case participation
-      when Profile.participations[:online]  then @online_counts_by_talk[tid]  = count
-      when Profile.participations[:offline] then @offline_counts_by_talk[tid] = count
-      end
-    end
+    @online_counts_by_talk, @offline_counts_by_talk = participation_counts_by_talk(talk_ids)
 
     @online_viewers_by_talk = OnlineViewerStats.new(@conference).viewer_counts_by_talk || {}
     @check_in_counts_by_talk = CheckInTalk.where(talk_id: talk_ids)
@@ -46,13 +35,30 @@ class AdminController < ApplicationController
 
   def export_statistics
     f = Tempfile.create('statistics.csv')
-    @conference = Conference.includes(talks: [registered_talks: :profile]).find_by(abbr: params[:event])
+    @conference = Conference.find_by(abbr: params[:event])
+    @talks = @conference.talks.accepted.order('conference_day_id ASC, start_time ASC, track_id ASC')
+    talk_ids = @talks.pluck(:id)
+
+    @online_counts_by_talk, @offline_counts_by_talk = participation_counts_by_talk(talk_ids)
+
     CSV.open(f.path, 'wb') do |csv|
       csv << %w[id item online_participation_size offline_participation_size]
-      @conference.talks.accepted.each do |talk|
-        csv << %W[#{talk.id} #{talk.title} #{talk.online_participation_size} #{talk.offline_participation_size}]
+      @talks.each do |talk|
+        csv << %W[#{talk.id} #{talk.title} #{@online_counts_by_talk[talk.id]} #{@offline_counts_by_talk[talk.id]}]
       end
     end
     send_file(f.path, filename: "statistics-#{Time.now.strftime("%F")}.csv", length: File.stat(f.path).size)
+  end
+
+  private
+
+  def participation_counts_by_talk(talk_ids)
+    online = RegisteredTalk.joins(:profile).merge(Profile.online)
+                           .where(talk_id: talk_ids).group(:talk_id).count
+    online.default = 0
+    offline = RegisteredTalk.joins(:profile).merge(Profile.offline)
+                            .where(talk_id: talk_ids).group(:talk_id).count
+    offline.default = 0
+    [online, offline]
   end
 end


### PR DESCRIPTION
## Summary
- `admin#statistics` / `admin#export_statistics` の「登録者数(現地)」「登録者数(オンライン)」が全 talk で 0 になる問題を修正
- 共通の集計処理を `participation_counts_by_talk(talk_ids)` private メソッドに抽出

## 原因
\`\`\`ruby
participation_counts = RegisteredTalk.joins(:profile)
                                     .where(talk_id: talk_ids)
                                     .group(:talk_id, 'profiles.participation')
                                     .count
participation_counts.each do |(tid, participation), count|
  case participation
  when Profile.participations[:online]  then ...
  when Profile.participations[:offline] then ...
  end
end
\`\`\`

- 上記 group 句は ORM を経由せず DB の生値で集計するため、Hash のキーは `[talk_id, "online"]` / `[talk_id, "offline"]`(enum のキー名)
- 一方 `Profile.participations[:online]` は enum の値 `"オンライン参加"` を返す
- 本番で確認したところ profiles.participation には `"online"` / `"offline"` が格納されており、case 文ではマッチせず常に 0 になっていた

## 修正
- `Profile.online` / `Profile.offline` scope を `merge` する形に変更
- enum 定義に従って WHERE 句が組み立てられるため、DB の実値が何であれ整合する(admin#show でも同じ scope を利用しており動作実績あり)
- `statistics` と `export_statistics` 両方で同じ集計を行うため `participation_counts_by_talk(talk_ids)` に抽出

## 関連 PR
- 集計 SQL 一括化を入れた a16b0008 (perf: admin/statistics の参加者数集計を SQL 一括化) のリグレッション
- #2827 で入ったチェックイン数の修正 (`@check_in_counts_by_talk` / `@checked_in_count`) には触れておらず維持されている

## Test plan
- [ ] `/<event>/admin/statistics` で各セッションの「登録者数(現地)」「登録者数(オンライン)」が以下と一致する
  \`\`\`ruby
  RegisteredTalk.joins(:profile).merge(Profile.offline).where(talk_id: t.id).count
  RegisteredTalk.joins(:profile).merge(Profile.online).where(talk_id: t.id).count
  \`\`\`
- [ ] 「エクスポート」ボタンで取得した CSV の `online_participation_size` / `offline_participation_size` が画面上の値と一致する
- [ ] チェックイン数 (`@check_in_counts_by_talk`) が引き続き正しく表示される (PR #2827 のリグレッションが無いこと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)