### PR TITLE
fix: セッション情報モーダル内で videojs 動画が再生できない問題を修正

### DIFF
--- a/app/javascript/packs/timetable.js
+++ b/app/javascript/packs/timetable.js
@@ -57,7 +57,13 @@ window.addEventListener('DOMContentLoaded', function() {
 
                 function closeModal() {
                     players.forEach(function(player) {
-                        try { player.dispose(); } catch (_) {}
+                        if (!player || typeof player.dispose !== 'function') return;
+                        if (typeof player.isDisposed === 'function' && player.isDisposed()) return;
+                        try {
+                            player.dispose();
+                        } catch (error) {
+                            console.error('Failed to dispose video player in talk modal.', error);
+                        }
                     });
                     players = [];
                     modal.classList.remove('show');

--- a/app/javascript/packs/timetable.js
+++ b/app/javascript/packs/timetable.js
@@ -46,7 +46,20 @@ window.addEventListener('DOMContentLoaded', function() {
                 modal.classList.add('show');
                 document.body.classList.add('modal-open');
 
+                var players = [];
+                if (window.videojs) {
+                    modal.querySelectorAll('video.video-js').forEach(function(el) {
+                        if (!el.hasAttribute('data-vjs-player')) {
+                            players.push(window.videojs(el));
+                        }
+                    });
+                }
+
                 function closeModal() {
+                    players.forEach(function(player) {
+                        try { player.dispose(); } catch (_) {}
+                    });
+                    players = [];
                     modal.classList.remove('show');
                     modal.style.display = 'none';
                     document.body.classList.remove('modal-open');


### PR DESCRIPTION
## Summary
- タイムテーブルやセッション一覧から開ける「セッション情報モーダル」内で video.js による動画再生ができない問題を修正
- モーダルが `fetch` + `innerHTML` で talk show ページの本文を後挿入するため、`DOMContentLoaded` でのみ走る `video_player.js` の自動初期化に拾われず、モーダル内の `<video class=\"video-js\">` が素の HTML5 video のまま残っていた（HLS をネイティブ再生できないブラウザでは再生不能）
- `timetable.js` 側でモーダル展開直後に `window.videojs(el)` を明示的に呼び、`closeModal` で `dispose()` するように変更

## Test plan
- [ ] 対象テンプレート (`_timetable.html.erb` / `_timetable_cnk.html.erb` / `_talk.html.erb`) を使う会期のタイムテーブルを開く
- [ ] 動画公開済みセッションのタイトルをクリックし、モーダル内で videojs UI（再生ボタン・シークバー等）が表示され、HLS が再生できることを確認
- [ ] モーダルを閉じてから別セッションを開き直し、前の再生が引き継がれずに新しい動画が再生できることを確認（dispose 確認）
- [ ] パーマリンク `/talks/:id` を直接開いてこれまで通り再生できることを確認（リグレッションなし）
- [ ] 動画未公開セッションでモーダルを開き、「アーカイブ動画は現在作成中」アラートが表示され JS エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)