### PR TITLE
Api の talks/tracks index で conference 未解決時に 404 を返す

### DIFF
--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::TalksController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def index
-    render_400 and return if current_conference.nil?
+    render_404_json and return if current_conference.nil?
     query = { conference_id: current_conference.id }
     query[:track_id] = params[:trackId] if params[:trackId]
     @talks = Talk.includes(:conference, :conference_day, :talk_time, :talk_difficulty, :talk_category, :talks_speakers, :video, :speakers, registered_talks: :profile)

--- a/app/controllers/api/v1/talks_controller.rb
+++ b/app/controllers/api/v1/talks_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::TalksController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def index
+    render_400 and return if current_conference.nil?
     query = { conference_id: current_conference.id }
     query[:track_id] = params[:trackId] if params[:trackId]
     @talks = Talk.includes(:conference, :conference_day, :talk_time, :talk_difficulty, :talk_category, :talks_speakers, :video, :speakers, registered_talks: :profile)

--- a/app/controllers/api/v1/tracks_controller.rb
+++ b/app/controllers/api/v1/tracks_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::TracksController < ApplicationController
   def index
-    render_400 and return if current_conference.nil?
+    render_404_json and return if current_conference.nil?
     @tracks = Track.where(conference_id: current_conference.id)
     render(:index, formats: :json, type: :jbuilder)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,6 +109,10 @@ class ApplicationController < ActionController::Base
     render(json: { message: 'bad request' }, status: 400, formats: :json)
   end
 
+  def render_404_json
+    render(json: { message: 'not found' }, status: 404, formats: :json)
+  end
+
   # カンファレンス開催前、かつCFP中
   # カンファレンス開催前、かつ自身が登壇者の場合(CFP締め切り後)
   # カンファレンス開催中、かつ自身が登壇者の場合

--- a/spec/requests/api/v1/talk_index_spec.rb
+++ b/spec/requests/api/v1/talk_index_spec.rb
@@ -56,14 +56,14 @@ describe TalksController, type: :request do
         create(:cndt2020)
       end
 
-      it 'returns 400 when eventAbbr is missing' do
+      it 'returns 404 when eventAbbr is missing' do
         get '/api/v1/talks'
-        expect(response.status).to(eq(400))
+        expect(response.status).to(eq(404))
       end
 
-      it 'returns 400 when eventAbbr does not match any conference' do
+      it 'returns 404 when eventAbbr does not match any conference' do
         get '/api/v1/talks?eventAbbr=not_found'
-        expect(response.status).to(eq(400))
+        expect(response.status).to(eq(404))
       end
     end
 

--- a/spec/requests/api/v1/talk_index_spec.rb
+++ b/spec/requests/api/v1/talk_index_spec.rb
@@ -51,6 +51,22 @@ describe TalksController, type: :request do
       end
     end
 
+    describe 'conference cannot be resolved' do
+      before do
+        create(:cndt2020)
+      end
+
+      it 'returns 400 when eventAbbr is missing' do
+        get '/api/v1/talks'
+        expect(response.status).to(eq(400))
+      end
+
+      it 'returns 400 when eventAbbr does not match any conference' do
+        get '/api/v1/talks?eventAbbr=not_found'
+        expect(response.status).to(eq(400))
+      end
+    end
+
     describe 'speakers exposes userId' do
       let!(:cndt2020) { create(:cndt2020) }
       let!(:speaker) { create(:speaker_alice, :with_talk1_accepted) }

--- a/spec/requests/api/v1/track_index_spec.rb
+++ b/spec/requests/api/v1/track_index_spec.rb
@@ -17,5 +17,15 @@ describe TalksController, type: :request do
       get '/api/v1/tracks?eventAbbr=cndt2020'
       expect(response.status).to(eq(200))
     end
+
+    it 'returns 404 when eventAbbr is missing' do
+      get '/api/v1/tracks'
+      expect(response.status).to(eq(404))
+    end
+
+    it 'returns 404 when eventAbbr does not match any conference' do
+      get '/api/v1/tracks?eventAbbr=not_found'
+      expect(response.status).to(eq(404))
+    end
   end
 end


### PR DESCRIPTION
## 概要

`GET /api/v1/talks`（および `GET /api/v1/tracks`）で `eventAbbr` が未指定、または存在しない abbr の場合に発生していた 500 エラー (`NoMethodError: undefined method 'id' for nil`) を修正します。

## 原因

- `/api/v1/talks`・`/api/v1/tracks` のルートはパスに `:event` を含まず、イベントはクエリパラメータ `eventAbbr` で渡す想定。
- `before_action :event_exists?` は（API で HTML 404 を返さないための意図的な仕様として）`params[:event]` がある場合のみ検証し、`eventAbbr` は検証しない。
- `TalksController#index` が `eventAbbr` を検証せず `current_conference.id` を呼ぶため、`eventAbbr` 欠落・不正時に `current_conference` が `nil` となり `NoMethodError` (500) になっていた。

Sentry: `Api::V1::TalksController#index': undefined method 'id' for nil` (`talks_controller.rb:8`)

## 対応

- conference が見つからないケースは「リソース未検出」であり **404** が適切と判断。
- JSON で 404 を返す共通ヘルパ `render_404_json` を `ApplicationController` に追加（`render_404` は HTML テンプレートを返すため API では使えない）。
- `TalksController#index` に `render_404_json and return if current_conference.nil?` を追加。
- 既存の `TracksController#index` は同条件で `render_400`（400）を返していたため、こちらも `render_404_json` に統一。
- 回帰テストを追加（talks・tracks とも `eventAbbr` 欠落／不正 → 404）。

## 検証

- `spec/requests/api/v1/talk_index_spec.rb` / `track_index_spec.rb`: 12 examples, 0 failures
- rubocop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)