### PR TITLE
キーノート専用のセッション時間を一般応募で選択できないように修正

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,7 +77,7 @@ Metrics/BlockLength:
 # Offense count: 9
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 452
+  Max: 460
 
 # Offense count: 2
 # Configuration parameters: IgnoredMethods.

--- a/app/javascript/packs/speaker_form.js
+++ b/app/javascript/packs/speaker_form.js
@@ -53,25 +53,6 @@ if (document.readyState === 'loading') {
     initializeRemoveTalkButton()
 }
 
-
-document.addEventListener('change', (e) => {
-    if (e.target.classList.contains('talk-categories')) {
-        const radio20min = e.target.parentElement.parentElement.querySelector('._20min');
-        const radio40min = e.target.parentElement.parentElement.querySelector('._40min');
-        if (e.target.selectedOptions[0].innerHTML == 'Keynote') {
-            radio20min.disabled = false;
-            radio40min.disabled = true;
-            radio20min.checked = true;
-        } else {
-            radio20min.checked = false;
-            radio20min.disabled = true;
-            radio40min.disabled = false;
-            radio40min.checked = true;
-        }
-    }
-    return false;
-});
-
 const addDeleteButtonListener = (obj) => {
     obj.removeEventListener('click', buttonListener);
     obj.addEventListener('click', buttonListener);

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -44,6 +44,7 @@ class Talk < ApplicationRecord
   # validates :start_time, presence: true
   # validates :end_time, presence: true
   validate :validate_proposal_item_configs, on: :entry_form
+  validate :validate_keynote_session_time, on: :entry_form
   validate :validate_three_conference_selection, on: :entry_form, if: -> { conference_id == 15 }
 
   SLOT_MAP = ['1000', '1300', '1400', '1500', '1600', '1700', '1800', '1900', '2000', '2100', '2200', '2300']
@@ -541,6 +542,20 @@ https://event.cloudnativedays.jp/#{conference.abbr}/talks/#{id}
       short = ProposalItemConfig.find_by(label: e).item_name.gsub(/（★*）/, '')
       errors.add(:base, "#{short}は最低1項目選択してください")
     }
+  end
+
+  # キーノート専用のセッション時間は、キーノート招待されたTalkでのみ選択できる
+  def validate_keynote_session_time
+    return if keynote?
+
+    item = proposal_items.detect { |proposal_item| proposal_item.label == SessionTime::LABEL }
+    return if item.blank?
+
+    config = ProposalItemConfig.find_by(id: item.params.to_s)
+    return if config.blank?
+    return unless config.params.to_s.include?('for keynote')
+
+    errors.add(:base, 'セッション時間にキーノート専用の項目は選択できません')
   end
 
   THREE_CONFERENCE_VALIDATION_CONFIG = [

--- a/app/views/speaker_dashboard/speakers/_session_times.html.erb
+++ b/app/views/speaker_dashboard/speakers/_session_times.html.erb
@@ -1,6 +1,9 @@
 <% classes += " #{item.params.split(' ').first}" if :session_times == label %>
 <% radio_id = "#{label}_#{item.id}_#{form_index}" %>
-<% if session_time_locked || (f.object&.proposal&.accepted?) %>
+<%# キーノート専用の選択肢は、キーノート招待されたTalk以外では選択させない %>
+<% keynote_only_item = item.params.to_s.include?('for keynote') %>
+<% disabled = session_time_locked || (keynote_only_item && !keynote_talk) || f.object&.proposal&.accepted? %>
+<% if disabled %>
   <%= radio_button_tag "speaker[talks_attributes][#{form_index}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, disabled: 'disabled', id: radio_id} %>
 <% else %>
   <%= radio_button_tag "speaker[talks_attributes][#{form_index}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, id: radio_id} %>

--- a/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
+++ b/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
@@ -135,6 +135,8 @@
           <% existing_items = f.object&.persisted? ? f.object.proposal_items.find_by(label: first_item.label)&.params : [] %>
           <% selected_radio_item = @conference.proposal_item_configs.where(item_number: item_number).find { |config| config.id.to_s == existing_items.to_s } %>
           <% session_time_locked = first_item.label == 'session_time' && selected_radio_item&.params.to_s.include?('for keynote') %>
+          <%# キーノート専用のセッション時間は、キーノート招待されたTalkでのみ選択できる %>
+          <% keynote_talk = f.object&.persisted? && f.object.keynote? %>
           <%= label_tag "speaker_talks_attributes_#{form_index}_#{first_item.label}[]", class: 'dk-label tw-block tw-font-semibold' do %>
             <%= first_item.item_name %><span class="dk-required">*</span>
           <% end %>
@@ -152,7 +154,7 @@
                 <% when 'presentation_method' %>
                   <%= render 'speaker_dashboard/speakers/presentation_method', f: f, existing_items: existing_items, first_item: first_item, item: item, classes: classes, label: label, checked: checked, form_index: form_index %>
                 <% when 'session_time' %>
-                  <%= render 'speaker_dashboard/speakers/session_times', f: f, existing_items: existing_items, first_item: first_item, item: item, classes: classes, label: label, checked: checked, form_index: form_index, session_time_locked: session_time_locked %>
+                  <%= render 'speaker_dashboard/speakers/session_times', f: f, existing_items: existing_items, first_item: first_item, item: item, classes: classes, label: label, checked: checked, form_index: form_index, session_time_locked: session_time_locked, keynote_talk: keynote_talk %>
                 <% else %>
                   <%= radio_button_tag "speaker[talks_attributes][#{form_index}][#{label}]", item.id, checked, {required: true, class: classes, params: item.params, id: radio_id} %>
                   <%= label_tag radio_id, item.params, {class: 'dk-check-label'} %>

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -563,4 +563,44 @@ https://event.cloudnativedays.jp/cndt2020/talks/1
       end
     end
   end
+
+  describe 'セッション時間のバリデーション' do
+    let!(:conference) { create(:cndt2020) }
+    let!(:talk) { create(:talk1) }
+    let!(:session_time_full) { create(:proposal_item_configs_session_time_40_min, conference:) }
+    let!(:session_time_keynote) { create(:proposal_item_configs_session_time_20_min, conference:) }
+    let(:error_message) { 'セッション時間にキーノート専用の項目は選択できません' }
+
+    context '一般応募のTalkがキーノート専用の時間を選んだ場合' do
+      before do
+        talk.create_or_update_proposal_item('session_time', session_time_keynote.id.to_s)
+      end
+
+      it 'バリデーションエラーになる' do
+        expect(talk.valid?(:entry_form)).to(be_falsey)
+        expect(talk.errors.full_messages).to(include(error_message))
+      end
+    end
+
+    context '一般応募のTalkが通常の時間を選んだ場合' do
+      before do
+        talk.create_or_update_proposal_item('session_time', session_time_full.id.to_s)
+      end
+
+      it 'バリデーションが通る' do
+        expect(talk.valid?(:entry_form)).to(be_truthy)
+      end
+    end
+
+    context 'キーノートのTalkがキーノート専用の時間を選んだ場合' do
+      before do
+        talk.talk_types << create(:talk_type, :keynote)
+        talk.create_or_update_proposal_item('session_time', session_time_keynote.id.to_s)
+      end
+
+      it 'バリデーションが通る' do
+        expect(talk.valid?(:entry_form)).to(be_truthy)
+      end
+    end
+  end
 end

--- a/spec/requests/speaker_dashboard/speakers_edit_spec.rb
+++ b/spec/requests/speaker_dashboard/speakers_edit_spec.rb
@@ -86,4 +86,53 @@ describe SpeakerDashboard::SpeakersController, type: :request do
       end
     end
   end
+
+  describe 'GET speakers#edit セッション時間の選択肢' do
+    let!(:conference) { create(:cndt2020) }
+    # 本番と同じく、セッション時間の選択肢は同一の item_number にまとめる
+    let!(:session_time_full) { create(:proposal_item_configs_session_time_40_min, conference:, item_number: 1) }
+    let!(:session_time_keynote) { create(:proposal_item_configs_session_time_20_min, conference:, item_number: 1) }
+    let!(:speaker) { create(:speaker_alice, :with_talk1_registered) }
+    let(:talk) { speaker.talks.first }
+
+    before do
+      allow_any_instance_of(ActionDispatch::Request::Session).to(receive(:[]).and_return(admin_userinfo[:userinfo]))
+    end
+
+    def session_time_radio(id)
+      Nokogiri::HTML.parse(response.body).at_css("input.radio_button_session_times[value='#{id}']")
+    end
+
+    context '一般応募のTalkの場合' do
+      it 'キーノート専用の選択肢だけが選択できない' do
+        get '/cndt2020/speaker_dashboard/speakers/1/edit'
+        expect(session_time_radio(session_time_full.id)['disabled']).to(be_nil)
+        expect(session_time_radio(session_time_keynote.id)['disabled']).to(eq('disabled'))
+      end
+    end
+
+    context 'キーノート招待されたTalkの場合' do
+      before do
+        talk.talk_types << create(:talk_type, :keynote)
+      end
+
+      it 'キーノート専用の選択肢も選択できる' do
+        get '/cndt2020/speaker_dashboard/speakers/1/edit'
+        expect(session_time_radio(session_time_keynote.id)['disabled']).to(be_nil)
+      end
+
+      context 'キーノート専用の時間が設定済みの場合' do
+        before do
+          talk.create_or_update_proposal_item('session_time', session_time_keynote.id.to_s)
+          talk.save!
+        end
+
+        it 'セッション時間を変更できない' do
+          get '/cndt2020/speaker_dashboard/speakers/1/edit'
+          expect(session_time_radio(session_time_full.id)['disabled']).to(eq('disabled'))
+          expect(session_time_radio(session_time_keynote.id)['disabled']).to(eq('disabled'))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

プロポーザル投稿フォームで、キーノート専用のセッション時間（`_20min (for keynote)` など）が一般応募でも選択できる状態になっていたため修正します。

## 原因

もともとは二段構えで制御していましたが、両方とも機能しなくなっていました。

### ① ERB 側（20分を常に disabled にする制御）

| コミット | 条件 | 挙動 |
|---|---|---|
| `60ea92ab` | `item.key.to_i == SessionTime::TWENTY_MINUTES` | 20分のラジオを常に disabled |
| `1e62ebdd` | `item.params.include('for keynote')` | `String#include` は存在せず描画時に `NoMethodError` |
| `85fc3313` | `session_time_locked` | エラー回避のため条件ごと差し替え。選択肢単位の制御が消滅 |

現在は「すでにキーノート用の時間が選ばれている Talk なら、時間欄グループ全体をロックする」だけになっており、新規・一般応募の Talk では何も制限されていませんでした。

### ② JS 側（カテゴリが Keynote のときだけ 20分を開放する制御）

`app/javascript/packs/speaker_form.js` のハンドラが 3 重に機能しなくなっていました。

1. トリガーとなる `Keynote` カテゴリが `talk_categories` に存在しない（conference_id 13 が最後で、CNDW2025・CNDW2026 には無い）
2. `af66cb92` のフォームデザイン刷新で DOM が 1 段深くなり、`parentElement.parentElement` が `.talk-field` を指さなくなった → `._20min` が `null`
3. CNDW2026 の選択肢は `_30min (full session)` のため `._40min` が存在せず、こちらも `null`

## 変更内容

- キーノート専用の選択肢は、キーノート招待された Talk 以外では disabled にする（`_session_times.html.erb`）
- キーノート判定はカテゴリ名ではなく `TalkType::KEYNOTE_SESSION_ID`（招待フローが付与）で行う（`_talk_fields.html.erb`）
- 機能しなくなっていた JS のハンドラを削除（`speaker_form.js`）
- disabled は迂回できるため、`Talk` に `on: :entry_form` のサーバ側バリデーションを追加
- モデル・リクエストの spec を追加
- `Metrics/ClassLength` の上限を 452 → 460 に更新

既存の「キーノート用の時間が設定済みなら変更させない」ロックはそのまま維持しています。

## テスト

- `bundle exec rspec` … 1089 examples, 0 failures
- `yarn jest` … 20 tests, 0 failures
- `bundle exec rubocop` … offenses なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVZyacLMJd6srTxA3H8rdH