### PR TITLE
CFPフォームでキーノート専用のセッション時間を選択できないようにする

### DIFF
--- a/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
+++ b/app/views/speaker_dashboard/speakers/_talk_fields.html.erb
@@ -145,6 +145,8 @@
             <% @conference.proposal_item_configs.where(item_number: item_number).each do |item| %>
               <% label = first_item.label.pluralize.to_sym %>
               <% checked = existing_items ? existing_items.include?(item.id.to_s) : false %>
+              <%# キーノート専用のセッション時間は一般応募では選択させない（招待済みで選択済みの場合のみ表示する） %>
+              <% next if first_item.label == 'session_time' && item.params.to_s.include?('for keynote') && selected_radio_item&.id != item.id %>
               <% classes = "radio_button_#{label} dk-radio" %>
               <% radio_id = "#{label}_#{item.id}_#{form_index}" %>
               <div class="cfp-radio-card tw-mb-2 tw-flex tw-items-start tw-gap-2 tw-rounded tw-border tw-p-2 <%= 'tw-border-blue-500 tw-bg-blue-50' if checked %>">


### PR DESCRIPTION
## 概要

CNDW2026 の CFP では講演時間として 30 分のみを想定しているが、キーノート専用の 20 分の選択肢もフォームに表示され、一般応募でも選択できる状態だった。

`session_time` のラジオボタンを描画する際に、`params` に `for keynote` を含む選択肢は **その talk が既に選択している場合を除いて表示しない** ようにする。

CNDW2026 (conference_id: 16) の `session_time` は以下の2つが定義されているため、この変更で一般応募のフォームには 30min のみが表示される。

- `_30min (full session)` (id: 299)
- `_20min (for keynote)` (id: 300)

## 20分の設定を残した理由

`app/models/keynote_speaker_invitation.rb:99` がキーノート招待時に `proposal_item_configs.find_by(label: 'session_time', value: '20')` を引いて暫定 Talk に紐付けているため、seed から 20min のレコードを削除すると招待機能が壊れる。そのため「データは残すが CFP フォームには表示しない」方針とした。

招待済みキーノートスピーカーが編集画面を開いた場合は、選択済みの 20min が引き続き表示される（既存の `session_time_locked` により disabled 表示のまま）。

判定条件 `params.include?('for keynote')` は、同ファイル 137 行目の既存の `session_time_locked` 判定と同じ方式に揃えている。CNK2025 (conference_id: 15) のように `_30min (for keynote)` / `_50min (for keynote)` を持つカンファレンスでも同様にキーノート専用枠が非表示になるが、こちらは CFP 終了済みのため影響はない想定。

## 未対応の点

- **サーバ側のバリデーションは入れていない。** `speakers_controller` は `session_times` パラメータの値を検証せず ProposalItemConfig の id をそのまま保存するため、POST を直接組み立てれば 20min を送り込むことは依然可能。フォーム上の選択を塞ぐという範囲に留めている。
- **ローカルでテストを実行できていない。** 手元の bundler 2.5.22 が Ruby 4.0.5 と非互換 (`undefined method 'parse' for class CGI`) で `bundle install` / `bundle exec rspec` が起動しなかったため、CI での確認をお願いしたい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxGBy17jcy6Z92VQjkdpC1