### PR TITLE
packageManager を yarn 1.22.22 に固定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "cndtattend",
     "private": true,
+    "packageManager": "yarn@1.22.22",
     "dependencies": {
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",


### PR DESCRIPTION
## 概要

`package.json` に `"packageManager": "yarn@1.22.22"` を追加します。

## 背景

`package.json` に `packageManager` の指定が無いため、corepack が有効な環境では corepack のグローバル設定（`~/.cache/node/corepack/lastKnownGood.json`）に記録されたバージョンが使われます。手元では yarn 4系が記録されており、その結果:

- `yarn install` / `yarn build`（`rails assets:precompile` 経由でも走る）のたびに `yarn.lock` が Berry 形式に丸ごと書き換わる（6000行規模の差分）
- `.yarnrc.yml` と `.yarn/` が勝手に生成される
- AGENT.md / README に書かれている `yarn install --check-files` が「Unsupported option name」で動かない

一方 Dockerfile は `YARN_VERSION=1.22.22`（yarn classic）前提なので、ローカルとコンテナで使われる yarn が食い違っている状態でした。

## 変更内容

Dockerfile の `YARN_VERSION` と同じ `yarn@1.22.22` を `packageManager` に指定します。

## 動作確認

手元（corepack の lastKnownGood が yarn 4.14.1 の状態）で確認:

- `yarn --version` → `1.22.22`
- `yarn install --check-files` → 成功。`yarn.lock` 無変更、`.yarnrc.yml` / `.yarn/` も生成されない
- `yarn build` → 成功。`yarn.lock` 無変更

## 影響範囲

- CI: `actions/setup-node` の `corepack` 入力は指定していないので corepack は有効化されず、ランナーの yarn classic がそのまま使われます。yarn 1 は `packageManager` フィールドを無視するため挙動は変わりません。
- Docker: `node` ステージは `/opt/yarn-v1.22.22` を直接シンボリックリンクしていて corepack を経由しないため、こちらも挙動は変わりません（指定値と一致）。

corepack を使っている開発者の手元だけが、意図した yarn classic に揃うことになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbLtNLgTzVkNvXsrLnwnEK
