### PR TITLE
CNDW2026 のスポンサー種別を追加

### DIFF
--- a/db/fixtures/development/03_sponsors.rb
+++ b/db/fixtures/development/03_sponsors.rb
@@ -207,6 +207,61 @@ SponsorType.seed(
     conference_id: 15,
     name: "Tool",
     order: 5,
+  },
+    # CNDW2026
+  {
+    id: 105,
+    conference_id: 16,
+    name: "Diamond",
+    order: 1,
+  },
+  {
+    id: 106,
+    conference_id: 16,
+    name: "Platinum",
+    order: 2,
+  },
+  {
+    id: 107,
+    conference_id: 16,
+    name: "Gold",
+    order: 3,
+  },
+  {
+    id: 108,
+    conference_id: 16,
+    name: "Booth",
+    order: 4,
+  },
+  {
+    id: 109,
+    conference_id: 16,
+    name: "Logo",
+    order: 5,
+  },
+  {
+    id: 110,
+    conference_id: 16,
+    name: "Party",
+    order: 6,
+  },
+  {
+    id: 111,
+    conference_id: 16,
+    name: "CM",
+    order: 7,
+  },
+  {
+    id: 112,
+    conference_id: 16,
+    name: "Tool",
+    order: 8,
+  },
+  {
+    id: 113,
+    conference_id: 16,
+    name: "Support",
+    order: 9,
   }
 )
 

--- a/db/fixtures/production/03_sponsors.rb
+++ b/db/fixtures/production/03_sponsors.rb
@@ -206,5 +206,60 @@ SponsorType.seed(
     conference_id: 15,
     name: "Tool",
     order: 5,
+  },
+    # CNDW2026
+  {
+    id: 105,
+    conference_id: 16,
+    name: "Diamond",
+    order: 1,
+  },
+  {
+    id: 106,
+    conference_id: 16,
+    name: "Platinum",
+    order: 2,
+  },
+  {
+    id: 107,
+    conference_id: 16,
+    name: "Gold",
+    order: 3,
+  },
+  {
+    id: 108,
+    conference_id: 16,
+    name: "Booth",
+    order: 4,
+  },
+  {
+    id: 109,
+    conference_id: 16,
+    name: "Logo",
+    order: 5,
+  },
+  {
+    id: 110,
+    conference_id: 16,
+    name: "Party",
+    order: 6,
+  },
+  {
+    id: 111,
+    conference_id: 16,
+    name: "CM",
+    order: 7,
+  },
+  {
+    id: 112,
+    conference_id: 16,
+    name: "Tool",
+    order: 8,
+  },
+  {
+    id: 113,
+    conference_id: 16,
+    name: "Support",
+    order: 9,
   }
 )


### PR DESCRIPTION
## 概要

CNDW2026 (`conference_id: 16`) のスポンサー種別を seed に追加します。

## 変更内容

`db/fixtures/development/03_sponsors.rb` と `db/fixtures/production/03_sponsors.rb` の `SponsorType.seed` に以下 9 件を追加しました（内容は両ファイルで同一）。既存の最大 ID が 104 (CNK) だったため 105〜113 を採番しています。

| id | name | order |
|----|------|-------|
| 105 | Diamond | 1 |
| 106 | Platinum | 2 |
| 107 | Gold | 3 |
| 108 | Booth | 4 |
| 109 | Logo | 5 |
| 110 | Party | 6 |
| 111 | CM | 7 |
| 112 | Tool | 8 |
| 113 | Support | 9 |

## 補足

- `order` は指定された並び順どおり 1〜9 の連番にしています。CNK では 5 が重複していましたが、`sponsor_types.order ASC` でのソート結果が不定になるため連番としました。
- `visible` はカラムのデフォルト (`true`) に任せています。
- `SponsorHelper#sponsor_logo_class` に `Party` の分岐はないため `else` (md:1/4 幅) になります。CNK も同じ扱いのため今回は変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019J4UZ26BTBqB6F5gxr88DW