### PR TITLE
fix: MediaLive 配信パラメータをスライド主体配信向けに最適化

### DIFF
--- a/app/models/media_live_channel.rb
+++ b/app/models/media_live_channel.rb
@@ -254,9 +254,9 @@ class MediaLiveChannel < ApplicationRecord
 
     def audio_descriptions
       [
-        audio_description_template('audio_1', 192000, 48000),
-        audio_description_template('audio_2', 192000, 48000),
-        audio_description_template('audio_3', 128000, 48000)
+        audio_description_template('audio_1', 96000, 48000),
+        audio_description_template('audio_2', 96000, 48000),
+        audio_description_template('audio_3', 64000, 48000)
       ]
     end
 
@@ -292,7 +292,7 @@ class MediaLiveChannel < ApplicationRecord
             caption_language_mappings: [],
             caption_language_setting: 'OMIT',
             client_cache: 'ENABLED',
-            codec_specification: 'RFC_4281',
+            codec_specification: 'RFC_6381',
             destination: { destination_ref_id: 'dest-mediapackage' },
             directory_structure: 'SINGLE_DIRECTORY',
             discontinuity_tags: 'INSERT',
@@ -317,15 +317,15 @@ class MediaLiveChannel < ApplicationRecord
             manifest_duration_format: 'INTEGER',
             mode: 'LIVE',
             output_selection: 'MANIFESTS_AND_SEGMENTS',
-            program_date_time: 'EXCLUDE',
-            program_date_time_period: 600,
+            program_date_time: 'INCLUDE',
+            program_date_time_period: 60,
             redundant_manifest: 'DISABLED',
-            segment_length: 1,
+            segment_length: 2,
             segmentation_mode: 'USE_SEGMENT_DURATION',
             segments_per_subdirectory: 10000,
             stream_inf_resolution: 'INCLUDE',
             timed_metadata_id_3_frame: 'PRIV',
-            timed_metadata_id_3_period: 10,
+            timed_metadata_id_3_period: 2,
             ts_file_mode: 'SEGMENTED_FILES'
           }
         },
@@ -370,13 +370,13 @@ class MediaLiveChannel < ApplicationRecord
 
     def video_descriptions
       [
-        video_description_template('video_1080p30', 1080, 1920, 5000000, 50),
-        video_description_template('video_720p30', 720, 1280, 3000000, 100),
-        video_description_template('video_480p30', 480, 854, 1500000, 100)
+        video_description_template('video_1080p30', 1080, 1920, 3500000, 50),
+        video_description_template('video_720p30', 720, 1280, 2000000, 100),
+        video_description_template('video_480p30', 480, 854, 800000, 100)
       ]
     end
 
-    def video_description_template(name, height, width, bitrate, sharpness)
+    def video_description_template(name, height, width, max_bitrate, sharpness)
       {
         name:,
         height:,
@@ -385,7 +385,6 @@ class MediaLiveChannel < ApplicationRecord
           h264_settings: {
             adaptive_quantization: 'HIGH',
             afd_signaling: 'NONE',
-            bitrate:,
             color_metadata: 'INSERT',
             entropy_encoding: 'CABAC',
             flicker_aq: 'ENABLED',
@@ -394,15 +393,17 @@ class MediaLiveChannel < ApplicationRecord
             framerate_numerator: 30,
             gop_b_reference: 'ENABLED',
             gop_closed_cadence: 1,
-            gop_num_b_frames: 1,
-            gop_size: 3,
-            gop_size_units: 'FRAMES',
+            gop_num_b_frames: 3,
+            gop_size: 2,
+            gop_size_units: 'SECONDS',
             level: 'H264_LEVEL_AUTO',
             look_ahead_rate_control: 'HIGH',
+            max_bitrate:,
             num_ref_frames: 3,
             par_control: 'INITIALIZE_FROM_SOURCE',
-            profile: 'MAIN',
-            rate_control_mode: 'CBR',
+            profile: 'HIGH',
+            qvbr_quality_level: 7,
+            rate_control_mode: 'QVBR',
             scan_type: 'PROGRESSIVE',
             scene_change_detect: 'ENABLED',
             slices: 1,
@@ -413,7 +414,7 @@ class MediaLiveChannel < ApplicationRecord
           }
         },
         respond_to_afd: 'NONE',
-        scaling_behavior: 'STRETCH_TO_OUTPUT',
+        scaling_behavior: 'DEFAULT',
         sharpness:
       }
     end
@@ -437,9 +438,9 @@ class MediaLiveChannel < ApplicationRecord
 
     def audio_descriptions
       [
-        audio_description_template('media_package_v2_audio_1', 192000, 48000),
-        audio_description_template('media_package_v2_audio_2', 192000, 48000),
-        audio_description_template('media_package_v2_audio_3', 128000, 48000)
+        audio_description_template('media_package_v2_audio_1', 96000, 48000),
+        audio_description_template('media_package_v2_audio_2', 96000, 48000),
+        audio_description_template('media_package_v2_audio_3', 64000, 48000)
       ]
     end
 
@@ -475,7 +476,7 @@ class MediaLiveChannel < ApplicationRecord
             caption_language_mappings: [],
             caption_language_setting: 'OMIT',
             client_cache: 'ENABLED',
-            codec_specification: 'RFC_4281',
+            codec_specification: 'RFC_6381',
             destination: { destination_ref_id: 'dest-mediapackagev2' },
             directory_structure: 'SINGLE_DIRECTORY',
             discontinuity_tags: 'INSERT',
@@ -500,15 +501,15 @@ class MediaLiveChannel < ApplicationRecord
             manifest_duration_format: 'INTEGER',
             mode: 'LIVE',
             output_selection: 'MANIFESTS_AND_SEGMENTS',
-            program_date_time: 'EXCLUDE',
-            program_date_time_period: 600,
+            program_date_time: 'INCLUDE',
+            program_date_time_period: 60,
             redundant_manifest: 'DISABLED',
-            segment_length: 1,
+            segment_length: 2,
             segmentation_mode: 'USE_SEGMENT_DURATION',
             segments_per_subdirectory: 10000,
             stream_inf_resolution: 'INCLUDE',
             timed_metadata_id_3_frame: 'PRIV',
-            timed_metadata_id_3_period: 10,
+            timed_metadata_id_3_period: 2,
             ts_file_mode: 'SEGMENTED_FILES'
           }
         },
@@ -553,13 +554,13 @@ class MediaLiveChannel < ApplicationRecord
 
     def video_descriptions
       [
-        video_description_template('media_package_v2_video_1080p30', 1080, 1920, 5000000, 50),
-        video_description_template('media_package_v2_video_720p30', 720, 1280, 3000000, 100),
-        video_description_template('media_package_v2_video_480p30', 480, 854, 1500000, 100)
+        video_description_template('media_package_v2_video_1080p30', 1080, 1920, 3500000, 50),
+        video_description_template('media_package_v2_video_720p30', 720, 1280, 2000000, 100),
+        video_description_template('media_package_v2_video_480p30', 480, 854, 800000, 100)
       ]
     end
 
-    def video_description_template(name, height, width, bitrate, sharpness)
+    def video_description_template(name, height, width, max_bitrate, sharpness)
       {
         name:,
         height:,
@@ -568,7 +569,6 @@ class MediaLiveChannel < ApplicationRecord
           h264_settings: {
             adaptive_quantization: 'HIGH',
             afd_signaling: 'NONE',
-            bitrate:,
             color_metadata: 'INSERT',
             entropy_encoding: 'CABAC',
             flicker_aq: 'ENABLED',
@@ -577,15 +577,17 @@ class MediaLiveChannel < ApplicationRecord
             framerate_numerator: 30,
             gop_b_reference: 'ENABLED',
             gop_closed_cadence: 1,
-            gop_num_b_frames: 1,
-            gop_size: 1,
+            gop_num_b_frames: 3,
+            gop_size: 2,
             gop_size_units: 'SECONDS',
             level: 'H264_LEVEL_AUTO',
             look_ahead_rate_control: 'HIGH',
+            max_bitrate:,
             num_ref_frames: 3,
             par_control: 'INITIALIZE_FROM_SOURCE',
-            profile: 'MAIN',
-            rate_control_mode: 'CBR',
+            profile: 'HIGH',
+            qvbr_quality_level: 7,
+            rate_control_mode: 'QVBR',
             scan_type: 'PROGRESSIVE',
             scene_change_detect: 'ENABLED',
             slices: 1,
@@ -596,7 +598,7 @@ class MediaLiveChannel < ApplicationRecord
           }
         },
         respond_to_afd: 'NONE',
-        scaling_behavior: 'STRETCH_TO_OUTPUT',
+        scaling_behavior: 'DEFAULT',
         sharpness:
       }
     end


### PR DESCRIPTION
## Summary

`app/models/media_live_channel.rb` の `OutputGroupMediaPackage` (V1) と `OutputGroupMediaPackageV2` (V2) の配信パラメータを見直し、Dreamkast のカンファレンス配信（スライド主体＋登壇者カメラ程度）に最適化しました。

### バグ修正
- **V1 の GOP サイズが 3 フレーム (0.1秒) と極端に短かった** のを 2 秒 (SECONDS) に修正。V2 は既に SECONDS 指定だったが値だけ 1 → 2 へ揃えた。
  - I フレームが過剰に挿入されて圧縮効率を著しく損ねていた状態を解消。

### 画質・互換性
- H.264 プロファイル `MAIN` → `HIGH`（同画質で 10〜15% 帯域削減）
- `scaling_behavior` `STRETCH_TO_OUTPUT` → `DEFAULT`（アスペクト比が崩れる不具合を防ぐ）
- `codec_specification` `RFC_4281` → `RFC_6381`（現行 HLS 推奨仕様）
- `program_date_time` `EXCLUDE` → `INCLUDE`（周期 600 → 60秒、プレイヤー同期向上）

### コスト削減
- レート制御 `CBR` → `QVBR` (`qvbr_quality_level: 7`)。動きの少ない区間で実効ビットレートが自動的に下がる。
- `gop_num_b_frames` 1 → 3、`gop_size` 2 秒 + HLS `segment_length` を 1 → 2 秒に揃えて I フレーム頻度を半減。
- ビデオ `max_bitrate`: 1080p 5.0 → 3.5 Mbps、720p 3.0 → 2.0 Mbps、480p 1.5 → 0.8 Mbps
- オーディオ bitrate: 192/192/128 → 96/96/64 kbps（登壇者音声主体・BGM 想定なし）
- `timed_metadata_id_3_period` 10 → 2（新 segment_length と整合）

### トレードオフ
- HLS セグメント長を 2 秒に伸ばしたため、ライブ遅延が約 1〜2 秒増加します。スライド配信中心であれば許容可能と判断しました。

## Test plan

- [ ] `bundle exec rspec spec/jobs/create_streaming_aws_resources_job_spec.rb spec/jobs/delete_streaming_aws_resources_job_spec.rb`
- [ ] `bundle exec rubocop app/models/media_live_channel.rb`
- [ ] review_app / staging で `Admin::StreamingsController#create_aws_resources` を実行し、AWS Console 上で以下を確認
  - `rate_control_mode = QVBR`, `qvbr_quality_level = 7`, `max_bitrate` の各値
  - `gop_size = 2 SECONDS`, `gop_num_b_frames = 3`, `profile = HIGH`
  - HLS `segment_length = 2`, `codec_specification = RFC_6381`, `program_date_time = INCLUDE`
- [ ] OBS から RTMP push し、MediaPackage の HLS マニフェスト (`.m3u8`) を確認
  - `#EXT-X-PROGRAM-DATE-TIME` が 60 秒ごとに挿入されている
  - `CODECS=` が `avc1.6400xx` 系 (HIGH プロファイル)
  - `BANDWIDTH=` が新 max_bitrate 付近
- [ ] hls.js リファレンスプレイヤーで再生し、レンディション切替・アスペクト比・音声に問題が無いことを確認
- [ ] 静止画区間で実効ビットレートが QVBR 平均見込み（1080p: 〜1.8 Mbps, 720p: 〜1.0 Mbps, 480p: 〜0.4 Mbps）まで下がること
- [ ] 検証後、`delete_aws_resources` で必ずリソースを破棄

## スコープ外（別タスク化候補）

- `MediaLiveInputSecurityGroup` の CIDR `0.0.0.0/0` 制限化
- IAM Role ARN のハードコード解消（環境変数化）
- V1/V2 コードの DRY 化（共通モジュール抽出）
- `OutputGroupIvs` クラスの利用状況確認
- `audio_rendition_sets` を使った 3 オーディオ → 1 オーディオへの統合
- `channel_class` SINGLE_PIPELINE → STANDARD 化（本番イベント時の冗長化）

https://claude.ai/code/session_01Rf6NeZ2cVggvgvWdgeYRPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf6NeZ2cVggvgvWdgeYRPQ)_